### PR TITLE
fix: avoid status reset after cancellation

### DIFF
--- a/server.js
+++ b/server.js
@@ -755,9 +755,10 @@ app.post('/api/cancel-order', async (req, res) => {
 
 // ===== Poll: marcar "filled" somente quando Gate **e** MEXC estiverem preenchidas
 async function pollOpenOrders() {
+  const ACTIVE_STATUSES = ['open', 'creating', 'gate_filled', 'mexc_filled', 'gate_error', 'mexc_error'];
   for (const item of orderHistory) {
     const symbol = item.symbol;
-    if (!['open', 'creating', 'gate_filled', 'mexc_filled', 'gate_error', 'mexc_error'].includes(item.status)) continue;
+    if (!ACTIVE_STATUSES.includes(item.status)) continue;
 
     // Gate
     let gFilled = 0, gAvg = Number(item.priceUsedGate || 0), gIsFilled = false;
@@ -795,6 +796,10 @@ async function pollOpenOrders() {
         mIsFilled = false;
       }
     }
+
+    // Se durante as chamadas assíncronas o status foi alterado (ex.: cancelado),
+    // não sobrescreve o valor definido pelo cancelamento.
+    if (!ACTIVE_STATUSES.includes(item.status)) continue;
 
     const prevStatus = item.status;
     const prevGateStatus = item.gateStatus;


### PR DESCRIPTION
## Summary
- avoid overwriting cancelled orders in polling logic

## Testing
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_68acee157e3c832f8c893a3b12ffa342