### PR TITLE
Exibe saldo da moeda base da MEXC no card de saldos

### DIFF
--- a/public/scripts.js
+++ b/public/scripts.js
@@ -31,16 +31,70 @@ function renderGateBalance(b) {
 }
 function renderMexcBalance(b) {
   if (!b) return '—';
-  if (typeof b.availableUSDT === 'number') {
-    const src = b.source ? ` (${b.source})` : '';
-    return `Disponível (USDT): ${b.availableUSDT}${src}`;
-  }
   if (b.unknown) {
     return (b.reason === 'client_not_initialized' || b.reason === 'no_web_token')
       ? 'Token/chaves não configurados (config.mexc).'
       : 'Saldo indisponível via API.';
   }
   if (b.error) return `Erro: ${JSON.stringify(b.error)}`;
+
+  const assets = (b.assets && typeof b.assets === 'object') ? { ...b.assets } : {};
+  const fmt = (v) => {
+    if (v == null) return '—';
+    const n = Number(v);
+    return Number.isFinite(n) ? n : v;
+  };
+
+  const baseInfo = (b.base && b.base.currency)
+    ? {
+        currency: b.base.currency.toUpperCase(),
+        available: b.base.available,
+        locked: b.base.locked,
+        source: b.base.source
+      }
+    : null;
+
+  if (baseInfo) {
+    const curr = baseInfo.currency;
+    assets[curr] = Object.assign({}, assets[curr] || {});
+    if (baseInfo.available != null && assets[curr].available == null) assets[curr].available = baseInfo.available;
+    if (baseInfo.locked != null && assets[curr].locked == null) assets[curr].locked = baseInfo.locked;
+  }
+
+  if (typeof b.availableUSDT === 'number') {
+    assets.USDT = Object.assign({}, assets.USDT || {}, { available: b.availableUSDT });
+  }
+
+  const keys = Object.keys(assets);
+  if (keys.length) {
+    const lines = [];
+    const order = [];
+    const used = new Set();
+    const baseCurr = baseInfo?.currency;
+    if (baseCurr && assets[baseCurr] !== undefined) { order.push(baseCurr); used.add(baseCurr); }
+    if (assets.USDT !== undefined && !used.has('USDT')) { order.push('USDT'); used.add('USDT'); }
+    keys.sort((a, b) => a.localeCompare(b));
+    keys.forEach(k => { if (!used.has(k)) order.push(k); });
+
+    order.forEach(curr => {
+      const data = assets[curr] || {};
+      const available = fmt(data.available);
+      const locked = fmt(data.locked);
+      let line = `${curr}: disponível ${available}`;
+      if (locked !== '—') line += ` | em ordem ${locked}`;
+      if (curr === baseCurr && baseInfo && baseInfo.source && baseInfo.source !== 'api') {
+        line += ` (${baseInfo.source === 'estimado' ? 'estimado' : baseInfo.source})`;
+      }
+      lines.push(line);
+    });
+
+    return lines.join('\n');
+  }
+
+  if (typeof b.availableUSDT === 'number') {
+    const src = b.source ? ` (${b.source})` : '';
+    return `Disponível (USDT): ${fmt(b.availableUSDT)}${src}`;
+  }
   if (b.reason === 'unexpected_assets_shape') return 'Saldo indisponível (formato inesperado).';
   return '—';
 }

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -38,65 +38,31 @@ function renderMexcBalance(b) {
   }
   if (b.error) return `Erro: ${JSON.stringify(b.error)}`;
 
-  const assets = (b.assets && typeof b.assets === 'object') ? { ...b.assets } : {};
   const fmt = (v) => {
     if (v == null) return '—';
     const n = Number(v);
     return Number.isFinite(n) ? n : v;
   };
 
-  const baseInfo = (b.base && b.base.currency)
-    ? {
-        currency: b.base.currency.toUpperCase(),
-        available: b.base.available,
-        locked: b.base.locked,
-        source: b.base.source
-      }
-    : null;
-
-  if (baseInfo) {
-    const curr = baseInfo.currency;
-    assets[curr] = Object.assign({}, assets[curr] || {});
-    if (baseInfo.available != null && assets[curr].available == null) assets[curr].available = baseInfo.available;
-    if (baseInfo.locked != null && assets[curr].locked == null) assets[curr].locked = baseInfo.locked;
+  const assets = (b.assets && typeof b.assets === 'object') ? b.assets : {};
+  const baseCurrency = (b.base?.currency || '').toString().toUpperCase();
+  if (!baseCurrency) {
+    if (b.reason === 'unexpected_assets_shape') return 'Saldo indisponível (formato inesperado).';
+    return 'Saldo da moeda base indisponível.';
   }
 
-  if (typeof b.availableUSDT === 'number') {
-    assets.USDT = Object.assign({}, assets.USDT || {}, { available: b.availableUSDT });
-  }
+  const assetEntry = assets[baseCurrency] || {};
+  const availableRaw = (b.base?.available != null) ? b.base.available : assetEntry.available;
+  const lockedRaw = (b.base?.locked != null) ? b.base.locked : assetEntry.locked;
+  const source = b.base?.source || ((assetEntry.available != null || assetEntry.locked != null) ? 'api' : null);
 
-  const keys = Object.keys(assets);
-  if (keys.length) {
-    const lines = [];
-    const order = [];
-    const used = new Set();
-    const baseCurr = baseInfo?.currency;
-    if (baseCurr && assets[baseCurr] !== undefined) { order.push(baseCurr); used.add(baseCurr); }
-    if (assets.USDT !== undefined && !used.has('USDT')) { order.push('USDT'); used.add('USDT'); }
-    keys.sort((a, b) => a.localeCompare(b));
-    keys.forEach(k => { if (!used.has(k)) order.push(k); });
+  const available = fmt(availableRaw);
+  const locked = fmt(lockedRaw);
 
-    order.forEach(curr => {
-      const data = assets[curr] || {};
-      const available = fmt(data.available);
-      const locked = fmt(data.locked);
-      let line = `${curr}: disponível ${available}`;
-      if (locked !== '—') line += ` | em ordem ${locked}`;
-      if (curr === baseCurr && baseInfo && baseInfo.source && baseInfo.source !== 'api') {
-        line += ` (${baseInfo.source === 'estimado' ? 'estimado' : baseInfo.source})`;
-      }
-      lines.push(line);
-    });
-
-    return lines.join('\n');
-  }
-
-  if (typeof b.availableUSDT === 'number') {
-    const src = b.source ? ` (${b.source})` : '';
-    return `Disponível (USDT): ${fmt(b.availableUSDT)}${src}`;
-  }
-  if (b.reason === 'unexpected_assets_shape') return 'Saldo indisponível (formato inesperado).';
-  return '—';
+  let line = `${baseCurrency}: disponível ${available}`;
+  if (locked !== '—') line += ` | em ordem ${locked}`;
+  if (source && source !== 'api') line += ` (${source === 'estimado' ? 'estimado' : source})`;
+  return line;
 }
 
 async function refreshBalances() {

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -37,6 +37,7 @@ function renderMexcBalance(b) {
       : 'Saldo indisponível via API.';
   }
   if (b.error) return `Erro: ${JSON.stringify(b.error)}`;
+  if (b.reason === 'unexpected_assets_shape') return 'Saldo indisponível (formato inesperado).';
 
   const fmt = (v) => {
     if (v == null) return '—';
@@ -45,24 +46,35 @@ function renderMexcBalance(b) {
   };
 
   const assets = (b.assets && typeof b.assets === 'object') ? b.assets : {};
+  const lines = [];
+
+  const pushLine = (currency, availableRaw, lockedRaw, source) => {
+    if (!currency) return;
+    const available = fmt(availableRaw);
+    const locked = fmt(lockedRaw);
+    let line = `${currency}: disponível ${available} | em ordem ${locked}`;
+    if (source && source !== 'api') line += ` (${source === 'estimado' ? 'estimado' : source})`;
+    lines.push(line);
+  };
+
   const baseCurrency = (b.base?.currency || '').toString().toUpperCase();
-  if (!baseCurrency) {
-    if (b.reason === 'unexpected_assets_shape') return 'Saldo indisponível (formato inesperado).';
-    return 'Saldo da moeda base indisponível.';
+  if (baseCurrency) {
+    const assetEntry = assets[baseCurrency] || {};
+    const availableRaw = (b.base?.available != null) ? b.base.available : assetEntry.available;
+    const lockedRaw = (b.base?.locked != null) ? b.base.locked : assetEntry.locked;
+    const source = b.base?.source || ((assetEntry.available != null || assetEntry.locked != null) ? 'api' : null);
+    pushLine(baseCurrency, availableRaw, lockedRaw, source);
   }
 
-  const assetEntry = assets[baseCurrency] || {};
-  const availableRaw = (b.base?.available != null) ? b.base.available : assetEntry.available;
-  const lockedRaw = (b.base?.locked != null) ? b.base.locked : assetEntry.locked;
-  const source = b.base?.source || ((assetEntry.available != null || assetEntry.locked != null) ? 'api' : null);
+  const usdtAsset = assets.USDT || {};
+  const usdtAvailableRaw = (b.availableUSDT != null) ? b.availableUSDT : usdtAsset.available;
+  const usdtLockedRaw = usdtAsset.locked;
+  if (usdtAvailableRaw != null || usdtLockedRaw != null) {
+    pushLine('USDT', usdtAvailableRaw, usdtLockedRaw, null);
+  }
 
-  const available = fmt(availableRaw);
-  const locked = fmt(lockedRaw);
-
-  let line = `${baseCurrency}: disponível ${available}`;
-  if (locked !== '—') line += ` | em ordem ${locked}`;
-  if (source && source !== 'api') line += ` (${source === 'estimado' ? 'estimado' : source})`;
-  return line;
+  if (!lines.length) return 'Saldo da moeda base indisponível.';
+  return lines.join('\n');
 }
 
 async function refreshBalances() {

--- a/server.js
+++ b/server.js
@@ -256,27 +256,111 @@ function parseMexcOrderDetail(detail) {
 }
 
 // ===== MEXC saldo (via web token)
-function pickUSDTFromAssets(assets) {
-  const arr = Array.isArray(assets?.data) ? assets.data : (Array.isArray(assets) ? assets : []);
-  for (const it of arr) {
-    const cc = (it.currency || '').toString().toUpperCase();
-    if (cc === 'USDT') {
-      const v = it.availableBalance ?? it.availableCash ?? it.availableOpen ?? it.balanceAvailable ?? it.available;
-      if (v != null) return Number(v);
-    }
-  }
-  return null;
+function parseMaybeNumber(v) {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
 }
-async function getMexcAvailableUSDT() {
+function extractMexcAssets(payload) {
+  const arr = Array.isArray(payload?.data) ? payload.data : (Array.isArray(payload) ? payload : []);
+  const out = {};
+  for (const it of arr) {
+    if (!it || typeof it !== 'object') continue;
+    const cc = (it.currency || it.asset || it.coin || '').toString().toUpperCase();
+    if (!cc) continue;
+    const available = parseMaybeNumber(
+      it.availableBalance ?? it.balanceAvailable ?? it.availableCash ?? it.availableOpen ??
+      it.availableMargin ?? it.marginAvailable ?? it.available ?? it.maxAvailable ?? it.equity ?? it.cashBalance
+    );
+    const locked = parseMaybeNumber(
+      it.frozenBalance ?? it.frozen ?? it.locked ?? it.positionMargin ??
+      it.marginFrozen ?? it.orderMargin ?? it.holdVol ?? it.frozenMargin
+    );
+    const entry = {};
+    if (available != null) entry.available = available;
+    if (locked != null) entry.locked = locked;
+    if (Object.keys(entry).length > 0) out[cc] = entry;
+  }
+  return out;
+}
+function collectMexcLocalBase(symbol) {
+  if (!symbol) return null;
+  const base = symbol.split('_')[0]?.toUpperCase();
+  if (!base) return null;
+
+  const filled = parseMaybeNumber(positionState?.mexc?.filledQty);
+  let locked = 0;
+  for (const item of orderHistory) {
+    if (item.symbol !== symbol) continue;
+    const st = item.mexcStatus;
+    if (st !== 'open' && st !== 'creating') continue;
+    const vol = parseMaybeNumber(item.mexcDisplayVolume ?? item.volume);
+    if (vol != null) locked += vol;
+  }
+  if (!Number.isFinite(locked) || locked <= 0) locked = null;
+
+  if (filled == null && locked == null) return null;
+  return {
+    currency: base,
+    available: filled ?? null,
+    locked: locked ?? null,
+    source: 'estimado'
+  };
+}
+async function getMexcAvailableUSDT(symbol) {
   const token = config.mexc?.webAuthToken;
   if (!token) return { unknown: true, reason: 'no_web_token' };
 
   const headers = { Authorization: token, 'Content-Type': 'application/json' };
   const url = 'https://futures.mexc.com/api/v1/private/account/assets';
+  const base = symbol ? symbol.split('_')[0]?.toUpperCase() : null;
   try {
     const { data } = await axios.get(url, { headers, timeout: 8000 });
-    const v = pickUSDTFromAssets(data);
-    return v == null ? { unknown: true, reason: 'not_found' } : { availableUSDT: v };
+    const assets = extractMexcAssets(data);
+    const result = { assets };
+
+    if (assets.USDT && assets.USDT.available != null) {
+      result.availableUSDT = parseMaybeNumber(assets.USDT.available);
+    }
+
+    if (base) {
+      const entry = assets[base];
+      if (entry && (entry.available != null || entry.locked != null)) {
+        result.base = {
+          currency: base,
+          available: entry.available != null ? parseMaybeNumber(entry.available) : null,
+          locked: entry.locked != null ? parseMaybeNumber(entry.locked) : null,
+          source: 'api'
+        };
+      }
+    }
+
+    if ((!result.base || result.base.available == null) && base) {
+      const fallback = collectMexcLocalBase(symbol);
+      if (fallback) {
+        result.base = fallback;
+        result.assets = result.assets || {};
+        result.assets[base] = Object.assign({}, result.assets[base] || {}, {
+          available: fallback.available != null ? fallback.available : (result.assets[base]?.available ?? null),
+          locked: fallback.locked != null ? fallback.locked : (result.assets[base]?.locked ?? null)
+        });
+      }
+    }
+
+    if (base && !result.base) {
+      result.base = { currency: base, available: null, locked: null, source: 'sem dados' };
+      result.assets = result.assets || {};
+      if (!result.assets[base]) result.assets[base] = {};
+    }
+
+    if (!Object.keys(result.assets || {}).length) {
+      if (result.base) {
+        result.assets = { [result.base.currency]: { available: result.base.available, locked: result.base.locked } };
+        return result;
+      }
+      return { unknown: true, reason: 'unexpected_assets_shape' };
+    }
+
+    return result;
   } catch (e) {
     const msg = e.response?.data || e.message;
     console.warn('[MEXC balance] erro:', msg);
@@ -468,7 +552,7 @@ app.get('/api/data', async (_req, res) => {
 app.get('/api/balances', async (_req, res) => {
   const symbol = currentSymbol;
   const gate = await getGateBalances(symbol);
-  const mexc = await getMexcAvailableUSDT();
+  const mexc = await getMexcAvailableUSDT(symbol);
   res.json({ gate, mexc });
 });
 
@@ -633,7 +717,7 @@ app.post('/api/precheck', async (req, res) => {
     }
 
     if (mode === 'open') {
-      const mexcBal = await getMexcAvailableUSDT();
+      const mexcBal = await getMexcAvailableUSDT(symbol);
       const contractValueUSDT = rounded.pm * Number(meta.mexc.contractSize);
       const required = (contractValueUSDT * contracts) / Number(meta.settings.leverage || 1);
       const details = {
@@ -724,7 +808,7 @@ app.post('/api/execute-trade', async (req, res) => {
 
     const [gateBalances, mexcBal] = await Promise.all([
       getGateBalances(symbol),
-      getMexcAvailableUSDT()
+      getMexcAvailableUSDT(symbol)
     ]);
 
     const leverage = Number(meta.settings.leverage) || 1;


### PR DESCRIPTION
## Summary
- amplia a consulta de saldo da MEXC para retornar mapa completo de ativos, incluindo moeda base e quedas para quando a API não responder
- adiciona estimativa local a partir das ordens abertas/posição para preencher disponibilidade da moeda base quando a API não informar
- atualiza a renderização do card de saldos para exibir a moeda base da MEXC no mesmo formato da Gate

## Testing
- not run (não disponível)

------
https://chatgpt.com/codex/tasks/task_e_68c8d08a1ff8832fbb2040ca6de89ba3