### PR TITLE
Persist position state and manual controls

### DIFF
--- a/db.js
+++ b/db.js
@@ -109,6 +109,11 @@ INSERT INTO position_summaries(id, symbol, created_at, summary_json)
 VALUES (@id, @symbol, @created_at, @json)
 `);
 
+const loadPositionSummariesStmt = db.prepare(`
+SELECT summary_json FROM position_summaries
+ORDER BY datetime(created_at) DESC, created_at DESC
+`);
+
 function saveHistoryItem(item) {
   // Garante que todos os campos são bindáveis
   const payload = {
@@ -164,6 +169,16 @@ function savePositionSummary(summary) {
   insertPositionSummaryStmt.run(payload);
 }
 
+function loadPositionSummaries() {
+  const arr = [];
+  for (const row of loadPositionSummariesStmt.all()) {
+    try {
+      arr.push(JSON.parse(row.summary_json));
+    } catch {}
+  }
+  return arr;
+}
+
 module.exports = {
   DB_PATH,
   upsertOverride,
@@ -172,5 +187,6 @@ module.exports = {
   loadHistory,
   savePositionState,
   loadPositionState,
-  savePositionSummary
+  savePositionSummary,
+  loadPositionSummaries
 };

--- a/db.js
+++ b/db.js
@@ -31,6 +31,17 @@ CREATE TABLE IF NOT EXISTS history (
   sentido TEXT,
   raw_json TEXT NOT NULL
 );
+CREATE TABLE IF NOT EXISTS position_state (
+  id TEXT PRIMARY KEY,
+  state_json TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS position_summaries (
+  id TEXT PRIMARY KEY,
+  symbol TEXT,
+  created_at TEXT NOT NULL,
+  summary_json TEXT NOT NULL
+);
 `);
 
 // Migração simples: garante colunas gate_status e mexc_status
@@ -83,6 +94,21 @@ INSERT OR REPLACE INTO history (
   @gateOrderId, @mexcOrderId, @status, @gateStatus, @mexcStatus, @sentido, @raw
 )`);
 
+const upsertPositionStateStmt = db.prepare(`
+INSERT INTO position_state(id, state_json, updated_at)
+VALUES (@id, @json, @updated_at)
+ON CONFLICT(id) DO UPDATE SET
+  state_json = excluded.state_json,
+  updated_at = excluded.updated_at
+`);
+
+const loadPositionStateStmt = db.prepare('SELECT state_json FROM position_state WHERE id = ?');
+
+const insertPositionSummaryStmt = db.prepare(`
+INSERT INTO position_summaries(id, symbol, created_at, summary_json)
+VALUES (@id, @symbol, @created_at, @json)
+`);
+
 function saveHistoryItem(item) {
   // Garante que todos os campos são bindáveis
   const payload = {
@@ -114,10 +140,37 @@ function loadHistory() {
   return arr;
 }
 
+function savePositionState(state, id = 'current') {
+  upsertPositionStateStmt.run({
+    id,
+    json: JSON.stringify(state || {}),
+    updated_at: new Date().toISOString()
+  });
+}
+
+function loadPositionState(id = 'current') {
+  const row = loadPositionStateStmt.get(id);
+  if (!row || !row.state_json) return null;
+  try { return JSON.parse(row.state_json); } catch { return null; }
+}
+
+function savePositionSummary(summary) {
+  const payload = {
+    id: summary.id,
+    symbol: summary.symbol || null,
+    created_at: summary.createdAt || new Date().toISOString(),
+    json: JSON.stringify(summary || {})
+  };
+  insertPositionSummaryStmt.run(payload);
+}
+
 module.exports = {
   DB_PATH,
   upsertOverride,
   loadOverrides,
   saveHistoryItem,
-  loadHistory
+  loadHistory,
+  savePositionState,
+  loadPositionState,
+  savePositionSummary
 };

--- a/public/index.html
+++ b/public/index.html
@@ -268,6 +268,31 @@
     </table>
   </div>
 
+  <div class="card" style="margin-top:16px;">
+    <h3>Histórico de Posições Fechadas</h3>
+    <table>
+      <thead>
+        <tr>
+          <th>Encerrada</th>
+          <th>Iniciada</th>
+          <th>Par</th>
+          <th>Meta (qty)</th>
+          <th>Preenchido</th>
+          <th>Preço médio final</th>
+          <th>Arb final (%)</th>
+          <th>PnL final (USDT)</th>
+          <th>Volume total</th>
+          <th>Gate preenchido</th>
+          <th>Gate preço médio</th>
+          <th>MEXC preenchido</th>
+          <th>MEXC preço médio</th>
+          <th>Obs.</th>
+        </tr>
+      </thead>
+      <tbody id="positionSummaryBody"></tbody>
+    </table>
+  </div>
+
   <script src="scripts.js"></script>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -35,6 +35,11 @@
     .quote-controls { margin-top: 10px; display: flex; flex-direction: column; gap: 8px; }
     .quote-control-row { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; font-size: 13px; }
     .quote-actions { display: flex; justify-content: flex-end; }
+    .position-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(170px, 1fr)); gap: 10px; }
+    .position-field { display: flex; flex-direction: column; font-size: 13px; }
+    .position-field input { margin-top: 4px; font-size: 13px; }
+    .position-subgrid { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 14px; margin-top: 12px; }
+    .position-actions { margin-top: 12px; display: flex; flex-wrap: wrap; gap: 8px; }
   </style>
 </head>
 <body>
@@ -179,15 +184,54 @@
       </div>
 
       <div class="mono" style="margin-top:10px;">
-        <div>Alvo: <span id="ppTarget">0</span></div>
-        <div style="margin-top:6px;"><strong>Gate</strong></div>
-        <div>Preenchido: <span id="ppGateFilled">0</span></div>
-        <div>Preço Médio: <span id="ppGateAvg">0</span></div>
-        <div style="margin-top:6px;"><strong>MEXC</strong></div>
-        <div>Preenchido: <span id="ppMexcFilled">0</span></div>
-        <div>Preço Médio: <span id="ppMexcAvg">0</span></div>
-        <div style="margin-top:6px;">Arb. Média (%): <span id="ppArb">0</span></div>
-        <div>PnL Geral (USDT): <span id="ppPnl">0</span></div>
+        <div class="position-grid">
+          <label class="position-field">Alvo atual
+            <input id="ppTargetCurrent" type="number" step="any" class="mono" />
+          </label>
+          <label class="position-field">Total preenchido
+            <input id="ppFilledInput" type="number" step="any" class="mono" />
+          </label>
+          <label class="position-field">Preço médio geral
+            <input id="ppAvgPriceInput" type="number" step="any" class="mono" />
+          </label>
+          <label class="position-field">Arb. média (%)
+            <input id="ppArbInput" type="number" step="any" class="mono" />
+          </label>
+          <label class="position-field">PnL geral (USDT)
+            <input id="ppPnlInput" type="number" step="any" class="mono" />
+          </label>
+          <label class="position-field">Volume total operado
+            <input id="ppVolumeInput" type="number" step="any" class="mono" />
+          </label>
+        </div>
+        <div class="position-subgrid">
+          <div>
+            <div><strong>Gate</strong></div>
+            <label class="position-field">Preenchido
+              <input id="ppGateFilledInput" type="number" step="any" class="mono" />
+            </label>
+            <label class="position-field">Preço médio
+              <input id="ppGateAvgInput" type="number" step="any" class="mono" />
+            </label>
+          </div>
+          <div>
+            <div><strong>MEXC</strong></div>
+            <label class="position-field">Preenchido
+              <input id="ppMexcFilledInput" type="number" step="any" class="mono" />
+            </label>
+            <label class="position-field">Preço médio
+              <input id="ppMexcAvgInput" type="number" step="any" class="mono" />
+            </label>
+            <label class="position-field">Position ID
+              <input id="ppMexcPositionId" type="text" class="mono" />
+            </label>
+          </div>
+        </div>
+      </div>
+
+      <div class="position-actions">
+        <button id="savePositionData">Salvar dados da posição</button>
+        <button id="dismantlePosition">Desmontar posição</button>
       </div>
 
       <div style="margin-top:10px;">

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -198,6 +198,24 @@ function setInputValue(id, value, decimals, force) {
   }
 }
 
+function formatDateTime(value) {
+  if (!value) return '-';
+  try {
+    return new Date(value).toLocaleString('pt-BR');
+  } catch {
+    return value;
+  }
+}
+
+function formatNumberCell(value, decimals) {
+  if (value === undefined || value === null || value === '') return '-';
+  const num = Number(value);
+  if (Number.isFinite(num)) {
+    return typeof decimals === 'number' ? num.toFixed(decimals) : String(num);
+  }
+  return String(value);
+}
+
 function getNumberFromInput(id) {
   const el = document.getElementById(id);
   if (!el) return undefined;
@@ -610,6 +628,61 @@ async function refreshHistory() {
 }
 setInterval(refreshHistory, 5000); refreshHistory();
 
+async function refreshPositionSummaries() {
+  const tbody = document.getElementById('positionSummaryBody');
+  if (!tbody) return;
+
+  const renderMessageRow = (text) => {
+    const tr = document.createElement('tr');
+    const td = document.createElement('td');
+    td.colSpan = 14;
+    td.textContent = text;
+    tr.appendChild(td);
+    tbody.appendChild(tr);
+  };
+
+  try {
+    const resp = await fetch('/api/position-summaries');
+    const out = await safeJson(resp);
+    if (!resp.ok) throw new Error(out?.error || 'Falha ao carregar');
+    const list = Array.isArray(out.summaries) ? out.summaries : [];
+    tbody.innerHTML = '';
+    if (!list.length) {
+      renderMessageRow('Nenhum resumo registrado ainda.');
+      return;
+    }
+
+    list.forEach((summary) => {
+      const tr = document.createElement('tr');
+      const td = (text) => { const el = document.createElement('td'); el.textContent = text; return el; };
+      const gate = summary.gate || {};
+      const mexc = summary.mexc || {};
+
+      tr.appendChild(td(formatDateTime(summary.endedAt || summary.createdAt)));
+      tr.appendChild(td(formatDateTime(summary.startedAt)));
+      tr.appendChild(td(summary.symbol || '-'));
+      tr.appendChild(td(formatNumberCell(summary.targetQty, 6)));
+      tr.appendChild(td(formatNumberCell(summary.finalFilledQty, 6)));
+      tr.appendChild(td(formatNumberCell(summary.finalAvgPrice, 11)));
+      tr.appendChild(td(formatNumberCell(summary.finalArbPct, 6)));
+      tr.appendChild(td(formatNumberCell(summary.finalPnlUsd, 6)));
+      tr.appendChild(td(formatNumberCell(summary.totalVolume, 11)));
+      tr.appendChild(td(formatNumberCell(gate.filledQty, 6)));
+      tr.appendChild(td(formatNumberCell(gate.avgPrice, 11)));
+      tr.appendChild(td(formatNumberCell(mexc.filledQty, 6)));
+      tr.appendChild(td(formatNumberCell(mexc.avgPrice, 11)));
+      tr.appendChild(td(summary.note ? String(summary.note) : '-'));
+
+      tbody.appendChild(tr);
+    });
+  } catch (err) {
+    console.error('refreshPositionSummaries erro:', err);
+    tbody.innerHTML = '';
+    renderMessageRow('Erro ao carregar resumos de posições.');
+  }
+}
+setInterval(refreshPositionSummaries, 7000); refreshPositionSummaries();
+
 async function refreshPosition() {
   try {
     const r = await fetch('/api/position-progress');
@@ -798,6 +871,7 @@ document.getElementById('dismantlePosition').addEventListener('click', async () 
     const totalVol = summary.totalVolume != null ? summary.totalVolume : '-';
     alert(`Posição desmontada. Arb final: ${finalArb}% | PnL final: ${finalPnl} USDT | Volume total: ${totalVol}`);
     await refreshPosition();
+    await refreshPositionSummaries();
   } catch (e) {
     alert('Erro ao desmontar posição: ' + (e.message || e));
   } finally {
@@ -841,5 +915,5 @@ function drawProgressChart(series) {
   if (isFinite(alertMax)) document.getElementById('alertMax').value = alertMax;
   document.getElementById('soundToggle').checked = soundEnabled;
   document.getElementById('telegramToggle').checked = telegramEnabled;
-  refreshBalances(); refreshHistory(); refreshPosition(); fetchData();
+  refreshBalances(); refreshHistory(); refreshPosition(); refreshPositionSummaries(); fetchData();
 })();

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -178,6 +178,35 @@ function numOrUndef(id) {
   const n = Number(v); return (Number.isFinite(n) ? n : undefined);
 }
 
+function setInputValue(id, value, decimals, force) {
+  const el = document.getElementById(id);
+  if (!el) return;
+  if (!force && document.activeElement === el) return;
+  if (value === undefined || value === null || value === '') {
+    el.value = '';
+    return;
+  }
+  const num = Number(value);
+  if (Number.isFinite(num)) {
+    if (typeof decimals === 'number') {
+      el.value = num.toFixed(decimals);
+    } else {
+      el.value = num;
+    }
+  } else {
+    el.value = value;
+  }
+}
+
+function getNumberFromInput(id) {
+  const el = document.getElementById(id);
+  if (!el) return undefined;
+  const raw = el.value;
+  if (raw === '' || raw === null || raw === undefined) return undefined;
+  const num = Number(raw);
+  return Number.isFinite(num) ? num : undefined;
+}
+
 function sanitizeLevelArray(arr) {
   if (!Array.isArray(arr)) return [];
   const out = [];
@@ -587,13 +616,21 @@ async function refreshPosition() {
     const s = await r.json();
     const g = s.gate || {};
     const m = s.mexc || {};
-    document.getElementById('ppTarget').textContent = s.targetQty || 0;
-    document.getElementById('ppGateFilled').textContent = g.filledQty || 0;
-    document.getElementById('ppGateAvg').textContent = (g.avgPrice || 0).toFixed ? g.avgPrice.toFixed(11) : g.avgPrice;
-    document.getElementById('ppMexcFilled').textContent = m.filledQty || 0;
-    document.getElementById('ppMexcAvg').textContent = (m.avgPrice || 0).toFixed ? m.avgPrice.toFixed(11) : m.avgPrice;
-    document.getElementById('ppArb').textContent = (s.arbPctAvg || 0).toFixed ? s.arbPctAvg.toFixed(6) : s.arbPctAvg;
-    document.getElementById('ppPnl').textContent = (s.pnlUsd || 0).toFixed ? s.pnlUsd.toFixed(6) : s.pnlUsd;
+    setInputValue('targetQty', s.targetQty);
+    setInputValue('ppTargetCurrent', s.targetQty);
+    setInputValue('ppFilledInput', s.filledQty);
+    setInputValue('ppAvgPriceInput', s.avgPrice, 11);
+    setInputValue('ppArbInput', s.arbPctAvg, 6);
+    setInputValue('ppPnlInput', s.pnlUsd, 6);
+    setInputValue('ppVolumeInput', s.totalVolume, 11);
+    setInputValue('ppGateFilledInput', g.filledQty);
+    setInputValue('ppGateAvgInput', g.avgPrice, 11);
+    setInputValue('ppMexcFilledInput', m.filledQty);
+    setInputValue('ppMexcAvgInput', m.avgPrice, 11);
+    const posIdEl = document.getElementById('ppMexcPositionId');
+    if (posIdEl && document.activeElement !== posIdEl) {
+      posIdEl.value = (m.positionId != null && m.positionId !== undefined) ? m.positionId : '';
+    }
     drawProgressChart(s.series || []);
   } catch {}
 }
@@ -672,9 +709,99 @@ document.getElementById('setTarget').addEventListener('click', async () => {
     });
     const out = await safeJson(resp);
     if (!resp.ok || !out.ok) { alert('Falha ao definir meta.'); return; }
-    document.getElementById('ppTarget').textContent = out.targetQty ?? val;
+    const newTarget = out.targetQty ?? val;
+    setInputValue('targetQty', newTarget, undefined, true);
+    setInputValue('ppTargetCurrent', newTarget, undefined, true);
+    await refreshPosition();
   } catch (e) {
     alert('Erro ao definir meta: ' + (e.message || e));
+  }
+});
+
+document.getElementById('savePositionData').addEventListener('click', async () => {
+  const btn = document.getElementById('savePositionData');
+  btn.disabled = true;
+  try {
+    const payload = {};
+    const gatePayload = {};
+    const mexcPayload = {};
+
+    const targetQty = getNumberFromInput('ppTargetCurrent');
+    if (targetQty !== undefined) payload.targetQty = targetQty;
+    const filledQty = getNumberFromInput('ppFilledInput');
+    if (filledQty !== undefined) payload.filledQty = filledQty;
+    const avgPrice = getNumberFromInput('ppAvgPriceInput');
+    if (avgPrice !== undefined) payload.avgPrice = avgPrice;
+    const arbPctAvg = getNumberFromInput('ppArbInput');
+    if (arbPctAvg !== undefined) payload.arbPctAvg = arbPctAvg;
+    const pnlUsd = getNumberFromInput('ppPnlInput');
+    if (pnlUsd !== undefined) payload.pnlUsd = pnlUsd;
+    const totalVolume = getNumberFromInput('ppVolumeInput');
+    if (totalVolume !== undefined) payload.totalVolume = totalVolume;
+
+    const gateFilled = getNumberFromInput('ppGateFilledInput');
+    if (gateFilled !== undefined) gatePayload.filledQty = gateFilled;
+    const gateAvg = getNumberFromInput('ppGateAvgInput');
+    if (gateAvg !== undefined) gatePayload.avgPrice = gateAvg;
+    if (Object.keys(gatePayload).length) payload.gate = gatePayload;
+
+    const mexcFilled = getNumberFromInput('ppMexcFilledInput');
+    if (mexcFilled !== undefined) mexcPayload.filledQty = mexcFilled;
+    const mexcAvg = getNumberFromInput('ppMexcAvgInput');
+    if (mexcAvg !== undefined) mexcPayload.avgPrice = mexcAvg;
+    const posIdEl = document.getElementById('ppMexcPositionId');
+    if (posIdEl) {
+      const trimmed = posIdEl.value.trim();
+      mexcPayload.positionId = trimmed === '' ? null : trimmed;
+    }
+    if (Object.keys(mexcPayload).length) payload.mexc = mexcPayload;
+
+    const resp = await fetch('/api/position-manual-update', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+    const out = await safeJson(resp);
+    if (!resp.ok || out.ok === false) {
+      const errMsg = (out && out.error) ? out.error : resp.statusText;
+      alert('Falha ao salvar dados da posição: ' + errMsg);
+      return;
+    }
+    await refreshPosition();
+  } catch (e) {
+    alert('Erro ao salvar dados da posição: ' + (e.message || e));
+  } finally {
+    btn.disabled = false;
+  }
+});
+
+document.getElementById('dismantlePosition').addEventListener('click', async () => {
+  const btn = document.getElementById('dismantlePosition');
+  const ok = confirm('Deseja desmontar a posição atual? Um resumo final será salvo.');
+  if (!ok) return;
+  btn.disabled = true;
+  try {
+    const resp = await fetch('/api/position-dismantle', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({})
+    });
+    const out = await safeJson(resp);
+    if (!resp.ok || out.ok === false) {
+      const errMsg = (out && out.error) ? out.error : resp.statusText;
+      alert('Falha ao desmontar posição: ' + errMsg);
+      return;
+    }
+    const summary = out.summary || {};
+    const finalArb = summary.finalArbPct != null ? Number(summary.finalArbPct).toFixed(6) : '-';
+    const finalPnl = summary.finalPnlUsd != null ? Number(summary.finalPnlUsd).toFixed(6) : '-';
+    const totalVol = summary.totalVolume != null ? summary.totalVolume : '-';
+    alert(`Posição desmontada. Arb final: ${finalArb}% | PnL final: ${finalPnl} USDT | Volume total: ${totalVol}`);
+    await refreshPosition();
+  } catch (e) {
+    alert('Erro ao desmontar posição: ' + (e.message || e));
+  } finally {
+    btn.disabled = false;
   }
 });
 

--- a/server.js
+++ b/server.js
@@ -7,6 +7,7 @@
 const express = require('express');
 const axios = require('axios');
 const path = require('path');
+const crypto = require('crypto');
 const GateApi = require('gate-api');
 const { MexcFuturesClient } = require('mexc-futures-sdk');
 const config = require('./config');
@@ -21,16 +22,102 @@ const autoMetaCache = new Map();
 const overridesBySymbol = new Map();
 
 let orderHistory = [];
-let positionState = {
-  targetQty: 0,
-  filledQty: 0,
-  avgPrice: 0,
-  arbPctAvg: 0,
-  pnlUsd: 0,
-  gate: { filledQty: 0, avgPrice: 0 },
-  mexc: { filledQty: 0, avgPrice: 0, positionId: null },
-  series: []
-};
+
+function createEmptyPositionState(symbol = currentSymbol) {
+  return {
+    symbol,
+    targetQty: 0,
+    filledQty: 0,
+    avgPrice: 0,
+    arbPctAvg: 0,
+    pnlUsd: 0,
+    totalVolume: 0,
+    startedAt: null,
+    lastUpdated: null,
+    gate: { filledQty: 0, avgPrice: 0 },
+    mexc: { filledQty: 0, avgPrice: 0, positionId: null },
+    series: []
+  };
+}
+
+function safeNumber(value, fallback = 0) {
+  if (value === undefined || value === null || value === '') return fallback;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function normalizePositionState(raw) {
+  if (!raw || typeof raw !== 'object') return createEmptyPositionState();
+  const symbol = typeof raw.symbol === 'string' && raw.symbol.includes('_')
+    ? raw.symbol.toUpperCase()
+    : currentSymbol;
+  const base = createEmptyPositionState(symbol);
+  base.targetQty = safeNumber(raw.targetQty, base.targetQty);
+  base.filledQty = safeNumber(raw.filledQty, base.filledQty);
+  base.avgPrice = safeNumber(raw.avgPrice, base.avgPrice);
+  base.arbPctAvg = safeNumber(raw.arbPctAvg, base.arbPctAvg);
+  base.pnlUsd = safeNumber(raw.pnlUsd, base.pnlUsd);
+  base.totalVolume = safeNumber(raw.totalVolume, base.totalVolume);
+  base.startedAt = raw.startedAt || null;
+  base.lastUpdated = raw.lastUpdated || null;
+  base.gate = {
+    filledQty: safeNumber(raw?.gate?.filledQty, 0),
+    avgPrice: safeNumber(raw?.gate?.avgPrice, 0)
+  };
+  base.mexc = {
+    filledQty: safeNumber(raw?.mexc?.filledQty, 0),
+    avgPrice: safeNumber(raw?.mexc?.avgPrice, 0),
+    positionId: raw?.mexc?.positionId ?? null
+  };
+  base.series = Array.isArray(raw.series) ? raw.series : [];
+  return base;
+}
+
+function parseNumberField(value, opts = {}) {
+  if (value === undefined) return undefined;
+  if (value === null || value === '') return undefined;
+  const n = Number(value);
+  if (!Number.isFinite(n)) throw new Error('Valor numérico inválido');
+  if (opts.min != null && n < opts.min) {
+    throw new Error(`Valor deve ser maior ou igual a ${opts.min}`);
+  }
+  return n;
+}
+
+function generateSummaryId() {
+  if (crypto && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(16).slice(2, 10)}`;
+}
+
+let positionState = createEmptyPositionState();
+
+function persistPositionState() {
+  try {
+    if (!positionState || typeof positionState !== 'object') return;
+    const sym = positionState.symbol && typeof positionState.symbol === 'string'
+      ? positionState.symbol.toUpperCase()
+      : currentSymbol;
+    positionState.symbol = sym.includes('_') ? sym : currentSymbol;
+    positionState.lastUpdated = new Date().toISOString();
+    db.savePositionState(positionState);
+  } catch (e) {
+    console.warn('[SQLite] Falha ao salvar posição:', e?.message || e);
+  }
+}
+
+try {
+  const storedState = db.loadPositionState();
+  if (storedState) {
+    positionState = normalizePositionState(storedState);
+    if (positionState.symbol && positionState.symbol.includes('_')) {
+      currentSymbol = positionState.symbol.toUpperCase();
+    }
+  }
+} catch (e) {
+  console.warn('[SQLite] Falha ao restaurar posição:', e?.message || e);
+}
 
 app.use(express.static(path.join(__dirname, 'public')));
 app.use(express.json());
@@ -70,6 +157,45 @@ function bnToStringMaybe(x) {
     if (typeof x.toString === 'function') return x.toString();
     return String(x);
   } catch { return String(x); }
+}
+
+function buildPositionSummary(state, extra = {}) {
+  const base = state || createEmptyPositionState();
+  const nowIso = new Date().toISOString();
+  const summary = {
+    id: extra.id || generateSummaryId(),
+    symbol: (base.symbol && typeof base.symbol === 'string' && base.symbol.includes('_'))
+      ? base.symbol.toUpperCase()
+      : currentSymbol,
+    createdAt: nowIso,
+    endedAt: extra.endedAt || nowIso,
+    startedAt: base.startedAt || null,
+    lastUpdated: base.lastUpdated || null,
+    targetQty: safeNumber(base.targetQty, 0),
+    finalFilledQty: safeNumber(base.filledQty, 0),
+    finalAvgPrice: roundTo(safeNumber(base.avgPrice, 0), 11),
+    finalArbPct: roundTo(safeNumber(base.arbPctAvg, 0), 6),
+    finalPnlUsd: roundTo(safeNumber(base.pnlUsd, 0), 6),
+    totalVolume: roundTo(safeNumber(base.totalVolume, 0), 11),
+    gate: {
+      filledQty: safeNumber(base?.gate?.filledQty, 0),
+      avgPrice: roundTo(safeNumber(base?.gate?.avgPrice, 0), 11)
+    },
+    mexc: {
+      filledQty: safeNumber(base?.mexc?.filledQty, 0),
+      avgPrice: roundTo(safeNumber(base?.mexc?.avgPrice, 0), 11),
+      positionId: base?.mexc?.positionId ?? null
+    },
+    seriesPoints: Array.isArray(base.series) ? base.series.length : 0
+  };
+  if (extra.note) summary.note = String(extra.note);
+  return summary;
+}
+
+function resetPositionState(symbol = positionState.symbol || currentSymbol) {
+  positionState = createEmptyPositionState(symbol);
+  persistPositionState();
+  return positionState;
 }
 
 // ===== Gate
@@ -553,6 +679,8 @@ app.post('/api/symbol', async (req, res) => {
   const s = String(req.body?.symbol || '').toUpperCase();
   if (!s.includes('_')) return res.status(400).json({ error: 'Símbolo inválido. Use BASE_QUOTE' });
   currentSymbol = s;
+  positionState.symbol = s;
+  persistPositionState();
   res.json({ ok: true, symbol: currentSymbol, meta: await getMergedMeta(currentSymbol) });
 });
 
@@ -722,9 +850,92 @@ app.post('/api/position-target', (req, res) => {
   const t = Number(req.body?.targetQty);
   if (!Number.isFinite(t) || t < 0) return res.status(400).json({ error: 'targetQty inválido' });
   positionState.targetQty = t;
+  persistPositionState();
   res.json({ ok: true, targetQty: t });
 });
 app.get('/api/position-progress', (_req, res) => res.json(positionState));
+
+app.post('/api/position-manual-update', (req, res) => {
+  try {
+    const body = req.body || {};
+    const gate = body.gate || {};
+    const mexc = body.mexc || {};
+
+    const applyNumber = (target, key, value, opts) => {
+      const parsed = parseNumberField(value, opts || {});
+      if (parsed !== undefined) target[key] = parsed;
+    };
+
+    const targetQty = parseNumberField(body.targetQty, { min: 0 });
+    if (targetQty !== undefined) positionState.targetQty = targetQty;
+
+    const filledQty = parseNumberField(body.filledQty);
+    if (filledQty !== undefined) positionState.filledQty = filledQty;
+
+    const avgPrice = parseNumberField(body.avgPrice);
+    if (avgPrice !== undefined) positionState.avgPrice = avgPrice;
+
+    const arbPctAvg = parseNumberField(body.arbPctAvg);
+    if (arbPctAvg !== undefined) positionState.arbPctAvg = arbPctAvg;
+
+    const pnlUsd = parseNumberField(body.pnlUsd);
+    if (pnlUsd !== undefined) positionState.pnlUsd = pnlUsd;
+
+    const totalVolume = parseNumberField(body.totalVolume, { min: 0 });
+    if (totalVolume !== undefined) positionState.totalVolume = totalVolume;
+
+    applyNumber(positionState.gate, 'filledQty', gate.filledQty);
+    applyNumber(positionState.gate, 'avgPrice', gate.avgPrice);
+
+    applyNumber(positionState.mexc, 'filledQty', mexc.filledQty);
+    applyNumber(positionState.mexc, 'avgPrice', mexc.avgPrice);
+
+    if ('positionId' in mexc) {
+      const raw = mexc.positionId;
+      positionState.mexc.positionId = (raw === null || raw === '' || raw === undefined)
+        ? null
+        : bnToStringMaybe(raw);
+    }
+
+    if (body.startedAt !== undefined) {
+      positionState.startedAt = body.startedAt ? String(body.startedAt) : null;
+    }
+
+    if (body.clearSeries === true) {
+      positionState.series = [];
+    }
+
+    if (Array.isArray(body.series)) {
+      positionState.series = body.series;
+    }
+
+    if (body.symbol) {
+      const sym = String(body.symbol).toUpperCase();
+      if (sym.includes('_')) {
+        positionState.symbol = sym;
+        currentSymbol = sym;
+      }
+    }
+
+    persistPositionState();
+    res.json({ ok: true, position: positionState });
+  } catch (err) {
+    res.status(400).json({ ok: false, error: err.message || 'Dados inválidos' });
+  }
+});
+
+app.post('/api/position-dismantle', (req, res) => {
+  const noteRaw = req.body?.note;
+  const note = typeof noteRaw === 'string' && noteRaw.trim() ? noteRaw.trim() : undefined;
+  const summary = buildPositionSummary(positionState, { note });
+  try {
+    db.savePositionSummary(summary);
+  } catch (e) {
+    console.warn('[SQLite] Falha ao salvar resumo da posição:', e?.message || e);
+  }
+  resetPositionState(summary.symbol || currentSymbol);
+  res.json({ ok: true, summary, state: positionState });
+});
 
 function updatePositionFromOrder(item, gFilled, gAvg, mFilled, mAvg) {
   const meta = item?.metaUsed || {};
@@ -746,6 +957,11 @@ function updatePositionFromOrder(item, gFilled, gAvg, mFilled, mAvg) {
   const mexcPrice = Number(mAvg || item.priceUsedMexc || 0);
   const sign = item.mode === 'close' ? -1 : 1;
   const adjQty = qty * sign;
+
+  positionState.symbol = (item?.symbol && typeof item.symbol === 'string' && item.symbol.includes('_'))
+    ? item.symbol.toUpperCase()
+    : currentSymbol;
+  if (!positionState.startedAt) positionState.startedAt = new Date().toISOString();
 
   const diff = mexcPrice - gatePrice;
   const arbRaw = (diff / gatePrice) * 100;
@@ -780,6 +996,7 @@ function updatePositionFromOrder(item, gFilled, gAvg, mFilled, mAvg) {
   positionState.avgPrice = newAvg;
   positionState.arbPctAvg = newArb;
   positionState.pnlUsd = (positionState.pnlUsd || 0) + item.pnlUsd;
+  positionState.totalVolume = roundTo((positionState.totalVolume || 0) + Math.abs(adjQty), 11);
 
   positionState.series.push({
     t: Date.now(),
@@ -787,9 +1004,12 @@ function updatePositionFromOrder(item, gFilled, gAvg, mFilled, mAvg) {
     avgPrice: Number(newAvg.toFixed(11)),
     arbPctAvg: Number(newArb.toFixed(6)),
     pnlUsd: Number(positionState.pnlUsd.toFixed(6)),
+    totalVolume: Number(positionState.totalVolume.toFixed(11)),
     gate: { filledQty: gNewQty, avgPrice: Number(gNewAvg.toFixed(11)) },
     mexc: { filledQty: mNewQty, avgPrice: Number(mNewAvg.toFixed(11)) }
   });
+
+  persistPositionState();
 }
 
 // ===== Precheck (respeita modo open/close do front)
@@ -1239,7 +1459,13 @@ app.post('/api/cancel-order', async (req, res) => {
         await mexcCancelOrder(symbol, String(item.mexcOrderId));
         const md = await getMexcOrderDetail(symbol, String(item.mexcOrderId));
         const p = parseMexcOrderDetail(md);
-        if (p.positionId) positionState.mexc.positionId = p.positionId;
+        if (p.positionId) {
+          const newPosId = bnToStringMaybe(p.positionId);
+          if (newPosId && positionState.mexc.positionId !== newPosId) {
+            positionState.mexc.positionId = newPosId;
+            persistPositionState();
+          }
+        }
         mFilled = Number(p.filled || 0);
         mAvg = Number(p.avgPrice || item.priceUsedMexc);
       }
@@ -1383,7 +1609,13 @@ async function pollOpenOrders() {
         console.log('MEXC detail', md);
         const p = parseMexcOrderDetail(md);
         console.log('parsed detail', p);
-        if (p.positionId) positionState.mexc.positionId = p.positionId;
+        if (p.positionId) {
+          const newPosId = bnToStringMaybe(p.positionId);
+          if (newPosId && positionState.mexc.positionId !== newPosId) {
+            positionState.mexc.positionId = newPosId;
+            persistPositionState();
+          }
+        }
         mFilled = Number(p.filled || 0);
         mAvg = Number(p.avgPrice || mAvg);
         mIsFilled = !!p.isFilled;

--- a/server.js
+++ b/server.js
@@ -855,6 +855,16 @@ app.post('/api/position-target', (req, res) => {
 });
 app.get('/api/position-progress', (_req, res) => res.json(positionState));
 
+app.get('/api/position-summaries', (_req, res) => {
+  try {
+    const summaries = db.loadPositionSummaries();
+    res.json({ summaries });
+  } catch (err) {
+    console.warn('[SQLite] Falha ao carregar resumos de posições:', err?.message || err);
+    res.status(500).json({ error: 'Falha ao carregar resumos de posições' });
+  }
+});
+
 app.post('/api/position-manual-update', (req, res) => {
   try {
     const body = req.body || {};


### PR DESCRIPTION
## Summary
- persist the position progress card data and final summaries in SQLite so the state survives restarts
- expose server helpers for restoring/saving position state, updating data manually, dismantling positions, and tracking cumulative volume
- refresh the front-end position card with editable inputs, save/reset controls, and client logic wired to the new APIs

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d4386812dc832fa4d94132b5b58b92