### PR TITLE
Fix MEXC order polling

### DIFF
--- a/server.js
+++ b/server.js
@@ -189,8 +189,10 @@ async function getMexcOrderDetail(symbol, orderId) {
   }
 
   const candidates = [
+    // SDK v1.5.1 expõe `getOrder(orderId)` como método principal.
+    // Outros nomes são mantidos apenas por compatibilidade com versões anteriores.
+    ['getOrder',       idStr],
     ['getOrderDetail', { orderId: idStr, symbol }],
-    ['getOrder',       { orderId: idStr, symbol }],
     ['orderQuery',     { orderId: idStr, symbol }],
     ['queryOrder',     { orderId: idStr, symbol }],
     ['getOrderById',   { orderId: idStr, symbol }],


### PR DESCRIPTION
## Summary
- correct MEXC order detail lookup to call `getOrder` with proper parameters

## Testing
- `node --check server.js`


------
https://chatgpt.com/codex/tasks/task_e_68abcd36a8c0832fb252579a5f8e16f1