### PR TITLE
Add spread tracking charts and controls

### DIFF
--- a/db.js
+++ b/db.js
@@ -42,6 +42,14 @@ CREATE TABLE IF NOT EXISTS position_summaries (
   note TEXT,
   summary_json TEXT NOT NULL
 );
+CREATE TABLE IF NOT EXISTS spread_snapshots (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  symbol TEXT NOT NULL,
+  ts INTEGER NOT NULL,
+  open_spread REAL,
+  close_spread REAL
+);
+CREATE INDEX IF NOT EXISTS idx_spread_symbol_ts ON spread_snapshots(symbol, ts);
 `);
 
 // Migração simples: garante colunas gate_status e mexc_status
@@ -187,6 +195,54 @@ function loadPositionSummaries(limit = 20) {
   });
 }
 
+const insertSpreadSnapshotStmt = db.prepare(`
+INSERT INTO spread_snapshots(symbol, ts, open_spread, close_spread)
+VALUES (@symbol, @ts, @open, @close)
+`);
+
+const pruneSpreadSnapshotsStmt = db.prepare(`
+DELETE FROM spread_snapshots
+WHERE symbol = @symbol AND ts < @cutoff
+`);
+
+const loadSpreadSnapshotsStmt = db.prepare(`
+SELECT ts, open_spread AS open, close_spread AS close
+FROM spread_snapshots
+WHERE symbol = @symbol AND ts >= @since
+ORDER BY ts ASC
+`);
+
+const clearSpreadSnapshotsStmt = db.prepare(`
+DELETE FROM spread_snapshots WHERE symbol = @symbol
+`);
+
+function saveSpreadSnapshot(symbol, ts, openSpread, closeSpread) {
+  if (!symbol) return;
+  const payload = {
+    symbol: String(symbol).toUpperCase(),
+    ts: Number.isFinite(ts) ? Math.trunc(ts) : Date.now(),
+    open: Number.isFinite(openSpread) ? openSpread : null,
+    close: Number.isFinite(closeSpread) ? closeSpread : null
+  };
+  insertSpreadSnapshotStmt.run(payload);
+}
+
+function pruneSpreadSnapshots(symbol, cutoffTs) {
+  if (!symbol || !Number.isFinite(cutoffTs)) return;
+  pruneSpreadSnapshotsStmt.run({ symbol: String(symbol).toUpperCase(), cutoff: Math.trunc(cutoffTs) });
+}
+
+function loadSpreadSnapshots(symbol, sinceTs) {
+  if (!symbol) return [];
+  const since = Number.isFinite(sinceTs) ? Math.trunc(sinceTs) : 0;
+  return loadSpreadSnapshotsStmt.all({ symbol: String(symbol).toUpperCase(), since });
+}
+
+function clearSpreadSnapshots(symbol) {
+  if (!symbol) return;
+  clearSpreadSnapshotsStmt.run({ symbol: String(symbol).toUpperCase() });
+}
+
 module.exports = {
   DB_PATH,
   upsertOverride,
@@ -196,5 +252,9 @@ module.exports = {
   savePositionState,
   loadPositionState,
   savePositionSummary,
-  loadPositionSummaries
+  loadPositionSummaries,
+  saveSpreadSnapshot,
+  loadSpreadSnapshots,
+  pruneSpreadSnapshots,
+  clearSpreadSnapshots
 };

--- a/public/index.html
+++ b/public/index.html
@@ -52,6 +52,8 @@
     .spread-controls button.active { background:#0066cc; color:#fff; }
     .spread-stats { display:grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap:8px; font-size:13px; margin-top:10px; }
     .spread-stats span.label { display:block; color:#555; font-size:12px; text-transform:uppercase; letter-spacing:0.04em; }
+    .spread-chart-wrapper { position: relative; width: 100%; max-width: 100%; height: 320px; }
+    .spread-chart-wrapper canvas { width: 100% !important; height: 100% !important; display: block; }
   </style>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.4/dist/chart.umd.min.js"></script>
 </head>
@@ -332,7 +334,9 @@
         <button data-spread-filter="cross">Cruzamentos</button>
         <button id="clearSpreadData" style="margin-left:auto;">Limpar dados do ativo</button>
       </div>
-      <canvas id="spreadChart" height="240"></canvas>
+      <div class="spread-chart-wrapper">
+        <canvas id="spreadChart"></canvas>
+      </div>
       <div class="spread-stats" style="margin-top:12px;">
         <div>
           <span class="label">Abertura máx</span>

--- a/public/index.html
+++ b/public/index.html
@@ -9,7 +9,7 @@
     h1 { margin: 0 0 16px 0; font-size: 22px; }
     .row { display: flex; gap: 16px; flex-wrap: wrap; }
     .card { border: 1px solid #ddd; border-radius: 6px; padding: 14px; background: #fff; }
-    .card h3 { margin: 0 0 10px 0; font-size: 18px; }
+    .card h3 { margin: 0 0 10px 0; font-size: 18px; display:flex; align-items:center; justify-content: space-between; gap:12px; }
     .w33 { flex: 1 1 360px; }
     label.inline { display: inline-block; margin-right: 8px; }
     input[type="text"], input[type="number"] { padding: 4px 6px; }
@@ -45,7 +45,15 @@
     .position-summaries table { font-size: 12px; }
     .position-summaries th { background: #fafafa; }
     .position-summaries td, .position-summaries th { text-align: left; }
+    .card.collapsed .card-body { display: none; }
+    .card-toggle { font-size: 12px; padding: 4px 8px; }
+    .spread-controls { display:flex; flex-wrap:wrap; gap:8px; margin-bottom:10px; align-items:center; }
+    .spread-controls button { padding:4px 8px; }
+    .spread-controls button.active { background:#0066cc; color:#fff; }
+    .spread-stats { display:grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap:8px; font-size:13px; margin-top:10px; }
+    .spread-stats span.label { display:block; color:#555; font-size:12px; text-transform:uppercase; letter-spacing:0.04em; }
   </style>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.4/dist/chart.umd.min.js"></script>
 </head>
 <body>
   <h1>Arbitragem Gate.io x MEXC — <span id="titleSymbol">BASE_USDT</span></h1>
@@ -308,6 +316,42 @@
       </thead>
       <tbody id="historyBody"></tbody>
     </table>
+  </div>
+
+  <div class="card" id="spreadCard">
+    <h3>
+      Gráfico de Spreads
+      <button id="toggleSpreadCard" class="card-toggle">Ocultar</button>
+    </h3>
+    <div class="card-body">
+      <div class="spread-controls">
+        <strong>Mostrar:</strong>
+        <button data-spread-filter="all" class="active">Todos</button>
+        <button data-spread-filter="open">Abertura</button>
+        <button data-spread-filter="close">Fechamento</button>
+        <button data-spread-filter="cross">Cruzamentos</button>
+        <button id="clearSpreadData" style="margin-left:auto;">Limpar dados do ativo</button>
+      </div>
+      <canvas id="spreadChart" height="240"></canvas>
+      <div class="spread-stats" style="margin-top:12px;">
+        <div>
+          <span class="label">Abertura máx</span>
+          <span id="spreadOpenMax">-</span>
+        </div>
+        <div>
+          <span class="label">Abertura mín</span>
+          <span id="spreadOpenMin">-</span>
+        </div>
+        <div>
+          <span class="label">Fechamento máx</span>
+          <span id="spreadCloseMax">-</span>
+        </div>
+        <div>
+          <span class="label">Fechamento mín</span>
+          <span id="spreadCloseMin">-</span>
+        </div>
+      </div>
+    </div>
   </div>
 
   <script src="scripts.js"></script>

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -132,6 +132,7 @@ document.getElementById('applySymbol').addEventListener('click', async () => {
   localStorage.setItem('lastSymbol', sym);
   document.getElementById('titleSymbol').textContent = sym;
   await refreshMetaUI(sym);
+  await fetchSpreadData(true);
 });
 
 document.getElementById('autoCfg').addEventListener('click', async () => {
@@ -237,6 +238,11 @@ let telegramIncludeSymbol = loadFlag('tgIncludeSymbol', true);
 let telegramIncludeDiff = loadFlag('tgIncludeDiff', true);
 let telegramIncludeVolumes = loadFlag('tgIncludeVolumes', false);
 let audioCtx = null, lastBeep = 0, lastTgSent = 0;
+
+let spreadChart = null;
+let spreadPoints = [];
+let spreadFilter = 'all';
+let lastSpreadFetch = 0;
 
 if (Number.isFinite(alertMin)) {
   const el = document.getElementById('alertMin');
@@ -580,6 +586,220 @@ function renderQuotes() {
   checkAlert(diffVal);
 }
 
+function ensureSpreadChart() {
+  if (spreadChart) return spreadChart;
+  if (typeof Chart === 'undefined') return null;
+  const canvas = document.getElementById('spreadChart');
+  if (!canvas) return null;
+  const ctx = canvas.getContext('2d');
+  spreadChart = new Chart(ctx, {
+    type: 'line',
+    data: {
+      datasets: [
+        {
+          id: 'open',
+          label: 'Abertura',
+          data: [],
+          borderColor: '#1f77b4',
+          backgroundColor: 'rgba(31,119,180,0.1)',
+          fill: false,
+          pointRadius: 0,
+          borderWidth: 2,
+          tension: 0.15,
+          spanGaps: true
+        },
+        {
+          id: 'close',
+          label: 'Fechamento',
+          data: [],
+          borderColor: '#ff7f0e',
+          backgroundColor: 'rgba(255,127,14,0.1)',
+          fill: false,
+          pointRadius: 0,
+          borderWidth: 2,
+          borderDash: [5, 4],
+          tension: 0.15,
+          spanGaps: true
+        },
+        {
+          id: 'cross',
+          label: 'Cruzamentos',
+          type: 'scatter',
+          data: [],
+          pointBackgroundColor: '#d62728',
+          pointBorderColor: '#d62728',
+          pointRadius: 5,
+          showLine: false
+        }
+      ]
+    },
+    options: {
+      animation: false,
+      responsive: true,
+      maintainAspectRatio: false,
+      interaction: { intersect: false, mode: 'nearest' },
+      scales: {
+        x: {
+          type: 'linear',
+          title: { display: true, text: 'Horário (24h)' },
+          ticks: {
+            callback: (value) => {
+              const date = new Date(Number(value));
+              if (!Number.isFinite(date.getTime())) return '';
+              return date.toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' });
+            },
+            maxRotation: 0
+          },
+          grid: { display: false }
+        },
+        y: {
+          title: { display: true, text: 'Diferença (%)' }
+        }
+      },
+      plugins: {
+        legend: { position: 'bottom' },
+        tooltip: {
+          callbacks: {
+            label: (ctx) => {
+              const prefix = ctx.dataset?.label ? `${ctx.dataset.label}: ` : '';
+              const value = Number(ctx.parsed.y);
+              const ts = Number(ctx.parsed.x);
+              const formatted = Number.isFinite(value) ? value.toFixed(4) + '%' : '-';
+              const time = Number.isFinite(ts)
+                ? new Date(ts).toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' })
+                : '';
+              return `${prefix}${formatted}${time ? ` às ${time}` : ''}`;
+            }
+          }
+        }
+      }
+    }
+  });
+  return spreadChart;
+}
+
+function computeSpreadCrossings(points) {
+  const out = [];
+  for (let i = 1; i < points.length; i++) {
+    const prev = points[i - 1];
+    const curr = points[i];
+    if (!prev || !curr) continue;
+    if (!Number.isFinite(prev.open) || !Number.isFinite(prev.close) || !Number.isFinite(curr.open) || !Number.isFinite(curr.close)) continue;
+    const prevDiff = prev.open - prev.close;
+    const currDiff = curr.open - curr.close;
+    if (!Number.isFinite(prevDiff) || !Number.isFinite(currDiff)) continue;
+    if (prevDiff === 0) {
+      out.push({ x: prev.ts, y: (prev.open + prev.close) / 2 });
+      continue;
+    }
+    if (currDiff === 0) {
+      out.push({ x: curr.ts, y: (curr.open + curr.close) / 2 });
+      continue;
+    }
+    if ((prevDiff > 0 && currDiff < 0) || (prevDiff < 0 && currDiff > 0)) {
+      const diffSpan = Math.abs(prevDiff) + Math.abs(currDiff);
+      if (diffSpan === 0) continue;
+      const ratio = Math.abs(prevDiff) / diffSpan;
+      const tsDelta = Number(curr.ts) - Number(prev.ts);
+      const crossTs = Number(prev.ts) + ratio * tsDelta;
+      const openVal = prev.open + (curr.open - prev.open) * ratio;
+      const closeVal = prev.close + (curr.close - prev.close) * ratio;
+      const y = (openVal + closeVal) / 2;
+      if (Number.isFinite(crossTs) && Number.isFinite(y)) out.push({ x: crossTs, y });
+    }
+  }
+  return out;
+}
+
+function applySpreadFilter(chart) {
+  chart.data.datasets.forEach((dataset) => {
+    if (!dataset?.id) return;
+    if (spreadFilter === 'all') {
+      dataset.hidden = false;
+    } else if (spreadFilter === 'open') {
+      dataset.hidden = dataset.id !== 'open';
+    } else if (spreadFilter === 'close') {
+      dataset.hidden = dataset.id !== 'close';
+    } else if (spreadFilter === 'cross') {
+      dataset.hidden = dataset.id !== 'cross';
+    }
+  });
+}
+
+function formatSpreadStat(entry) {
+  if (!entry || !Number.isFinite(entry.value)) return '-';
+  const value = `${entry.value.toFixed(4)}%`;
+  if (!Number.isFinite(entry.ts)) return value;
+  const time = new Date(entry.ts).toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' });
+  return `${value} às ${time}`;
+}
+
+function updateSpreadStats(extremes) {
+  const openMaxEl = document.getElementById('spreadOpenMax');
+  const openMinEl = document.getElementById('spreadOpenMin');
+  const closeMaxEl = document.getElementById('spreadCloseMax');
+  const closeMinEl = document.getElementById('spreadCloseMin');
+  const open = extremes?.open || {};
+  const close = extremes?.close || {};
+  if (openMaxEl) openMaxEl.textContent = formatSpreadStat(open.max);
+  if (openMinEl) openMinEl.textContent = formatSpreadStat(open.min);
+  if (closeMaxEl) closeMaxEl.textContent = formatSpreadStat(close.max);
+  if (closeMinEl) closeMinEl.textContent = formatSpreadStat(close.min);
+}
+
+function renderSpreadChart() {
+  const chart = ensureSpreadChart();
+  if (!chart) return;
+  const openData = [];
+  const closeData = [];
+  for (const entry of spreadPoints) {
+    if (Number.isFinite(entry.open)) openData.push({ x: entry.ts, y: entry.open });
+    if (Number.isFinite(entry.close)) closeData.push({ x: entry.ts, y: entry.close });
+  }
+  const crossData = computeSpreadCrossings(spreadPoints);
+  const datasetById = new Map(chart.data.datasets.map((d) => [d.id, d]));
+  if (datasetById.has('open')) datasetById.get('open').data = openData;
+  if (datasetById.has('close')) datasetById.get('close').data = closeData;
+  if (datasetById.has('cross')) datasetById.get('cross').data = crossData;
+  applySpreadFilter(chart);
+  chart.update('none');
+}
+
+async function fetchSpreadData(force = false) {
+  const now = Date.now();
+  if (!force && now - lastSpreadFetch < 10000) return;
+  lastSpreadFetch = now;
+  try {
+    const symbol = lastQuotes?.symbol;
+    const url = symbol ? `/api/spreads?symbol=${encodeURIComponent(symbol)}` : '/api/spreads';
+    const resp = await fetch(url);
+    const data = await safeJson(resp);
+    if (!resp.ok) throw new Error(data?.error || 'Falha ao carregar spreads.');
+    const pts = Array.isArray(data.points) ? data.points : [];
+    spreadPoints = pts.map((entry) => {
+      const ts = Number(entry.ts);
+      const openRaw = entry.open;
+      const closeRaw = entry.close;
+      const openNum = Number(openRaw);
+      const closeNum = Number(closeRaw);
+      return {
+        ts: Number.isFinite(ts) ? ts : Date.now(),
+        open: (openRaw === null || openRaw === undefined || !Number.isFinite(openNum)) ? null : openNum,
+        close: (closeRaw === null || closeRaw === undefined || !Number.isFinite(closeNum)) ? null : closeNum
+      };
+    });
+    updateSpreadStats(data.extremes || null);
+    renderSpreadChart();
+  } catch (e) {
+    console.warn('Falha ao carregar spreads:', e?.message || e);
+    if (force) {
+      spreadPoints = [];
+      updateSpreadStats(null);
+      renderSpreadChart();
+    }
+  }
+}
+
 async function fetchData() {
   try {
     const r = await fetch('/api/data');
@@ -587,9 +807,60 @@ async function fetchData() {
     lastQuotes = d;
     document.getElementById('titleSymbol').textContent = d.symbol || '-';
     renderQuotes();
+    fetchSpreadData();
   } catch {}
 }
 setInterval(fetchData, 1000);
+setInterval(() => fetchSpreadData(false), 15000);
+
+const spreadFilterButtons = document.querySelectorAll('[data-spread-filter]');
+spreadFilterButtons.forEach((btn) => {
+  btn.addEventListener('click', () => {
+    const filter = btn.dataset.spreadFilter || 'all';
+    spreadFilter = filter;
+    spreadFilterButtons.forEach((b) => b.classList.toggle('active', b === btn));
+    renderSpreadChart();
+  });
+});
+
+const toggleSpreadCardBtn = document.getElementById('toggleSpreadCard');
+if (toggleSpreadCardBtn) {
+  toggleSpreadCardBtn.addEventListener('click', () => {
+    const card = document.getElementById('spreadCard');
+    if (!card) return;
+    card.classList.toggle('collapsed');
+    const collapsed = card.classList.contains('collapsed');
+    toggleSpreadCardBtn.textContent = collapsed ? 'Mostrar' : 'Ocultar';
+    if (!collapsed) renderSpreadChart();
+  });
+}
+
+const clearSpreadBtn = document.getElementById('clearSpreadData');
+if (clearSpreadBtn) {
+  clearSpreadBtn.addEventListener('click', async () => {
+    const symbol = lastQuotes?.symbol;
+    if (!symbol) {
+      alert('Símbolo ainda não carregado.');
+      return;
+    }
+    if (!confirm(`Apagar dados armazenados de ${symbol}?`)) return;
+    try {
+      const resp = await fetch(`/api/spreads?symbol=${encodeURIComponent(symbol)}`, { method: 'DELETE' });
+      const out = await safeJson(resp);
+      if (!resp.ok || out?.ok === false) {
+        alert('Falha ao limpar dados: ' + JSON.stringify(out));
+        return;
+      }
+      spreadPoints = [];
+      updateSpreadStats(null);
+      renderSpreadChart();
+    } catch (e) {
+      alert('Erro ao limpar dados: ' + (e?.message || e));
+    }
+  });
+}
+
+fetchSpreadData(true);
 
 // ======== Histórico / Posição
 async function refreshHistory() {

--- a/server.js
+++ b/server.js
@@ -17,6 +17,8 @@ const PORT = 3000;
 
 let currentSymbol = (config?.defaultSymbol || 'BASE_USDT').toUpperCase();
 
+const SPREAD_WINDOW_MS = 24 * 60 * 60 * 1000;
+
 const autoMetaCache = new Map();
 const overridesBySymbol = new Map();
 
@@ -879,6 +881,19 @@ app.get('/api/data', async (_req, res) => {
       };
     });
 
+    const nowTs = Date.now();
+    const openSpread = Number(openLevels[0]?.diffPct);
+    const closeSpread = Number(closeLevels[0]?.diffPct);
+    try {
+      db.saveSpreadSnapshot(symbol, nowTs,
+        Number.isFinite(openSpread) ? openSpread : null,
+        Number.isFinite(closeSpread) ? closeSpread : null
+      );
+      db.pruneSpreadSnapshots(symbol, nowTs - SPREAD_WINDOW_MS);
+    } catch (err) {
+      console.warn('[SQLite] Falha ao registrar spread:', err?.message || err);
+    }
+
     res.json({
       symbol,
       baseSymbol: base,
@@ -890,6 +905,61 @@ app.get('/api/data', async (_req, res) => {
   } catch (e) {
     console.error('[ERRO /api/data]:', e.response?.data || e.message);
     res.status(500).json({ error: 'Erro ao obter dados.' });
+  }
+});
+
+app.get('/api/spreads', (req, res) => {
+  const symbol = String(req.query.symbol || currentSymbol || '').toUpperCase();
+  if (!symbol) return res.status(400).json({ error: 'Símbolo inválido.' });
+  const nowTs = Date.now();
+  const since = nowTs - SPREAD_WINDOW_MS;
+  let rows = [];
+  try {
+    rows = db.loadSpreadSnapshots(symbol, since);
+  } catch (e) {
+    console.warn('[SQLite] Falha ao carregar spreads:', e?.message || e);
+    return res.status(500).json({ error: 'Erro ao carregar spreads.' });
+  }
+
+  const points = rows.map((row) => ({
+    ts: Number(row.ts) || nowTs,
+    open: row.open == null ? null : Number(row.open),
+    close: row.close == null ? null : Number(row.close)
+  }));
+
+  const computeExtrema = (key) => {
+    let max = null;
+    let min = null;
+    for (const entry of points) {
+      const value = entry[key];
+      if (!Number.isFinite(value)) continue;
+      if (!max || value > max.value) max = { value, ts: entry.ts };
+      if (!min || value < min.value) min = { value, ts: entry.ts };
+    }
+    return { max, min };
+  };
+
+  res.json({
+    symbol,
+    windowStart: since,
+    windowEnd: nowTs,
+    points,
+    extremes: {
+      open: computeExtrema('open'),
+      close: computeExtrema('close')
+    }
+  });
+});
+
+app.delete('/api/spreads', (req, res) => {
+  const symbol = String(req.query.symbol || currentSymbol || '').toUpperCase();
+  if (!symbol) return res.status(400).json({ error: 'Símbolo inválido.' });
+  try {
+    db.clearSpreadSnapshots(symbol);
+    res.json({ ok: true });
+  } catch (e) {
+    console.warn('[SQLite] Falha ao limpar spreads:', e?.message || e);
+    res.status(500).json({ error: 'Erro ao limpar spreads.' });
   }
 });
 


### PR DESCRIPTION
## Summary
- persist opening and closing spread snapshots in SQLite and expose API endpoints to query or clear history
- capture spreads on every data fetch, maintain a 24h rolling window, and compute extrema for the front-end
- add a collapsible card with Chart.js charts, filters, stats, and a data reset button to visualise spreads and crossings

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d86e731a34832fb83aac307363817e