### PR TITLE
Add ACS_USDT to supported instrument list

### DIFF
--- a/server.js
+++ b/server.js
@@ -21,7 +21,7 @@ const autoMetaCache = new Map();
 const overridesBySymbol = new Map();
 
 // Lista simples de instrumentos permitidos para consultas MEXC
-const SUPPORTED_INSTRUMENTS = new Set(['BOXCAT_USDT', 'WMTX_USDT']);
+const SUPPORTED_INSTRUMENTS = new Set(['BOXCAT_USDT', 'WMTX_USDT', 'ACS_USDT']);
 
 let orderHistory = [];
 let positionState = { targetQty: 0, filledQty: 0, avgPrice: 0, arbPctAvg: 0, series: [] };


### PR DESCRIPTION
## Summary
- include ACS_USDT in SUPPORTED_INSTRUMENTS to avoid MEXC symbol errors

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check server.js`
- `node - <<'NODE' ... getMexcOrderDetail('ACS_USDT','123') ...`

------
https://chatgpt.com/codex/tasks/task_e_68abd545ba58832faa7aa73d2456e9d0