### PR TITLE
Track arbitrage and PnL metrics

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -126,6 +126,7 @@
         <div>Preenchido: <span id="ppMexcFilled">0</span></div>
         <div>Preço Médio: <span id="ppMexcAvg">0</span></div>
         <div style="margin-top:6px;">Arb. Média (%): <span id="ppArb">0</span></div>
+        <div>PnL Geral (USDT): <span id="ppPnl">0</span></div>
       </div>
 
       <div style="margin-top:10px;">
@@ -146,6 +147,8 @@
           <th>Gate Price</th>
           <th>MEXC Price</th>
           <th>Volume (WMTX)</th>
+          <th>%Arb</th>
+          <th>$PnL</th>
           <th>Gate Order ID</th>
           <th>Gate Status</th>
           <th>GRO</th>

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -315,6 +315,8 @@ async function refreshHistory() {
       tr.appendChild(td(h.priceUsedGate || '-'));
       tr.appendChild(td(h.priceUsedMexc || '-'));
       tr.appendChild(td(h.volume || '-'));
+      tr.appendChild(td(h.arbPct != null ? Number(h.arbPct).toFixed(6) : '-'));
+      tr.appendChild(td(h.pnlUsd != null ? Number(h.pnlUsd).toFixed(6) : '-'));
       tr.appendChild(td(h.gateOrderId || '-'));
       tr.appendChild(td(h.gateStatus || '-'));
       const groTd = document.createElement('td'); groTd.appendChild(groBtn); tr.appendChild(groTd);
@@ -342,6 +344,7 @@ async function refreshPosition() {
     document.getElementById('ppMexcFilled').textContent = m.filledQty || 0;
     document.getElementById('ppMexcAvg').textContent = (m.avgPrice || 0).toFixed ? m.avgPrice.toFixed(11) : m.avgPrice;
     document.getElementById('ppArb').textContent = (s.arbPctAvg || 0).toFixed ? s.arbPctAvg.toFixed(6) : s.arbPctAvg;
+    document.getElementById('ppPnl').textContent = (s.pnlUsd || 0).toFixed ? s.pnlUsd.toFixed(6) : s.pnlUsd;
     drawProgressChart(s.series || []);
   } catch {}
 }

--- a/server.js
+++ b/server.js
@@ -26,6 +26,7 @@ let positionState = {
   filledQty: 0,
   avgPrice: 0,
   arbPctAvg: 0,
+  pnlUsd: 0,
   gate: { filledQty: 0, avgPrice: 0 },
   mexc: { filledQty: 0, avgPrice: 0, positionId: null },
   series: []
@@ -458,23 +459,32 @@ app.post('/api/position-target', (req, res) => {
 });
 app.get('/api/position-progress', (_req, res) => res.json(positionState));
 
-function updatePositionFromOrder(item, filledQty, gateAvg) {
-  if (!filledQty || filledQty <= 0) return;
+function updatePositionFromOrder(item, gFilled, gAvg, mFilled, mAvg) {
+  const gateQty = Number(gFilled || 0);
+  const mexcQty = Number(mFilled || gateQty);
+  const qty = Math.min(gateQty, mexcQty);
+  if (!qty || qty <= 0) return;
 
-  // Close orders reduzem a posição
+  const gatePrice = Number(gAvg || item.priceUsedGate || 0);
+  const mexcPrice = Number(mAvg || item.priceUsedMexc || 0);
   const sign = item.mode === 'close' ? -1 : 1;
-  const adjQty = filledQty * sign;
+  const adjQty = qty * sign;
+
+  const diff = mexcPrice - gatePrice;
+  const arbRaw = (diff / gatePrice) * 100;
+  const pnlUsd = diff * qty * sign;
+  item.arbPct = roundTo(arbRaw * sign, 6);
+  item.pnlUsd = roundTo(pnlUsd, 6);
 
   // Gate stats
   const gPrevQty = positionState.gate.filledQty;
   const gPrevAvg = positionState.gate.avgPrice;
   const gNewQty = gPrevQty + adjQty;
-  const gNewAvg = gNewQty > 0 ? ((gPrevAvg * gPrevQty) + (gateAvg * adjQty)) / gNewQty : 0;
+  const gNewAvg = gNewQty > 0 ? ((gPrevAvg * gPrevQty) + (gatePrice * adjQty)) / gNewQty : 0;
   positionState.gate.filledQty = gNewQty;
   positionState.gate.avgPrice = gNewAvg;
 
-  // MEXC stats (use original priceUsedMexc from item)
-  const mexcPrice = Number(item.priceUsedMexc || 0);
+  // MEXC stats
   const mPrevQty = positionState.mexc.filledQty;
   const mPrevAvg = positionState.mexc.avgPrice;
   const mNewQty = mPrevQty + adjQty;
@@ -487,18 +497,19 @@ function updatePositionFromOrder(item, filledQty, gateAvg) {
   const prevQty = positionState.filledQty;
   const prevAvg = positionState.avgPrice;
   const newQty = prevQty + adjQty;
-  const newAvg = newQty > 0 ? ((prevAvg * prevQty) + (gateAvg * adjQty)) / newQty : 0;
-  const arbThis = ((mexcPrice - parseFloat(item.priceUsedGate)) / parseFloat(item.priceUsedGate)) * 100;
-  const newArb = newQty > 0 ? (((positionState.arbPctAvg || 0) * prevQty) + (arbThis * adjQty)) / newQty : 0;
+  const newAvg = newQty > 0 ? ((prevAvg * prevQty) + (gatePrice * adjQty)) / newQty : 0;
+  const newArb = newQty > 0 ? (((positionState.arbPctAvg || 0) * prevQty) + (arbRaw * adjQty)) / newQty : 0;
   positionState.filledQty = newQty;
   positionState.avgPrice = newAvg;
   positionState.arbPctAvg = newArb;
+  positionState.pnlUsd = (positionState.pnlUsd || 0) + item.pnlUsd;
 
   positionState.series.push({
     t: Date.now(),
     filledQty: newQty,
     avgPrice: Number(newAvg.toFixed(11)),
     arbPctAvg: Number(newArb.toFixed(6)),
+    pnlUsd: Number(positionState.pnlUsd.toFixed(6)),
     gate: { filledQty: gNewQty, avgPrice: Number(gNewAvg.toFixed(11)) },
     mexc: { filledQty: mNewQty, avgPrice: Number(mNewAvg.toFixed(11)) }
   });
@@ -816,7 +827,10 @@ app.post('/api/cancel-order', async (req, res) => {
     if (item.mexcOrderId) item.mexcStatus = 'cancelled';
     try { db.saveHistoryItem(item); } catch (e) { console.warn('[SQLite] save history (cancel):', e?.message || e); }
 
-    if (gFilled > 0 || mFilled > 0) updatePositionFromOrder(item, gFilled, gAvg, mFilled, mAvg);
+    if (gFilled > 0 || mFilled > 0) {
+      updatePositionFromOrder(item, gFilled, gAvg, mFilled, mAvg);
+      try { db.saveHistoryItem(item); } catch (e) { console.warn('[SQLite] save history (cancel post):', e?.message || e); }
+    }
     res.json({ ok: true, localId, status: item.status });
   } catch (e) {
     res.status(500).json({ error: 'Erro ao cancelar ordem.' });


### PR DESCRIPTION
## Summary
- compute arbitrage percentage and dollar PnL for filled orders and store in history
- aggregate per-order metrics into position progress, including overall PnL
- expose new %Arb and $PnL columns in history table and PnL Geral in progress card

## Testing
- `node --check server.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bba4bb27e0832f8882b282f472dd97