### PR TITLE
Log MEXC order detail and parsed detail

### DIFF
--- a/server.js
+++ b/server.js
@@ -741,7 +741,9 @@ async function pollOpenOrders() {
     if (item.mexcOrderId) {
       try {
         const md = await getMexcOrderDetail(symbol, String(item.mexcOrderId));
+        console.log('MEXC detail', md);
         const p = parseMexcOrderDetail(md);
+        console.log('parsed detail', p);
         mIsFilled = !!p.isFilled;
       } catch {
         // caso não consiga consultar, não marca como filled


### PR DESCRIPTION
## Summary
- log full response from `getMexcOrderDetail` in `pollOpenOrders`
- log result of `parseMexcOrderDetail` for easier debugging

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abd54c835c832f9ca6014309b442d1