### PR TITLE
Display per-exchange position progress

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -111,9 +111,13 @@
 
       <div class="mono" style="margin-top:10px;">
         <div>Alvo: <span id="ppTarget">0</span></div>
-        <div>Preenchido: <span id="ppFilled">0</span></div>
-        <div>Preço Médio: <span id="ppAvg">0</span></div>
-        <div>Arb. Média (%): <span id="ppArb">0</span></div>
+        <div style="margin-top:6px;"><strong>Gate</strong></div>
+        <div>Preenchido: <span id="ppGateFilled">0</span></div>
+        <div>Preço Médio: <span id="ppGateAvg">0</span></div>
+        <div style="margin-top:6px;"><strong>MEXC</strong></div>
+        <div>Preenchido: <span id="ppMexcFilled">0</span></div>
+        <div>Preço Médio: <span id="ppMexcAvg">0</span></div>
+        <div style="margin-top:6px;">Arb. Média (%): <span id="ppArb">0</span></div>
       </div>
 
       <div style="margin-top:10px;">

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -246,9 +246,13 @@ async function refreshPosition() {
   try {
     const r = await fetch('/api/position-progress');
     const s = await r.json();
+    const g = s.gate || {};
+    const m = s.mexc || {};
     document.getElementById('ppTarget').textContent = s.targetQty || 0;
-    document.getElementById('ppFilled').textContent = s.filledQty || 0;
-    document.getElementById('ppAvg').textContent = (s.avgPrice || 0).toFixed ? s.avgPrice.toFixed(11) : s.avgPrice;
+    document.getElementById('ppGateFilled').textContent = g.filledQty || 0;
+    document.getElementById('ppGateAvg').textContent = (g.avgPrice || 0).toFixed ? g.avgPrice.toFixed(11) : g.avgPrice;
+    document.getElementById('ppMexcFilled').textContent = m.filledQty || 0;
+    document.getElementById('ppMexcAvg').textContent = (m.avgPrice || 0).toFixed ? m.avgPrice.toFixed(11) : m.avgPrice;
     document.getElementById('ppArb').textContent = (s.arbPctAvg || 0).toFixed ? s.arbPctAvg.toFixed(6) : s.arbPctAvg;
     drawProgressChart(s.series || []);
   } catch {}
@@ -341,12 +345,18 @@ function drawProgressChart(series) {
   ctx.clearRect(0,0,W,H);
   ctx.beginPath(); ctx.moveTo(40,H-30); ctx.lineTo(W-10,H-30); ctx.moveTo(40,H-30); ctx.lineTo(40,10); ctx.stroke();
   if (!series.length) { ctx.fillText('Sem dados de preenchimento ainda', 60, H/2); return; }
-  const xs = series.map(p=>p.t), ys = series.map(p=>p.filledQty);
+  const filledOf = p => {
+    if (typeof p.filledQty === 'number') return p.filledQty;
+    if (p.gate && typeof p.gate.filledQty === 'number') return p.gate.filledQty;
+    if (p.mexc && typeof p.mexc.filledQty === 'number') return p.mexc.filledQty;
+    return 0;
+  };
+  const xs = series.map(p=>p.t), ys = series.map(p=>filledOf(p));
   const minX = Math.min(...xs), maxX = Math.max(...xs), maxY = Math.max(...ys)||1;
   const x = (t)=> 40 + (t-minX)*(W-60)/(maxX-minX || 1);
   const y = (v)=> (H-30) - v*(H-50)/(maxY || 1);
-  ctx.beginPath(); series.forEach((p,i)=>{ const X=x(p.t), Y=y(p.filledQty); if(!i) ctx.moveTo(X,Y); else ctx.lineTo(X,Y); }); ctx.stroke();
-  series.forEach(p=>{ const X=x(p.t), Y=y(p.filledQty); ctx.beginPath(); ctx.arc(X,Y,2,0,Math.PI*2); ctx.fill(); });
+  ctx.beginPath(); series.forEach((p,i)=>{ const X=x(p.t), Y=y(filledOf(p)); if(!i) ctx.moveTo(X,Y); else ctx.lineTo(X,Y); }); ctx.stroke();
+  series.forEach(p=>{ const X=x(p.t), Y=y(filledOf(p)); ctx.beginPath(); ctx.arc(X,Y,2,0,Math.PI*2); ctx.fill(); });
 }
 
 // ======== Init


### PR DESCRIPTION
## Summary
- show Gate.io and MEXC position progress separately in dashboard
- populate new per-exchange progress fields in the client and chart aggregation
- track per-exchange stats on the server and expose details and series

## Testing
- `node --check server.js`
- `node --check public/scripts.js`
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68acb4507b64832fba14cff6028fd229