### PR TITLE
Ensure position summaries note migration runs before prepared statements

### DIFF
--- a/db.js
+++ b/db.js
@@ -48,6 +48,7 @@ CREATE TABLE IF NOT EXISTS position_summaries (
 try { db.exec('ALTER TABLE history ADD COLUMN gate_status TEXT'); } catch {}
 try { db.exec('ALTER TABLE history ADD COLUMN mexc_status TEXT'); } catch {}
 try { db.exec('ALTER TABLE history ADD COLUMN sentido TEXT'); } catch {}
+try { db.exec('ALTER TABLE position_summaries ADD COLUMN note TEXT'); } catch {}
 
 const upsertOverrideStmt = db.prepare(`
 INSERT INTO overrides(symbol, override_json, updated_at)


### PR DESCRIPTION
## Summary
- add a guarded migration to add the note column to position_summaries before preparing statements

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d717f64c5c832f90f2c0f3c22a9568