### PR TITLE
Fix MEXC volume conversion in position progress

### DIFF
--- a/server.js
+++ b/server.js
@@ -500,8 +500,18 @@ app.post('/api/position-target', (req, res) => {
 app.get('/api/position-progress', (_req, res) => res.json(positionState));
 
 function updatePositionFromOrder(item, gFilled, gAvg, mFilled, mAvg) {
+  const meta = item?.metaUsed || {};
   const gateQty = Number(gFilled || 0);
-  const mexcQty = Number(mFilled || gateQty);
+  const mexcContracts = Number(mFilled || 0);
+
+  let mexcQty = gateQty;
+  if (Number.isFinite(mexcContracts) && mexcContracts > 0) {
+    mexcQty = contractsToWmtx(mexcContracts, meta);
+  } else if (item?.mexcDisplayVolume != null) {
+    const displayQty = Number(item.mexcDisplayVolume);
+    if (Number.isFinite(displayQty) && displayQty > 0) mexcQty = displayQty;
+  }
+
   const qty = Math.min(gateQty, mexcQty);
   if (!qty || qty <= 0) return;
 


### PR DESCRIPTION
## Summary
- convert filled contract volume from MEXC into base-asset units when updating position metrics
- keep previous fallbacks for missing MEXC fills so historical orders continue to behave the same

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c8b7a95624832fb28242fc0f398e2a