### PR TITLE
Add Gate open order extra percentage option

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -34,6 +34,7 @@ module.exports = {
 
   // Políticas de execução (opcional). Você já usa a margem de 10%:
   execution: {
-    marginPct: 10 // % de distância para evitar que a ordem seja consumida imediatamente
+    marginPct: 10, // % de distância para evitar que a ordem seja consumida imediatamente
+    gateOpenExtraPct: 0 // % adicional aplicado apenas às ordens de abertura enviadas para a Gate
   }
 };

--- a/public/index.html
+++ b/public/index.html
@@ -71,7 +71,8 @@
         <div>
           <div class="muted" style="margin-bottom:6px;"><strong>Settings</strong></div>
           <label>margem (%) <input id="ov_set_margin" type="number" step="any" class="mono" /></label><br/>
-          <label>leverage <input id="ov_set_lev" type="number" step="any" class="mono" /></label>
+          <label>leverage <input id="ov_set_lev" type="number" step="any" class="mono" /></label><br/>
+          <label>Gate extra (%) <input id="ov_set_gate_extra" type="number" step="any" class="mono" /></label>
         </div>
       </div>
       <div style="margin-top:10px;">

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -104,12 +104,14 @@ function fillOverridesUI(merged) {
   set('ov_mexc_minc', m.minContracts);
   set('ov_set_margin', s.marginPct);
   set('ov_set_lev', s.leverage);
+  set('ov_set_gate_extra', s.gateOpenExtraPct);
 }
 function metaToText(label, meta) {
+  const gateExtra = (meta.settings && meta.settings.gateOpenExtraPct != null) ? meta.settings.gateOpenExtraPct : 0;
   return `${label}
 Gate: priceScale=${meta.gate.priceScale}, qtyScale=${meta.gate.qtyScale}, minQty=${meta.gate.minQty}, minQuote=${meta.gate.minQuote}
 MEXC: priceScale=${meta.mexc.priceScale}, volPrecision=${meta.mexc.volPrecision}, contractSize=${meta.mexc.contractSize}, minContracts=${meta.mexc.minContracts}
-Settings: margem=${meta.settings.marginPct}%, lev=${meta.settings.leverage}, parity=${meta.settings.parityVolumes}`;
+Settings: margem=${meta.settings.marginPct}%, lev=${meta.settings.leverage}, gateExtra=${gateExtra}%, parity=${meta.settings.parityVolumes}`;
 }
 async function refreshMetaUI(symbol) {
   const r = await fetch('/api/market-meta?symbol=' + encodeURIComponent(symbol));
@@ -156,6 +158,7 @@ document.getElementById('saveOverride').addEventListener('click', async () => {
     settings: {
       marginPct: numOrUndef('ov_set_margin'),
       leverage: numOrUndef('ov_set_lev'),
+      gateOpenExtraPct: numOrUndef('ov_set_gate_extra'),
       parityVolumes: true
     }
   };
@@ -548,7 +551,19 @@ async function refreshHistory() {
       tr.appendChild(td(h.sentido || '-'));
       tr.appendChild(td(h.priceUsedGate || '-'));
       tr.appendChild(td(h.priceUsedMexc || '-'));
-      tr.appendChild(td(h.volume || '-'));
+      const volumeCell = (() => {
+        if (h.volume == null) return '-';
+        const gateVol = h.gateOrderVolume;
+        if (gateVol != null && gateVol !== '') {
+          const baseNum = Number(h.volume);
+          const gateNum = Number(gateVol);
+          if ((Number.isFinite(baseNum) && Number.isFinite(gateNum) && baseNum !== gateNum) || gateVol !== h.volume) {
+            return `${h.volume} (Gate: ${gateVol})`;
+          }
+        }
+        return String(h.volume);
+      })();
+      tr.appendChild(td(volumeCell));
       tr.appendChild(td(h.arbPct != null ? Number(h.arbPct).toFixed(6) : '-'));
       tr.appendChild(td(h.pnlUsd != null ? Number(h.pnlUsd).toFixed(6) : '-'));
       tr.appendChild(td(h.gateOrderId || '-'));
@@ -612,12 +627,13 @@ document.getElementById('executeTrade').addEventListener('click', async () => {
       const ok = confirm(
         `Saldo possivelmente insuficiente na MEXC.\n` +
         `Requerido: ${d.requiredUSDT} USDT | Disponível: ${d.availableUSDT}\n` +
-        `Alavancagem: ${d.leverage}x | Contratos: ${d.mexcContracts} (x${d.contractSize} moeda base) | Moeda base final: ${d.finalBaseQty}\n` +
+        `Alavancagem: ${d.leverage}x | Contratos: ${d.mexcContracts} (x${d.contractSize} moeda base) | Moeda base final (MEXC): ${d.finalBaseQty}\n` +
+        `Gate ordem base (após extra): ${d.gateOrderBaseQty ?? d.finalBaseQty} | Extra Gate (%): ${d.gateOpenExtraPct ?? 0}\n` +
         `Deseja prosseguir?`
       );
       if (!ok) { document.getElementById('status').textContent = 'Cancelado pelo usuário.'; btn.disabled = false; return; }
     } else if (preOut.unknownBalance) {
-      document.getElementById('status').textContent = `Saldo MEXC não estimado; prosseguindo... (moeda base final: ${d.finalBaseQty})`;
+      document.getElementById('status').textContent = `Saldo MEXC não estimado; prosseguindo... (moeda base final: ${d.finalBaseQty} | Gate ordem base: ${d.gateOrderBaseQty ?? d.finalBaseQty})`;
     }
 
     document.getElementById('status').textContent = 'Executando...';

--- a/server.js
+++ b/server.js
@@ -406,7 +406,11 @@ async function autoDiscoverMexcMeta(symbol) {
 async function autoDiscoverMeta(symbol) {
   const gate = await autoDiscoverGateMeta(symbol);
   const mexc = await autoDiscoverMexcMeta(symbol);
-  const settings = { marginPct: Number(config.execution?.marginPct ?? 10), leverage: Number(config.mexc?.leverage ?? 1) };
+  const settings = {
+    marginPct: Number(config.execution?.marginPct ?? 10),
+    leverage: Number(config.mexc?.leverage ?? 1),
+    gateOpenExtraPct: Number(config.execution?.gateOpenExtraPct ?? 0)
+  };
   return { symbolSpot: symbol, symbolFut: symbol, gate, mexc, settings };
 }
 function deepMerge(target, src) {
@@ -448,6 +452,22 @@ function applyRoundingMeta(pg, pm, qtyW, meta) {
   const pmR = roundTo(pm, psm);
   const qR = roundDownTo(qtyW, qsg);
   return { pg: pgR, pm: pmR, q: qR };
+}
+
+function computeGateOrderQty(baseQty, meta, mode) {
+  let qty = Number(baseQty) || 0;
+  if (mode === 'open') {
+    const extraPct = Number(meta?.settings?.gateOpenExtraPct || 0);
+    if (Number.isFinite(extraPct) && extraPct > 0) {
+      const factor = 1 + (extraPct / 100);
+      const qtyScale = Number(meta?.gate?.qtyScale || 0);
+      const adjusted = roundTo(qty * factor, qtyScale);
+      if (Number.isFinite(adjusted)) {
+        qty = Math.max(qty, adjusted);
+      }
+    }
+  }
+  return qty;
 }
 
 function normalizeLevelSelection(raw, maxGateLevels, maxMexcLevels) {
@@ -893,11 +913,13 @@ app.post('/api/precheck', async (req, res) => {
       return res.json({ ok: true, blocked: true, reason: 'min_contracts_not_met', minContracts, mode });
     }
 
+    const gateOrderBaseQty = computeGateOrderQty(rounded.q, meta, mode);
+
     const minQuote = Number(meta.gate.minQuote || 0);
-    if (minQuote > 0 && rounded.q * rounded.pg < minQuote) {
+    if (minQuote > 0 && gateOrderBaseQty * rounded.pg < minQuote) {
       return res.json({
         ok: true, blocked: true, reason: 'min_quote_not_met', minQuote,
-        calc: { gateQuote: Number((rounded.q * rounded.pg).toFixed(6)) }, mode
+        calc: { gateQuote: Number((gateOrderBaseQty * rounded.pg).toFixed(6)) }, mode
       });
     }
 
@@ -908,8 +930,11 @@ app.post('/api/precheck', async (req, res) => {
       const details = {
         mode, symbol, gateRounded: rounded.pg, mexcRounded: rounded.pm,
         mexcContracts: contracts, contractSize: cs,
-        finalBaseQty: rounded.q, leverage: meta.settings.leverage,
-        marginPct: meta.settings.marginPct, requiredUSDT: Number(required.toFixed(6)),
+        finalBaseQty: rounded.q, gateOrderBaseQty,
+        leverage: meta.settings.leverage,
+        marginPct: meta.settings.marginPct,
+        gateOpenExtraPct: meta.settings.gateOpenExtraPct,
+        requiredUSDT: Number(required.toFixed(6)),
         levelsUsed: selectedLevels
       };
       if (mexcBal.availableUSDT == null) return res.json({ ok: true, needConfirm: false, unknownBalance: true, details });
@@ -921,8 +946,11 @@ app.post('/api/precheck', async (req, res) => {
       const details = {
         mode, symbol, gateRounded: rounded.pg, mexcRounded: rounded.pm,
         mexcContracts: contracts, contractSize: cs,
-        finalBaseQty: rounded.q, leverage: meta.settings.leverage,
-        marginPct: meta.settings.marginPct, requiredUSDT: 0,
+        finalBaseQty: rounded.q, gateOrderBaseQty,
+        leverage: meta.settings.leverage,
+        marginPct: meta.settings.marginPct,
+        gateOpenExtraPct: meta.settings.gateOpenExtraPct,
+        requiredUSDT: 0,
         levelsUsed: selectedLevels
       };
       return res.json({ ok: true, needConfirm: false, unknownBalance: false, details });
@@ -1055,8 +1083,10 @@ app.post('/api/execute-trade', async (req, res) => {
       return res.status(400).json({ error: `Volume abaixo do mínimo de contratos (${minContracts}).` });
     }
 
+    const gateOrderBaseQty = computeGateOrderQty(rounded.q, meta, mode);
+
     const minQuote = Number(meta.gate.minQuote || 0);
-    if (minQuote > 0 && rounded.q * rounded.pg < minQuote) {
+    if (minQuote > 0 && gateOrderBaseQty * rounded.pg < minQuote) {
       return res.status(400).json({ error: `Mínimo da Gate não atendido (>= ${minQuote} USDT). Tente aumentar contratos.` });
     }
 
@@ -1083,7 +1113,7 @@ app.post('/api/execute-trade', async (req, res) => {
     }
 
     if (mode === 'open') {
-      const neededGateUSDT = rounded.pg * rounded.q;
+      const neededGateUSDT = rounded.pg * gateOrderBaseQty;
       const gateUSDTAvail = Number(gateBalances?.USDT?.available || 0);
       if (gateUSDTAvail < neededGateUSDT) {
         return res.status(400).json({
@@ -1095,10 +1125,10 @@ app.post('/api/execute-trade', async (req, res) => {
     } else {
       const baseCurrency = symbol.split('_')[0];
       const gateBaseAvailable = Number(gateBalances?.[baseCurrency]?.available || 0);
-      if (gateBaseAvailable < rounded.q) {
+      if (gateBaseAvailable < gateOrderBaseQty) {
         return res.status(400).json({
           error: `Saldo Gate ${baseCurrency} insuficiente`,
-          requiredBase: Number(rounded.q.toFixed(meta.gate.qtyScale)),
+          requiredBase: Number(gateOrderBaseQty.toFixed(meta.gate.qtyScale)),
           availableBase: gateBaseAvailable
         });
       }
@@ -1107,7 +1137,7 @@ app.post('/api/execute-trade', async (req, res) => {
     console.log('[EXECUTAR] Modo:', mode);
     console.log('[EXECUTAR] Preço Gate:', rounded.pg);
     console.log('[EXECUTAR] Preço MEXC:', rounded.pm);
-    console.log('[EXECUTAR] Volume (moeda base final):', rounded.q, '| contratos MEXC:', contracts);
+    console.log('[EXECUTAR] Volume (moeda base final):', rounded.q, '| Volume Gate (com extra):', gateOrderBaseQty, '| contratos MEXC:', contracts);
 
     const localId = Date.now().toString();
     const histItem = {
@@ -1133,9 +1163,10 @@ app.post('/api/execute-trade', async (req, res) => {
         symbol,
         side,
         String(rounded.pg.toFixed(meta.gate.priceScale)),
-        String(rounded.q.toFixed(meta.gate.qtyScale))
+        String(gateOrderBaseQty.toFixed(meta.gate.qtyScale))
       );
       histItem.gateOrderId = (go?.id != null) ? String(go.id) : null;
+      histItem.gateOrderVolume = String(gateOrderBaseQty.toFixed(meta.gate.qtyScale));
       gateOk = !!histItem.gateOrderId;
       histItem.gateStatus = gateOk ? 'open' : 'error';
     } catch (e) {
@@ -1173,7 +1204,7 @@ app.post('/api/execute-trade', async (req, res) => {
 
     res.json({
       ok: true, localId, mode,
-      gate: { id: histItem.gateOrderId, price: histItem.priceUsedGate },
+      gate: { id: histItem.gateOrderId, price: histItem.priceUsedGate, displayBaseQty: histItem.gateOrderVolume },
       mexc: { id: histItem.mexcOrderId, price: histItem.priceUsedMexc, displayBaseQty: histItem.mexcDisplayVolume },
       status: histItem.status
     });
@@ -1248,7 +1279,11 @@ app.post('/api/reposition-gate', async (req, res) => {
     const gAsk = book.data.asks[0], gBid = book.data.bids[0];
     const rawPrice = (item.mode === 'open') ? Number(gAsk[0]) : Number(gBid[0]);
     const newPrice = Number(rawPrice.toFixed(meta.gate.priceScale));
-    const qty = Number(item.volume);
+    const storedQty = Number(item.gateOrderVolume);
+    let qty = Number.isFinite(storedQty)
+      ? storedQty
+      : computeGateOrderQty(Number(item.volume), meta, item.mode);
+    if (!Number.isFinite(qty) || qty <= 0) qty = Number(item.volume);
     const side = (item.mode === 'open') ? 'buy' : 'sell';
 
     try { await cancelGateOrderSdk(symbol, item.gateOrderId); } catch {}
@@ -1260,6 +1295,7 @@ app.post('/api/reposition-gate', async (req, res) => {
     );
     item.gateOrderId = go?.id ? String(go.id) : null;
     item.priceUsedGate = String(newPrice);
+    item.gateOrderVolume = String(qty.toFixed(meta.gate.qtyScale));
     item.gateStatus = item.gateOrderId ? 'open' : 'error';
     item.status = (item.mexcStatus === 'filled') ? 'mexc_filled' : 'open';
     try { db.saveHistoryItem(item); } catch (e) { console.warn('[SQLite] save history (reposition gate):', e?.message || e); }


### PR DESCRIPTION
## Summary
- add support for configuring an extra Gate open-order percentage in backend metadata and config
- apply the configured percentage when validating and submitting Gate open orders, persisting the adjusted quantity
- expose the percentage field in the Settings overrides UI and surface the adjusted amount in history and confirmations

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d21403cd7c832f8cf4f7ccd45c61bc