### PR TITLE
Add Gate minQuote override field

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -47,7 +47,8 @@
           <div class="muted" style="margin-bottom:6px;"><strong>Gate</strong></div>
           <label>priceScale <input id="ov_gate_price" type="number" step="1" class="mono" /></label><br/>
           <label>qtyScale <input id="ov_gate_qty" type="number" step="1" class="mono" /></label><br/>
-          <label>minQty <input id="ov_gate_minqty" type="number" step="any" class="mono" /></label>
+          <label>minQty <input id="ov_gate_minqty" type="number" step="any" class="mono" /></label><br/>
+          <label>minQuote <input id="ov_gate_minquote" type="number" step="any" class="mono" /></label>
         </div>
         <div>
           <div class="muted" style="margin-bottom:6px;"><strong>MEXC</strong></div>

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -65,6 +65,7 @@ function fillOverridesUI(merged) {
   set('ov_gate_price', g.priceScale);
   set('ov_gate_qty', g.qtyScale);
   set('ov_gate_minqty', g.minQty);
+  set('ov_gate_minquote', g.minQuote);
   set('ov_mexc_price', m.priceScale);
   set('ov_mexc_volp', m.volPrecision);
   set('ov_mexc_cs', m.contractSize);
@@ -74,7 +75,7 @@ function fillOverridesUI(merged) {
 }
 function metaToText(label, meta) {
   return `${label}
-Gate: priceScale=${meta.gate.priceScale}, qtyScale=${meta.gate.qtyScale}, minQty=${meta.gate.minQty}
+Gate: priceScale=${meta.gate.priceScale}, qtyScale=${meta.gate.qtyScale}, minQty=${meta.gate.minQty}, minQuote=${meta.gate.minQuote}
 MEXC: priceScale=${meta.mexc.priceScale}, volPrecision=${meta.mexc.volPrecision}, contractSize=${meta.mexc.contractSize}, minContracts=${meta.mexc.minContracts}
 Settings: margem=${meta.settings.marginPct}%, lev=${meta.settings.leverage}, parity=${meta.settings.parityVolumes}`;
 }
@@ -111,7 +112,8 @@ document.getElementById('saveOverride').addEventListener('click', async () => {
     gate: {
       priceScale: numOrUndef('ov_gate_price'),
       qtyScale: numOrUndef('ov_gate_qty'),
-      minQty: numOrUndef('ov_gate_minqty')
+      minQty: numOrUndef('ov_gate_minqty'),
+      minQuote: numOrUndef('ov_gate_minquote')
     },
     mexc: {
       priceScale: numOrUndef('ov_mexc_price'),


### PR DESCRIPTION
## Summary
- Add minQuote override input for Gate metadata
- Save and display Gate minQuote in overrides UI and meta text

## Testing
- `node --check public/scripts.js`
- `node --check server.js`


------
https://chatgpt.com/codex/tasks/task_e_68b2728cfbd0832f9e367a5281c05c12