### PR TITLE
Add Telegram alert notifications for arbitrage thresholds

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,19 @@ module.exports = {
 };
 ```
 
+### Notificações por Telegram
+
+1. No Telegram, converse com [@BotFather](https://t.me/BotFather) e crie um bot com o comando `/newbot`. Anote o **token** informado.
+2. Crie um grupo e adicione o bot como participante. Envie qualquer mensagem nesse grupo.
+3. Obtenha o `chat_id` acessando `https://api.telegram.org/botTOKEN/getUpdates` (substitua `TOKEN` pelo valor recebido). O campo `chat.id` da última mensagem corresponde ao ID do grupo.
+4. Edite `config.js` e preencha:
+
+   ```javascript
+   telegram: { botToken: 'SEU_TOKEN', chatId: 'SEU_CHAT_ID' }
+   ```
+
+5. Reinicie o servidor. No painel web, marque a opção **Telegram** ao lado do alerta de diferença para ativar o envio das mensagens.
+
 ## Execução
 Inicie o servidor com:
 

--- a/config.js
+++ b/config.js
@@ -26,6 +26,12 @@ module.exports = {
     leverage: 1
   },
 
+  // Dados do bot/grupo do Telegram para notificações (opcional)
+  telegram: {
+    botToken: '', // token obtido com o BotFather
+    chatId: ''    // ID do grupo ou chat que receberá os alertas
+  },
+
   // Políticas de execução (opcional). Você já usa a margem de 10%:
   execution: {
     marginPct: 10 // % de distância para evitar que a ordem seja consumida imediatamente

--- a/public/index.html
+++ b/public/index.html
@@ -84,6 +84,7 @@
         <input id="alertMin" type="number" step="any" class="mono" style="width:70px;" placeholder="min" />
         <input id="alertMax" type="number" step="any" class="mono" style="width:70px;" placeholder="max" />
         <label style="margin-left:4px;"><input type="checkbox" id="soundToggle" /> Som</label>
+        <label style="margin-left:4px;"><input type="checkbox" id="telegramToggle" /> Telegram</label>
       </div>
 
       <label><input type="checkbox" id="modeClose" /> Fechar posições (inverter lógica)</label>

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -163,7 +163,8 @@ let lastQuotes = null;
 let alertMin = parseFloat(localStorage.getItem('alertMin'));
 let alertMax = parseFloat(localStorage.getItem('alertMax'));
 let soundEnabled = localStorage.getItem('soundOn') === '1';
-let audioCtx = null, lastBeep = 0;
+let telegramEnabled = localStorage.getItem('tgOn') === '1';
+let audioCtx = null, lastBeep = 0, lastTgSent = 0;
 
 function playBeep() {
   try {
@@ -179,15 +180,29 @@ function playBeep() {
   } catch {}
 }
 
+async function notifyTelegram(diff) {
+  if (!telegramEnabled) return;
+  const now = Date.now();
+  if (now - lastTgSent < 10000) return; // evita spam
+  lastTgSent = now;
+  try {
+    await fetch('/api/notify-telegram', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ diff })
+    });
+  } catch {}
+}
+
 function checkAlert(diffStr) {
-  if (!soundEnabled) return;
   const diff = parseFloat(diffStr);
   if (!isFinite(diff)) return;
   const min = isFinite(alertMin) ? alertMin : -Infinity;
   const max = isFinite(alertMax) ? alertMax : Infinity;
   if (diff < min || diff > max) {
     const now = Date.now();
-    if (now - lastBeep > 1000) { playBeep(); lastBeep = now; }
+    if (soundEnabled && now - lastBeep > 1000) { playBeep(); lastBeep = now; }
+    notifyTelegram(diff);
   }
 }
 
@@ -202,6 +217,10 @@ document.getElementById('alertMax').addEventListener('change', e => {
 document.getElementById('soundToggle').addEventListener('change', e => {
   soundEnabled = e.target.checked;
   localStorage.setItem('soundOn', soundEnabled ? '1' : '0');
+});
+document.getElementById('telegramToggle').addEventListener('change', e => {
+  telegramEnabled = e.target.checked;
+  localStorage.setItem('tgOn', telegramEnabled ? '1' : '0');
 });
 
 function renderQuotes() {
@@ -471,5 +490,6 @@ function drawProgressChart(series) {
   if (isFinite(alertMin)) document.getElementById('alertMin').value = alertMin;
   if (isFinite(alertMax)) document.getElementById('alertMax').value = alertMax;
   document.getElementById('soundToggle').checked = soundEnabled;
+  document.getElementById('telegramToggle').checked = telegramEnabled;
   refreshBalances(); refreshHistory(); refreshPosition(); fetchData();
 })();

--- a/server.js
+++ b/server.js
@@ -472,6 +472,24 @@ app.get('/api/balances', async (_req, res) => {
   res.json({ gate, mexc });
 });
 
+// ===== Notificação via Telegram
+app.post('/api/notify-telegram', async (req, res) => {
+  const diff = req.body?.diff;
+  if (!config.telegram?.botToken || !config.telegram?.chatId) {
+    return res.status(500).json({ error: 'Telegram não configurado' });
+  }
+  try {
+    await axios.post(`https://api.telegram.org/bot${config.telegram.botToken}/sendMessage`, {
+      chat_id: config.telegram.chatId,
+      text: `Alerta de arbitragem: ${diff}%`
+    });
+    res.json({ ok: true });
+  } catch (e) {
+    console.error('[Telegram] falha ao enviar:', e.response?.data || e.message || e);
+    res.status(500).json({ error: 'Falha ao enviar' });
+  }
+});
+
 // ===== Posição (meta e progresso)
 app.post('/api/position-target', (req, res) => {
   const t = Number(req.body?.targetQty);


### PR DESCRIPTION
## Summary
- add Telegram bot configuration and endpoint to dispatch alerts
- allow enabling/disabling Telegram alerts via new checkbox in UI
- document Telegram setup steps in README

## Testing
- `npm install express axios gate-api mexc-futures-sdk better-sqlite3 --no-save --no-package-lock`
- `node --check public/scripts.js`
- `node --check server.js`
- `node -e "require('./server'); setTimeout(()=>process.exit(0), 1000);"`


------
https://chatgpt.com/codex/tasks/task_e_68bf8aa5dbd4832f9f0300b786319b30