### PR TITLE
Persist manual position state and summaries

### DIFF
--- a/db.js
+++ b/db.js
@@ -31,6 +31,17 @@ CREATE TABLE IF NOT EXISTS history (
   sentido TEXT,
   raw_json TEXT NOT NULL
 );
+CREATE TABLE IF NOT EXISTS position_state (
+  id INTEGER PRIMARY KEY CHECK (id = 1),
+  state_json TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS position_summaries (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  created_at TEXT NOT NULL,
+  note TEXT,
+  summary_json TEXT NOT NULL
+);
 `);
 
 // Migração simples: garante colunas gate_status e mexc_status
@@ -114,10 +125,75 @@ function loadHistory() {
   return arr;
 }
 
+const upsertPositionStateStmt = db.prepare(`
+INSERT INTO position_state (id, state_json, updated_at)
+VALUES (1, @json, @updatedAt)
+ON CONFLICT(id) DO UPDATE SET
+  state_json = excluded.state_json,
+  updated_at = excluded.updated_at
+`);
+
+function savePositionState(state) {
+  upsertPositionStateStmt.run({
+    json: JSON.stringify(state || {}),
+    updatedAt: new Date().toISOString()
+  });
+}
+
+const loadPositionStateStmt = db.prepare('SELECT state_json FROM position_state WHERE id = 1');
+function loadPositionState() {
+  const row = loadPositionStateStmt.get();
+  if (!row || !row.state_json) return null;
+  try { return JSON.parse(row.state_json); }
+  catch { return null; }
+}
+
+const insertPositionSummaryStmt = db.prepare(`
+INSERT INTO position_summaries (created_at, note, summary_json)
+VALUES (@createdAt, @note, @summaryJson)
+`);
+
+function savePositionSummary(summary) {
+  const createdAt = new Date().toISOString();
+  const info = insertPositionSummaryStmt.run({
+    createdAt,
+    note: typeof summary?.note === 'string' && summary.note.trim() ? summary.note.trim() : null,
+    summaryJson: JSON.stringify(summary || {})
+  });
+  return { id: info.lastInsertRowid, createdAt };
+}
+
+const loadPositionSummariesStmt = db.prepare(`
+SELECT id, created_at, note, summary_json
+FROM position_summaries
+ORDER BY id DESC
+LIMIT ?
+`);
+
+function loadPositionSummaries(limit = 20) {
+  const limNum = Number(limit);
+  const lim = Number.isFinite(limNum) && limNum > 0 ? limNum : 20;
+  const rows = loadPositionSummariesStmt.all(lim);
+  return rows.map((row) => {
+    let parsed = null;
+    try { parsed = JSON.parse(row.summary_json); } catch {}
+    return {
+      id: row.id,
+      createdAt: row.created_at,
+      note: row.note || (parsed && typeof parsed.note === 'string' ? parsed.note : null) || null,
+      summary: parsed || {}
+    };
+  });
+}
+
 module.exports = {
   DB_PATH,
   upsertOverride,
   loadOverrides,
   saveHistoryItem,
-  loadHistory
+  loadHistory,
+  savePositionState,
+  loadPositionState,
+  savePositionSummary,
+  loadPositionSummaries
 };

--- a/public/index.html
+++ b/public/index.html
@@ -35,6 +35,16 @@
     .quote-controls { margin-top: 10px; display: flex; flex-direction: column; gap: 8px; }
     .quote-control-row { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; font-size: 13px; }
     .quote-actions { display: flex; justify-content: flex-end; }
+    .position-edit-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 12px; margin-top: 10px; }
+    .position-edit-grid label { display: flex; flex-direction: column; gap: 4px; font-size: 13px; }
+    .position-edit-grid input { padding: 4px 6px; }
+    .position-edit-actions { margin-top: 12px; display: flex; flex-direction: column; gap: 8px; }
+    .position-edit-actions textarea { width: 100%; min-height: 50px; resize: vertical; padding: 6px; font-family: inherit; }
+    .position-edit-buttons { display: flex; gap: 10px; flex-wrap: wrap; }
+    .position-summaries { margin-top: 16px; }
+    .position-summaries table { font-size: 12px; }
+    .position-summaries th { background: #fafafa; }
+    .position-summaries td, .position-summaries th { text-align: left; }
   </style>
 </head>
 <body>
@@ -193,6 +203,76 @@
       <div style="margin-top:10px;">
         <canvas id="progressChart" width="600" height="260"></canvas>
       </div>
+    </div>
+  </div>
+
+  <div class="card" style="margin-top:16px;">
+    <h3>Editar estado da posição</h3>
+    <div class="position-edit-grid">
+      <div>
+        <label>Meta total
+          <input id="posEditTarget" type="number" step="any" class="mono" />
+        </label>
+        <label>Total preenchido
+          <input id="posEditFilled" type="number" step="any" class="mono" />
+        </label>
+        <label>Preço médio geral
+          <input id="posEditAvg" type="number" step="any" class="mono" />
+        </label>
+        <label>Arb média (%)
+          <input id="posEditArb" type="number" step="any" class="mono" />
+        </label>
+        <label>PnL acumulado (USDT)
+          <input id="posEditPnl" type="number" step="any" class="mono" />
+        </label>
+      </div>
+      <div>
+        <div class="muted" style="margin-bottom:4px;"><strong>Gate</strong></div>
+        <label>Preenchido
+          <input id="posEditGateFilled" type="number" step="any" class="mono" />
+        </label>
+        <label>Preço médio
+          <input id="posEditGateAvg" type="number" step="any" class="mono" />
+        </label>
+      </div>
+      <div>
+        <div class="muted" style="margin-bottom:4px;"><strong>MEXC</strong></div>
+        <label>Preenchido
+          <input id="posEditMexcFilled" type="number" step="any" class="mono" />
+        </label>
+        <label>Preço médio
+          <input id="posEditMexcAvg" type="number" step="any" class="mono" />
+        </label>
+        <label>Position ID
+          <input id="posEditMexcId" type="text" class="mono" />
+        </label>
+      </div>
+    </div>
+    <div class="position-edit-actions">
+      <textarea id="positionNote" placeholder="Anotação (opcional, usada ao desmontar)"></textarea>
+      <div class="position-edit-buttons">
+        <button id="positionSaveBtn">Salvar posição</button>
+        <button id="positionDismantleBtn">Desmontar posição</button>
+      </div>
+    </div>
+    <div class="position-summaries">
+      <h4>Resumos recentes</h4>
+      <table>
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Data</th>
+            <th>Meta</th>
+            <th>Gate</th>
+            <th>MEXC</th>
+            <th>Preenchido</th>
+            <th>Arb (%)</th>
+            <th>PnL</th>
+            <th>Nota</th>
+          </tr>
+        </thead>
+        <tbody id="positionSummariesBody"></tbody>
+      </table>
     </div>
   </div>
 

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -587,10 +587,112 @@ async function refreshHistory() {
 }
 setInterval(refreshHistory, 5000); refreshHistory();
 
+function setInputValueIfIdle(id, value) {
+  const el = document.getElementById(id);
+  if (!el || document.activeElement === el) return;
+  if (value === null || value === undefined || value === '') {
+    el.value = '';
+  } else if (typeof value === 'number' && Number.isFinite(value)) {
+    el.value = value;
+  } else {
+    el.value = String(value);
+  }
+}
+
+function readNumberInput(id) {
+  const el = document.getElementById(id);
+  if (!el) return 0;
+  const raw = el.value;
+  if (raw === '' || raw === null || raw === undefined) return 0;
+  const num = Number(raw);
+  return Number.isFinite(num) ? num : 0;
+}
+
+function readPositionIdInput(id) {
+  const el = document.getElementById(id);
+  if (!el) return null;
+  const raw = el.value.trim();
+  if (!raw) return null;
+  const num = Number(raw);
+  return Number.isFinite(num) ? num : raw;
+}
+
+function fillPositionForm(state) {
+  if (!state || typeof state !== 'object') return;
+  const g = state.gate || {};
+  const m = state.mexc || {};
+  setInputValueIfIdle('posEditTarget', state.targetQty ?? '');
+  setInputValueIfIdle('posEditFilled', state.filledQty ?? '');
+  setInputValueIfIdle('posEditAvg', state.avgPrice ?? '');
+  setInputValueIfIdle('posEditArb', state.arbPctAvg ?? '');
+  setInputValueIfIdle('posEditPnl', state.pnlUsd ?? '');
+  setInputValueIfIdle('posEditGateFilled', g.filledQty ?? '');
+  setInputValueIfIdle('posEditGateAvg', g.avgPrice ?? '');
+  setInputValueIfIdle('posEditMexcFilled', m.filledQty ?? '');
+  setInputValueIfIdle('posEditMexcAvg', m.avgPrice ?? '');
+  setInputValueIfIdle('posEditMexcId', m.positionId ?? '');
+}
+
+function collectPositionFormState() {
+  return {
+    targetQty: readNumberInput('posEditTarget'),
+    filledQty: readNumberInput('posEditFilled'),
+    avgPrice: readNumberInput('posEditAvg'),
+    arbPctAvg: readNumberInput('posEditArb'),
+    pnlUsd: readNumberInput('posEditPnl'),
+    gate: {
+      filledQty: readNumberInput('posEditGateFilled'),
+      avgPrice: readNumberInput('posEditGateAvg')
+    },
+    mexc: {
+      filledQty: readNumberInput('posEditMexcFilled'),
+      avgPrice: readNumberInput('posEditMexcAvg'),
+      positionId: readPositionIdInput('posEditMexcId')
+    }
+  };
+}
+
+function formatSummaryNumber(value, decimals) {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return '-';
+  if (typeof decimals === 'number') return num.toFixed(decimals);
+  return String(num);
+}
+
+function renderPositionSummaries(list) {
+  const tbody = document.getElementById('positionSummariesBody');
+  if (!tbody) return;
+  tbody.innerHTML = '';
+  (Array.isArray(list) ? list : []).forEach((item) => {
+    const state = item?.summary?.state || {};
+    const gate = state.gate || {};
+    const mexc = state.mexc || {};
+    const tr = document.createElement('tr');
+    const cells = [
+      item?.id ?? '-',
+      item?.createdAt ? new Date(item.createdAt).toLocaleString('pt-BR') : '-',
+      formatSummaryNumber(state.targetQty),
+      `${formatSummaryNumber(gate.filledQty)} @ ${formatSummaryNumber(gate.avgPrice)}`,
+      `${formatSummaryNumber(mexc.filledQty)} @ ${formatSummaryNumber(mexc.avgPrice)}`,
+      formatSummaryNumber(state.filledQty),
+      formatSummaryNumber(state.arbPctAvg, 6),
+      formatSummaryNumber(state.pnlUsd, 6),
+      item?.note || item?.summary?.note || '-'
+    ];
+    cells.forEach((text) => {
+      const td = document.createElement('td');
+      td.textContent = text;
+      tr.appendChild(td);
+    });
+    tbody.appendChild(tr);
+  });
+}
+
 async function refreshPosition() {
   try {
     const r = await fetch('/api/position-progress');
-    const s = await r.json();
+    const payload = await r.json();
+    const s = payload?.state || payload || {};
     const g = s.gate || {};
     const m = s.mexc || {};
     document.getElementById('ppTarget').textContent = s.targetQty || 0;
@@ -601,6 +703,8 @@ async function refreshPosition() {
     document.getElementById('ppArb').textContent = (s.arbPctAvg || 0).toFixed ? s.arbPctAvg.toFixed(6) : s.arbPctAvg;
     document.getElementById('ppPnl').textContent = (s.pnlUsd || 0).toFixed ? s.pnlUsd.toFixed(6) : s.pnlUsd;
     drawProgressChart(s.series || []);
+    fillPositionForm(s);
+    renderPositionSummaries(payload?.summaries || []);
   } catch {}
 }
 setInterval(refreshPosition, 4000); refreshPosition();
@@ -684,6 +788,58 @@ document.getElementById('setTarget').addEventListener('click', async () => {
     alert('Erro ao definir meta: ' + (e.message || e));
   }
 });
+
+const positionSaveBtn = document.getElementById('positionSaveBtn');
+if (positionSaveBtn) {
+  positionSaveBtn.addEventListener('click', async () => {
+    positionSaveBtn.disabled = true;
+    try {
+      const state = collectPositionFormState();
+      const resp = await fetch('/api/position-manual-update', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ state })
+      });
+      const out = await safeJson(resp);
+      if (!resp.ok || out.ok === false) {
+        alert('Falha ao salvar posição: ' + JSON.stringify(out));
+        return;
+      }
+      await refreshPosition();
+    } catch (e) {
+      alert('Erro ao salvar posição: ' + (e.message || e));
+    } finally {
+      positionSaveBtn.disabled = false;
+    }
+  });
+}
+
+const positionDismantleBtn = document.getElementById('positionDismantleBtn');
+if (positionDismantleBtn) {
+  positionDismantleBtn.addEventListener('click', async () => {
+    positionDismantleBtn.disabled = true;
+    try {
+      const noteEl = document.getElementById('positionNote');
+      const note = noteEl ? noteEl.value : '';
+      const resp = await fetch('/api/position-dismantle', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ note })
+      });
+      const out = await safeJson(resp);
+      if (!resp.ok || out.ok === false) {
+        alert('Falha ao desmontar posição: ' + JSON.stringify(out));
+        return;
+      }
+      if (noteEl) noteEl.value = '';
+      await refreshPosition();
+    } catch (e) {
+      alert('Erro ao desmontar posição: ' + (e.message || e));
+    } finally {
+      positionDismantleBtn.disabled = false;
+    }
+  });
+}
 
 // ======== Gráfico simples
 function drawProgressChart(series) {

--- a/server.js
+++ b/server.js
@@ -21,16 +21,131 @@ const autoMetaCache = new Map();
 const overridesBySymbol = new Map();
 
 let orderHistory = [];
-let positionState = {
-  targetQty: 0,
-  filledQty: 0,
-  avgPrice: 0,
-  arbPctAvg: 0,
-  pnlUsd: 0,
-  gate: { filledQty: 0, avgPrice: 0 },
-  mexc: { filledQty: 0, avgPrice: 0, positionId: null },
-  series: []
+
+const SERIES_LIMIT = 500;
+const POSITION_SUMMARY_LIMIT = 50;
+
+function createEmptyPositionState() {
+  return {
+    targetQty: 0,
+    filledQty: 0,
+    avgPrice: 0,
+    arbPctAvg: 0,
+    pnlUsd: 0,
+    gate: { filledQty: 0, avgPrice: 0 },
+    mexc: { filledQty: 0, avgPrice: 0, positionId: null },
+    series: []
+  };
+}
+
+const finiteOr = (value, fallback) => {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
 };
+
+const nullableFinite = (value) => {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+};
+
+function sanitizeSeries(series) {
+  if (!Array.isArray(series)) return [];
+  const cleaned = [];
+  for (const entry of series) {
+    if (!entry || typeof entry !== 'object') continue;
+    const out = {};
+    out.t = finiteOr(entry.t, Date.now());
+    if ('filledQty' in entry) out.filledQty = finiteOr(entry.filledQty, 0);
+    if ('avgPrice' in entry) out.avgPrice = finiteOr(entry.avgPrice, 0);
+    if ('arbPctAvg' in entry) out.arbPctAvg = finiteOr(entry.arbPctAvg, 0);
+    if ('pnlUsd' in entry) out.pnlUsd = finiteOr(entry.pnlUsd, 0);
+    if (entry.gate && typeof entry.gate === 'object') {
+      const g = {};
+      if ('filledQty' in entry.gate) g.filledQty = finiteOr(entry.gate.filledQty, 0);
+      if ('avgPrice' in entry.gate) g.avgPrice = finiteOr(entry.gate.avgPrice, 0);
+      if (Object.keys(g).length) out.gate = g;
+    }
+    if (entry.mexc && typeof entry.mexc === 'object') {
+      const m = {};
+      if ('filledQty' in entry.mexc) m.filledQty = finiteOr(entry.mexc.filledQty, 0);
+      if ('avgPrice' in entry.mexc) m.avgPrice = finiteOr(entry.mexc.avgPrice, 0);
+      if (Object.keys(m).length) out.mexc = m;
+    }
+    cleaned.push(out);
+  }
+  return cleaned.length > SERIES_LIMIT ? cleaned.slice(-SERIES_LIMIT) : cleaned;
+}
+
+function applyPositionStatePatch(base, patch) {
+  const out = {
+    ...base,
+    gate: { ...base.gate },
+    mexc: { ...base.mexc },
+    series: Array.isArray(base.series) ? [...base.series] : []
+  };
+
+  if (patch && typeof patch === 'object') {
+    if ('targetQty' in patch) out.targetQty = finiteOr(patch.targetQty, out.targetQty);
+    if ('filledQty' in patch) out.filledQty = finiteOr(patch.filledQty, out.filledQty);
+    if ('avgPrice' in patch) out.avgPrice = finiteOr(patch.avgPrice, out.avgPrice);
+    if ('arbPctAvg' in patch) out.arbPctAvg = finiteOr(patch.arbPctAvg, out.arbPctAvg);
+    if ('pnlUsd' in patch) out.pnlUsd = finiteOr(patch.pnlUsd, out.pnlUsd);
+
+    if (patch.gate && typeof patch.gate === 'object') {
+      if ('filledQty' in patch.gate) out.gate.filledQty = finiteOr(patch.gate.filledQty, out.gate.filledQty);
+      if ('avgPrice' in patch.gate) out.gate.avgPrice = finiteOr(patch.gate.avgPrice, out.gate.avgPrice);
+      for (const key of Object.keys(patch.gate)) {
+        if (!['filledQty', 'avgPrice'].includes(key)) out.gate[key] = patch.gate[key];
+      }
+    }
+
+    if (patch.mexc && typeof patch.mexc === 'object') {
+      if ('filledQty' in patch.mexc) out.mexc.filledQty = finiteOr(patch.mexc.filledQty, out.mexc.filledQty);
+      if ('avgPrice' in patch.mexc) out.mexc.avgPrice = finiteOr(patch.mexc.avgPrice, out.mexc.avgPrice);
+      if ('positionId' in patch.mexc) {
+        const pid = patch.mexc.positionId;
+        if (pid === null || pid === '' || pid === undefined) {
+          out.mexc.positionId = null;
+        } else {
+          const nPid = nullableFinite(pid);
+          out.mexc.positionId = nPid != null ? nPid : pid;
+        }
+      }
+      for (const key of Object.keys(patch.mexc)) {
+        if (!['filledQty', 'avgPrice', 'positionId'].includes(key)) out.mexc[key] = patch.mexc[key];
+      }
+    }
+
+    if ('series' in patch) {
+      if (Array.isArray(patch.series)) out.series = sanitizeSeries(patch.series);
+      else if (patch.series === null) out.series = [];
+    }
+
+    for (const key of Object.keys(patch)) {
+      if (!['targetQty','filledQty','avgPrice','arbPctAvg','pnlUsd','gate','mexc','series'].includes(key)) {
+        out[key] = patch[key];
+      }
+    }
+  }
+
+  return out;
+}
+
+function clonePositionState(src) {
+  return applyPositionStatePatch(createEmptyPositionState(), src || {});
+}
+
+let positionState = createEmptyPositionState();
+let positionSummaries = [];
+
+function persistPositionState(context = 'unknown') {
+  try {
+    positionState.series = sanitizeSeries(positionState.series);
+    db.savePositionState(positionState);
+  } catch (e) {
+    console.warn(`[SQLite] Falha ao salvar posição (${context}):`, e?.message || e);
+  }
+}
 
 app.use(express.static(path.join(__dirname, 'public')));
 app.use(express.json());
@@ -44,6 +159,22 @@ try {
 } catch (e) {
   console.warn('[SQLite] Falha ao carregar estado:', e?.message || e);
 }
+
+try {
+  const savedPos = db.loadPositionState();
+  if (savedPos) positionState = clonePositionState(savedPos);
+} catch (e) {
+  console.warn('[SQLite] Falha ao carregar posição:', e?.message || e);
+}
+
+try {
+  positionSummaries = db.loadPositionSummaries(POSITION_SUMMARY_LIMIT);
+} catch (e) {
+  positionSummaries = [];
+  console.warn('[SQLite] Falha ao carregar resumos de posição:', e?.message || e);
+}
+
+console.log(`[SQLite] Estado da posição carregado: filled=${positionState.filledQty}, gate=${positionState.gate?.filledQty ?? 0}, mexc=${positionState.mexc?.filledQty ?? 0}. Resumos: ${positionSummaries.length}.`);
 
 // ===== Utils
 const nowBR = () => new Date().toLocaleString('pt-BR');
@@ -722,9 +853,60 @@ app.post('/api/position-target', (req, res) => {
   const t = Number(req.body?.targetQty);
   if (!Number.isFinite(t) || t < 0) return res.status(400).json({ error: 'targetQty inválido' });
   positionState.targetQty = t;
+  persistPositionState('set-target');
   res.json({ ok: true, targetQty: t });
 });
-app.get('/api/position-progress', (_req, res) => res.json(positionState));
+app.get('/api/position-progress', (_req, res) => {
+  res.json({ ok: true, state: positionState, summaries: positionSummaries });
+});
+
+app.post('/api/position-manual-update', (req, res) => {
+  try {
+    const payload = req.body?.state;
+    if (!payload || typeof payload !== 'object') {
+      return res.status(400).json({ ok: false, error: 'invalid_state' });
+    }
+    const next = applyPositionStatePatch(positionState, payload);
+    next.series = sanitizeSeries(next.series);
+    positionState = next;
+    persistPositionState('manual-update');
+    res.json({ ok: true, state: positionState, summaries: positionSummaries });
+  } catch (e) {
+    console.error('[API] position-manual-update:', e?.message || e);
+    res.status(500).json({ ok: false, error: 'internal_error' });
+  }
+});
+
+app.post('/api/position-dismantle', (req, res) => {
+  try {
+    const noteRaw = req.body?.note;
+    const note = typeof noteRaw === 'string' ? noteRaw.trim() : '';
+    const snapshot = clonePositionState(positionState);
+    snapshot.series = sanitizeSeries(snapshot.series);
+    const summaryPayload = {
+      note: note || undefined,
+      state: snapshot
+    };
+    const info = db.savePositionSummary(summaryPayload);
+    const createdAt = info?.createdAt || new Date().toISOString();
+    const entry = {
+      id: info?.id || Date.now(),
+      createdAt,
+      note: note || null,
+      summary: { ...summaryPayload, createdAt }
+    };
+    positionSummaries.unshift(entry);
+    if (positionSummaries.length > POSITION_SUMMARY_LIMIT) {
+      positionSummaries = positionSummaries.slice(0, POSITION_SUMMARY_LIMIT);
+    }
+    positionState = createEmptyPositionState();
+    persistPositionState('dismantle-reset');
+    res.json({ ok: true, state: positionState, summaries: positionSummaries });
+  } catch (e) {
+    console.error('[API] position-dismantle:', e?.message || e);
+    res.status(500).json({ ok: false, error: 'internal_error' });
+  }
+});
 
 function updatePositionFromOrder(item, gFilled, gAvg, mFilled, mAvg) {
   const meta = item?.metaUsed || {};
@@ -790,6 +972,8 @@ function updatePositionFromOrder(item, gFilled, gAvg, mFilled, mAvg) {
     gate: { filledQty: gNewQty, avgPrice: Number(gNewAvg.toFixed(11)) },
     mexc: { filledQty: mNewQty, avgPrice: Number(mNewAvg.toFixed(11)) }
   });
+  positionState.series = sanitizeSeries(positionState.series);
+  persistPositionState('update-position');
 }
 
 // ===== Precheck (respeita modo open/close do front)
@@ -1256,7 +1440,10 @@ app.post('/api/cancel-order', async (req, res) => {
         await mexcCancelOrder(symbol, String(item.mexcOrderId));
         const md = await getMexcOrderDetail(symbol, String(item.mexcOrderId));
         const p = parseMexcOrderDetail(md);
-        if (p.positionId) positionState.mexc.positionId = p.positionId;
+        if (p.positionId && positionState.mexc.positionId !== p.positionId) {
+          positionState.mexc.positionId = p.positionId;
+          persistPositionState('cancel-mexc-position-id');
+        }
         mFilled = Number(p.filled || 0);
         mAvg = Number(p.avgPrice || item.priceUsedMexc);
       }
@@ -1400,7 +1587,10 @@ async function pollOpenOrders() {
         console.log('MEXC detail', md);
         const p = parseMexcOrderDetail(md);
         console.log('parsed detail', p);
-        if (p.positionId) positionState.mexc.positionId = p.positionId;
+        if (p.positionId && positionState.mexc.positionId !== p.positionId) {
+          positionState.mexc.positionId = p.positionId;
+          persistPositionState('poll-mexc-position-id');
+        }
         mFilled = Number(p.filled || 0);
         mAvg = Number(p.avgPrice || mAvg);
         mIsFilled = !!p.isFilled;


### PR DESCRIPTION
## Summary
- add SQLite tables and helpers to store the current position snapshot and dismantle summaries
- load, persist, and expose the position state through new manual update and dismantle endpoints while logging summaries on reset
- extend the UI with an editable position card, summary table, and JavaScript handlers to edit, save, and dismantle positions

## Testing
- `node server.js`
- `curl -s http://localhost:3000/api/position-progress | jq '.state'`
- `curl -s -X POST http://localhost:3000/api/position-dismantle -H 'Content-Type: application/json' -d '{"note":"teste desmontar"}' | jq`


------
https://chatgpt.com/codex/tasks/task_e_68d711ad7b60832f83e5241bc3b46253