### PR TITLE
Add configurable Telegram alert template and volume guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ module.exports = {
    ```
 
 5. Reinicie o servidor. No painel web, marque a opção **Telegram** ao lado do alerta de diferença para ativar o envio das mensagens.
+   - Use as opções logo abaixo para personalizar o conteúdo do alerta (incluir nome do ativo, diferença percentual e volumes por nível)
+     e, se desejar, restringir o disparo apenas quando os volumes em USDT atenderem aos mínimos exigidos pelas corretoras.
 
 ## Execução
 Inicie o servidor com:

--- a/public/index.html
+++ b/public/index.html
@@ -157,6 +157,12 @@
           <label><input type="checkbox" id="soundToggle" /> Som</label>
           <label><input type="checkbox" id="telegramToggle" /> Telegram</label>
         </div>
+        <div class="quote-control-row telegram-template-row">
+          <label><input type="checkbox" id="telegramVolumeGuard" /> Somente se volume ≥ mínimos</label>
+          <label><input type="checkbox" id="telegramIncludeSymbol" checked /> Nome do ativo</label>
+          <label><input type="checkbox" id="telegramIncludeDiff" checked /> Diferença (%)</label>
+          <label><input type="checkbox" id="telegramIncludeVolumes" /> Volumes (3 níveis)</label>
+        </div>
         <div class="quote-actions">
           <button id="executeTrade">Executar Ordem Simultânea</button>
         </div>

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -121,6 +121,7 @@ async function refreshMetaUI(symbol) {
     metaToText('Auto', d.auto) + '\n\n' +
     'Override: ' + (d.override ? JSON.stringify(d.override) : '(nenhum)') + '\n\n' +
     metaToText('Usado', d.merged);
+  currentMeta = d.merged || null;
   fillOverridesUI(d.merged);
 }
 
@@ -217,6 +218,7 @@ document.getElementById('modeClose')?.addEventListener('change', () => {
 });
 
 let lastQuotes = null;
+let currentMeta = null;
 const levelSelections = {
   open: new Set(loadLevelSelection('open')),
   close: new Set(loadLevelSelection('close'))
@@ -225,6 +227,15 @@ let alertMin = parseFloat(localStorage.getItem('alertMin'));
 let alertMax = parseFloat(localStorage.getItem('alertMax'));
 let soundEnabled = localStorage.getItem('soundOn') === '1';
 let telegramEnabled = localStorage.getItem('tgOn') === '1';
+const loadFlag = (key, defaultValue) => {
+  const raw = localStorage.getItem(key);
+  if (raw === null || raw === undefined) return defaultValue;
+  return raw === '1';
+};
+let telegramVolumeGuard = loadFlag('tgVolumeGuard', false);
+let telegramIncludeSymbol = loadFlag('tgIncludeSymbol', true);
+let telegramIncludeDiff = loadFlag('tgIncludeDiff', true);
+let telegramIncludeVolumes = loadFlag('tgIncludeVolumes', false);
 let audioCtx = null, lastBeep = 0, lastTgSent = 0;
 
 if (Number.isFinite(alertMin)) {
@@ -239,6 +250,14 @@ const soundToggleEl = document.getElementById('soundToggle');
 if (soundToggleEl) soundToggleEl.checked = soundEnabled;
 const telegramToggleEl = document.getElementById('telegramToggle');
 if (telegramToggleEl) telegramToggleEl.checked = telegramEnabled;
+const telegramVolumeGuardEl = document.getElementById('telegramVolumeGuard');
+if (telegramVolumeGuardEl) telegramVolumeGuardEl.checked = telegramVolumeGuard;
+const telegramIncludeSymbolEl = document.getElementById('telegramIncludeSymbol');
+if (telegramIncludeSymbolEl) telegramIncludeSymbolEl.checked = telegramIncludeSymbol;
+const telegramIncludeDiffEl = document.getElementById('telegramIncludeDiff');
+if (telegramIncludeDiffEl) telegramIncludeDiffEl.checked = telegramIncludeDiff;
+const telegramIncludeVolumesEl = document.getElementById('telegramIncludeVolumes');
+if (telegramIncludeVolumesEl) telegramIncludeVolumesEl.checked = telegramIncludeVolumes;
 
 function playBeep() {
   try {
@@ -256,14 +275,90 @@ function playBeep() {
 
 async function notifyTelegram(diff) {
   if (!telegramEnabled) return;
+  if (!lastQuotes) return;
   const now = Date.now();
   if (now - lastTgSent < 10000) return; // evita spam
+  const mode = getMode();
+  const stats = computeSelectionStats(mode);
+  const selectedLevels = Array.from(levelSelections[mode]).sort((a, b) => a - b);
+  const levelsRaw = mode === 'close'
+    ? (lastQuotes?.close?.levels || [])
+    : (lastQuotes?.open?.levels || []);
+  const levelEntries = Array.isArray(levelsRaw) ? levelsRaw.slice(0, 3) : [];
+  const baseSymbol = lastQuotes?.baseSymbol || (lastQuotes?.symbol ? String(lastQuotes.symbol).split('_')[0] : 'BASE');
+  const symbol = lastQuotes?.symbol || null;
+
+  if (telegramVolumeGuard) {
+    if (!currentMeta) return;
+    const gateMinQuote = Number(currentMeta?.gate?.minQuote || 0);
+    const gateQuote = Number.isFinite(stats.gateQuote) ? stats.gateQuote : 0;
+    if (gateMinQuote > 0 && gateQuote < gateMinQuote) return;
+
+    const minContracts = Number(currentMeta?.mexc?.minContracts || 0);
+    const contractSize = Number(currentMeta?.mexc?.contractSize || 1);
+    const mexcMinBase = minContracts * contractSize;
+    const mexcQuote = Number.isFinite(stats.mexcQuote) ? stats.mexcQuote : 0;
+    const mexcAvg = Number.isFinite(stats.mexcAvg) ? stats.mexcAvg : 0;
+    if (mexcMinBase > 0) {
+      const requiredQuote = mexcAvg > 0 ? mexcMinBase * mexcAvg : Infinity;
+      if (!Number.isFinite(requiredQuote) || mexcQuote < requiredQuote) return;
+    }
+  }
+
   lastTgSent = now;
+  const sanitizeLevel = (entry) => {
+    const level = Number(entry?.level);
+    const gatePrice = Number(entry?.gate?.price);
+    const gateBase = Number(entry?.gate?.baseVolume);
+    const gateQuote = Number(entry?.gate?.usdtVolume);
+    const mexcPrice = Number(entry?.mexc?.price);
+    const mexcBase = Number(entry?.mexc?.baseVolume);
+    const mexcQuote = Number(entry?.mexc?.usdtVolume);
+    return {
+      level: Number.isInteger(level) ? level : undefined,
+      gate: {
+        price: Number.isFinite(gatePrice) ? gatePrice : null,
+        baseVolume: Number.isFinite(gateBase) ? gateBase : null,
+        usdtVolume: Number.isFinite(gateQuote) ? gateQuote : null
+      },
+      mexc: {
+        price: Number.isFinite(mexcPrice) ? mexcPrice : null,
+        baseVolume: Number.isFinite(mexcBase) ? mexcBase : null,
+        usdtVolume: Number.isFinite(mexcQuote) ? mexcQuote : null
+      }
+    };
+  };
+
+  const payload = {
+    symbol,
+    baseSymbol,
+    mode,
+    diff,
+    options: {
+      includeSymbol: telegramIncludeSymbol,
+      includeDiff: telegramIncludeDiff,
+      includeVolumes: telegramIncludeVolumes,
+      requireMinVolume: telegramVolumeGuard
+    },
+    active: {
+      selectedLevels,
+      stats: {
+        gateBase: Number.isFinite(stats.gateBase) ? stats.gateBase : 0,
+        gateQuote: Number.isFinite(stats.gateQuote) ? stats.gateQuote : 0,
+        mexcBase: Number.isFinite(stats.mexcBase) ? stats.mexcBase : 0,
+        mexcQuote: Number.isFinite(stats.mexcQuote) ? stats.mexcQuote : 0,
+        gateAvg: Number.isFinite(stats.gateAvg) ? stats.gateAvg : null,
+        mexcAvg: Number.isFinite(stats.mexcAvg) ? stats.mexcAvg : null,
+        diffPct: Number.isFinite(stats.diffPct) ? stats.diffPct : null
+      },
+      levels: levelEntries.map(sanitizeLevel)
+    }
+  };
   try {
     await fetch('/api/notify-telegram', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ diff })
+      body: JSON.stringify(payload)
     });
   } catch {}
 }
@@ -295,6 +390,22 @@ document.getElementById('soundToggle').addEventListener('change', e => {
 document.getElementById('telegramToggle').addEventListener('change', e => {
   telegramEnabled = e.target.checked;
   localStorage.setItem('tgOn', telegramEnabled ? '1' : '0');
+});
+telegramVolumeGuardEl?.addEventListener('change', e => {
+  telegramVolumeGuard = e.target.checked;
+  localStorage.setItem('tgVolumeGuard', telegramVolumeGuard ? '1' : '0');
+});
+telegramIncludeSymbolEl?.addEventListener('change', e => {
+  telegramIncludeSymbol = e.target.checked;
+  localStorage.setItem('tgIncludeSymbol', telegramIncludeSymbol ? '1' : '0');
+});
+telegramIncludeDiffEl?.addEventListener('change', e => {
+  telegramIncludeDiff = e.target.checked;
+  localStorage.setItem('tgIncludeDiff', telegramIncludeDiff ? '1' : '0');
+});
+telegramIncludeVolumesEl?.addEventListener('change', e => {
+  telegramIncludeVolumes = e.target.checked;
+  localStorage.setItem('tgIncludeVolumes', telegramIncludeVolumes ? '1' : '0');
 });
 
 function persistSelections() {

--- a/server.js
+++ b/server.js
@@ -901,18 +901,171 @@ app.get('/api/balances', async (_req, res) => {
   res.json({ gate, mexc });
 });
 
+function sanitizeTelegramLevels(levels) {
+  const map = new Map();
+  if (!Array.isArray(levels)) return map;
+  for (const entry of levels) {
+    if (!entry || typeof entry !== 'object') continue;
+    const idx = Number(entry.level);
+    if (!Number.isInteger(idx) || idx < 0) continue;
+    const gate = entry.gate || {};
+    const mexc = entry.mexc || {};
+    const gatePrice = Number(gate.price);
+    const gateBase = Number(gate.baseVolume);
+    const gateQuote = Number(gate.usdtVolume);
+    const mexcPrice = Number(mexc.price);
+    const mexcBase = Number(mexc.baseVolume);
+    const mexcQuote = Number(mexc.usdtVolume);
+    map.set(idx, {
+      level: idx,
+      gate: {
+        price: Number.isFinite(gatePrice) ? gatePrice : null,
+        baseVolume: Number.isFinite(gateBase) ? gateBase : null,
+        usdtVolume: Number.isFinite(gateQuote) ? gateQuote : null
+      },
+      mexc: {
+        price: Number.isFinite(mexcPrice) ? mexcPrice : null,
+        baseVolume: Number.isFinite(mexcBase) ? mexcBase : null,
+        usdtVolume: Number.isFinite(mexcQuote) ? mexcQuote : null
+      }
+    });
+  }
+  return map;
+}
+
+function computeTelegramStats(levelMap, selectedLevels) {
+  const result = {
+    gateBase: 0,
+    gateQuote: 0,
+    mexcBase: 0,
+    mexcQuote: 0,
+    gateAvg: null,
+    mexcAvg: null,
+    diffPct: null
+  };
+
+  const sanitizedSelected = Array.isArray(selectedLevels)
+    ? Array.from(new Set(selectedLevels.map(n => Number(n)).filter(n => Number.isInteger(n) && n >= 0)))
+    : [];
+
+  let indices = sanitizedSelected;
+  if (!indices.length) {
+    if (levelMap.has(0)) indices = [0];
+    else indices = Array.from(levelMap.keys()).sort((a, b) => a - b).slice(0, 1);
+  }
+
+  for (const idx of indices) {
+    const level = levelMap.get(idx);
+    if (!level) continue;
+    const gBase = Number(level.gate?.baseVolume);
+    const gQuote = Number(level.gate?.usdtVolume);
+    const mBase = Number(level.mexc?.baseVolume);
+    const mQuote = Number(level.mexc?.usdtVolume);
+    if (Number.isFinite(gBase) && gBase > 0) result.gateBase += gBase;
+    if (Number.isFinite(gQuote) && gQuote > 0) result.gateQuote += gQuote;
+    if (Number.isFinite(mBase) && mBase > 0) result.mexcBase += mBase;
+    if (Number.isFinite(mQuote) && mQuote > 0) result.mexcQuote += mQuote;
+  }
+
+  if (result.gateBase > 0 && result.gateQuote > 0) {
+    result.gateAvg = result.gateQuote / result.gateBase;
+  }
+  if (result.mexcBase > 0 && result.mexcQuote > 0) {
+    result.mexcAvg = result.mexcQuote / result.mexcBase;
+  }
+  if (Number.isFinite(result.gateAvg) && result.gateAvg > 0 && Number.isFinite(result.mexcAvg)) {
+    result.diffPct = ((result.mexcAvg - result.gateAvg) / result.gateAvg) * 100;
+  }
+
+  return result;
+}
+
+function formatTelegramVolumeLines(levelMap) {
+  const entries = Array.from(levelMap.values()).filter(Boolean).sort((a, b) => {
+    const la = Number.isInteger(a.level) ? a.level : Number.MAX_SAFE_INTEGER;
+    const lb = Number.isInteger(b.level) ? b.level : Number.MAX_SAFE_INTEGER;
+    return la - lb;
+  }).slice(0, 3);
+
+  const fmt = (value) => {
+    if (value == null) return '—';
+    const num = Number(value);
+    return Number.isFinite(num)
+      ? num.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 2 })
+      : '—';
+  };
+
+  return entries.map(entry => {
+    const lvl = Number.isInteger(entry.level) ? entry.level + 1 : '?';
+    const gateText = fmt(entry.gate?.usdtVolume);
+    const mexcText = fmt(entry.mexc?.usdtVolume);
+    return `Nível ${lvl}: Gate ${gateText} USDT | MEXC ${mexcText} USDT`;
+  });
+}
+
 // ===== Notificação via Telegram
 app.post('/api/notify-telegram', async (req, res) => {
-  const diff = req.body?.diff;
   if (!config.telegram?.botToken || !config.telegram?.chatId) {
     return res.status(500).json({ error: 'Telegram não configurado' });
   }
   try {
+    const payload = req.body || {};
+    const symbolRaw = typeof payload.symbol === 'string' ? payload.symbol.trim() : '';
+    const symbol = symbolRaw ? symbolRaw.toUpperCase() : currentSymbol;
+    const options = payload.options || {};
+    const includeSymbol = options.includeSymbol !== false;
+    const includeDiff = options.includeDiff !== false;
+    const includeVolumes = !!options.includeVolumes;
+    const requireMinVolume = !!options.requireMinVolume;
+
+    const levelMap = sanitizeTelegramLevels(payload.active?.levels);
+    const stats = computeTelegramStats(levelMap, payload.active?.selectedLevels);
+
+    const meta = await getMergedMeta(symbol || currentSymbol);
+    if (requireMinVolume) {
+      const gateMinQuote = Number(meta?.gate?.minQuote || 0);
+      if (gateMinQuote > 0 && stats.gateQuote < gateMinQuote) {
+        return res.json({ ok: true, skipped: true, reason: 'gate_min_quote' });
+      }
+
+      const minContracts = Number(meta?.mexc?.minContracts || 0);
+      const contractSize = Number(meta?.mexc?.contractSize || 1);
+      const mexcMinBase = minContracts * contractSize;
+      if (mexcMinBase > 0) {
+        const mexcAvg = stats.mexcAvg;
+        if (!Number.isFinite(mexcAvg) || mexcAvg <= 0) {
+          return res.json({ ok: true, skipped: true, reason: 'mexc_avg_unavailable' });
+        }
+        const requiredQuote = mexcMinBase * mexcAvg;
+        if (!Number.isFinite(requiredQuote) || stats.mexcQuote < requiredQuote) {
+          return res.json({ ok: true, skipped: true, reason: 'mexc_min_quote' });
+        }
+      }
+    }
+
+    const lines = ['Alerta de arbitragem'];
+    if (includeSymbol && symbol) lines.push(`Ativo: ${symbol}`);
+    const diffRaw = Number(payload.diff);
+    const diffVal = Number.isFinite(diffRaw) ? diffRaw : (Number.isFinite(stats.diffPct) ? stats.diffPct : null);
+    if (includeDiff && Number.isFinite(diffVal)) {
+      const diffText = Number(diffVal).toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 3 });
+      lines.push(`Diferença: ${diffText}%`);
+    }
+    if (includeVolumes) {
+      const volumes = formatTelegramVolumeLines(levelMap);
+      if (volumes.length) {
+        lines.push('Volumes (USDT):');
+        lines.push(...volumes);
+      }
+    }
+
+    const message = lines.join('\n');
+
     await axios.post(`https://api.telegram.org/bot${config.telegram.botToken}/sendMessage`, {
       chat_id: config.telegram.chatId,
-      text: `Alerta de arbitragem: ${diff}%`
+      text: message
     });
-    res.json({ ok: true });
+    res.json({ ok: true, sent: true });
   } catch (e) {
     console.error('[Telegram] falha ao enviar:', e.response?.data || e.message || e);
     res.status(500).json({ error: 'Falha ao enviar' });


### PR DESCRIPTION
## Summary
- add frontend toggles so Telegram alerts can include symbol, percent diff, level volumes and enforce minimum volume guard
- update client notification payload to carry level data, apply local volume validation and persist meta information
- enhance server Telegram endpoint to validate minimum volumes, format the message per user options, and document the new behavior in the README

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d84115e4f8832fbf74450c942d8376