### PR TITLE
Use order-specific symbol when polling order status

### DIFF
--- a/server.js
+++ b/server.js
@@ -712,8 +712,8 @@ app.post('/api/cancel-order', async (req, res) => {
 
 // ===== Poll: marcar "filled" somente quando Gate **e** MEXC estiverem preenchidas
 async function pollOpenOrders() {
-  const symbol = currentSymbol;
   for (const item of orderHistory) {
+    const symbol = item.symbol;
     if (!['open', 'creating', 'gate_filled', 'mexc_filled', 'gate_error', 'mexc_error'].includes(item.status)) continue;
 
     // Gate


### PR DESCRIPTION
## Summary
- query exchange order details using each history item's symbol instead of the current symbol

## Testing
- `node --check server.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abd54a003c832f876048c380f87303