### PR TITLE
Improve dashboard layout and balance tools

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,9 +8,11 @@
     body { font-family: Arial, Helvetica, sans-serif; margin: 0; padding: 16px; color: #111; }
     h1 { margin: 0 0 16px 0; font-size: 22px; }
     .row { display: flex; gap: 16px; flex-wrap: wrap; }
-    .card { border: 1px solid #ddd; border-radius: 6px; padding: 14px; background: #fff; }
-    .card h3 { margin: 0 0 10px 0; font-size: 18px; display:flex; align-items:center; justify-content: space-between; gap:12px; }
+    .card { border: 1px solid #ddd; border-radius: 6px; padding: 14px; background: #fff; position: relative; }
+    .card h3 { margin: 0; font-size: 18px; display:flex; align-items:center; justify-content: space-between; gap:12px; }
+    .card-body { margin-top: 10px; }
     .w33 { flex: 1 1 360px; }
+    .w66 { flex: 2 1 360px; }
     label.inline { display: inline-block; margin-right: 8px; }
     input[type="text"], input[type="number"] { padding: 4px 6px; }
     button { padding: 6px 10px; cursor: pointer; }
@@ -54,6 +56,24 @@
     .spread-stats span.label { display:block; color:#555; font-size:12px; text-transform:uppercase; letter-spacing:0.04em; }
     .spread-chart-wrapper { position: relative; width: 100%; max-width: 100%; height: 320px; }
     .spread-chart-wrapper canvas { width: 100% !important; height: 100% !important; display: block; }
+    .progress-section { display: flex; flex-direction: column; gap: 8px; }
+    .progress-bar { position: relative; width: 100%; height: 20px; background: #f0f0f0; border-radius: 10px; overflow: hidden; border: 1px solid #ddd; }
+    .progress-bar-fill { height: 100%; background: linear-gradient(90deg, #2ca02c, #1f77b4); width: 0%; display:flex; align-items:center; justify-content:flex-end; color:#fff; font-size: 12px; font-weight:600; padding-right:6px; transition: width 0.3s ease; }
+    .progress-bar-label { position: absolute; top: 0; left: 50%; transform: translateX(-50%); font-size: 12px; font-weight: 600; color: #111; line-height: 20px; }
+    .progress-metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 8px; font-size: 13px; }
+    .progress-metrics span.label { display:block; font-size: 11px; text-transform: uppercase; letter-spacing: 0.04em; color:#555; }
+    .balance-section { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 12px; margin-top: 14px; }
+    .balance-column { border: 1px solid #eee; border-radius: 6px; padding: 10px; background: #fafafa; display:flex; flex-direction:column; gap:8px; }
+    .balance-column h4 { margin: 0; font-size: 15px; }
+    .balance-line { display:flex; flex-direction:column; gap:4px; font-size: 13px; }
+    .balance-line .balance-label { font-weight: 600; }
+    .balance-values { display:flex; gap:6px; flex-wrap:wrap; }
+    .balance-max { display:flex; align-items:center; gap:6px; font-size: 12px; color:#333; }
+    .balance-target-button { padding: 2px 6px; font-size: 12px; cursor: pointer; }
+    .balance-target-button:disabled { opacity: 0.5; cursor: not-allowed; }
+    .balance-message { font-size: 12px; color: #b00; }
+    .balance-actions { margin-top: 10px; display:flex; justify-content:flex-end; }
+    .quotes-card .quote-controls { margin-top: 12px; }
   </style>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.4/dist/chart.umd.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom@2.0.1/dist/chartjs-plugin-zoom.umd.min.js"></script>
@@ -61,288 +81,28 @@
 <body>
   <h1>Arbitragem Gate.io x MEXC — <span id="titleSymbol">BASE_USDT</span></h1>
 
-  <!-- Par & Configurações (no topo, como no layout original) -->
-  <div class="card top">
-    <h3>Par &amp; Configurações</h3>
-    <div style="display:flex; align-items:center; gap:8px; flex-wrap:wrap;">
-      <label class="inline" for="symbolInput">Par (BASE_QUOTE):</label>
-      <input id="symbolInput" type="text" value="BASE_USDT" class="mono" />
-      <button id="applySymbol">Usar</button>
-      <button id="autoCfg">Auto-configurar</button>
-      <span id="metaBadge" class="mono muted">meta: —</span>
-    </div>
-
-    <details style="margin-top:10px;">
-      <summary>Overrides manuais (opcional)</summary>
-      <div style="display:grid; grid-template-columns: repeat(3, minmax(180px, 1fr)); gap:10px; margin-top:10px;">
-        <div>
-          <div class="muted" style="margin-bottom:6px;"><strong>Gate</strong></div>
-          <label>priceScale <input id="ov_gate_price" type="number" step="1" class="mono" /></label><br/>
-          <label>qtyScale <input id="ov_gate_qty" type="number" step="1" class="mono" /></label><br/>
-          <label>minQty <input id="ov_gate_minqty" type="number" step="any" class="mono" /></label><br/>
-          <label>minQuote <input id="ov_gate_minquote" type="number" step="any" class="mono" /></label>
-        </div>
-        <div>
-          <div class="muted" style="margin-bottom:6px;"><strong>MEXC</strong></div>
-          <label>priceScale <input id="ov_mexc_price" type="number" step="1" class="mono" /></label><br/>
-          <label>volPrecision <input id="ov_mexc_volp" type="number" step="1" class="mono" /></label><br/>
-          <label>contractSize <input id="ov_mexc_cs" type="number" step="any" class="mono" /></label><br/>
-          <label>minContracts <input id="ov_mexc_minc" type="number" step="1" class="mono" /></label>
-        </div>
-        <div>
-          <div class="muted" style="margin-bottom:6px;"><strong>Settings</strong></div>
-          <label>margem (%) <input id="ov_set_margin" type="number" step="any" class="mono" /></label><br/>
-          <label>leverage <input id="ov_set_lev" type="number" step="any" class="mono" /></label><br/>
-          <label>Gate extra (%) <input id="ov_set_gate_extra" type="number" step="any" class="mono" /></label>
-        </div>
-      </div>
-      <div style="margin-top:10px;">
-        <button id="saveOverride">Salvar override</button>
-      </div>
-      <pre id="metaText" class="mono" style="margin-top:10px;">(meta não carregada)</pre>
-    </details>
-  </div>
-
-  <div class="row">
-    <!-- Cotações -->
-    <div class="card w33 quotes-card">
-      <h3>Cotações</h3>
-
-      <div class="quote-summary">
-        <div><strong>Modo atual:</strong> <span id="quoteModeLabel">Abrir</span></div>
-        <div><strong>Diferença selecionada:</strong> <span id="diff">-%</span></div>
-      </div>
-      <div class="quote-summary">
-        <div>Open selecionado: <span id="openSummary">-</span></div>
-        <div>Close selecionado: <span id="closeSummary">-</span></div>
-      </div>
-
-      <div class="quotes-section">
-        <h4>Open — Gate (asks) vs MEXC (bids)</h4>
-        <table class="quotes-table">
-          <thead>
-            <tr>
-              <th class="col-check">Usar</th>
-              <th>Nível</th>
-              <th>Gate preço</th>
-              <th>Gate base</th>
-              <th>Gate USDT</th>
-              <th>MEXC preço</th>
-              <th>MEXC base</th>
-              <th>MEXC USDT</th>
-              <th>Dif.%</th>
-            </tr>
-          </thead>
-          <tbody id="openQuotesBody"></tbody>
-        </table>
-      </div>
-
-      <div class="quotes-section">
-        <h4>Close — Gate (bids) vs MEXC (asks)</h4>
-        <table class="quotes-table">
-          <thead>
-            <tr>
-              <th class="col-check">Usar</th>
-              <th>Nível</th>
-              <th>Gate preço</th>
-              <th>Gate base</th>
-              <th>Gate USDT</th>
-              <th>MEXC preço</th>
-              <th>MEXC base</th>
-              <th>MEXC USDT</th>
-              <th>Dif.%</th>
-            </tr>
-          </thead>
-          <tbody id="closeQuotesBody"></tbody>
-        </table>
-      </div>
-
-      <div class="quote-controls">
-        <div class="quote-control-row">
-          <label><input type="checkbox" id="modeClose" /> Fechar posições (inverter lógica)</label>
-        </div>
-        <div class="quote-control-row">
-          <span>Alerta de dif. (%):</span>
-          <input id="alertMin" type="number" step="any" class="mono" placeholder="min" />
-          <input id="alertMax" type="number" step="any" class="mono" placeholder="max" />
-          <label><input type="checkbox" id="soundToggle" /> Som</label>
-          <label><input type="checkbox" id="telegramToggle" /> Telegram</label>
-        </div>
-        <div class="quote-control-row telegram-template-row">
-          <label><input type="checkbox" id="telegramVolumeGuard" /> Somente se volume ≥ mínimos</label>
-          <label><input type="checkbox" id="telegramIncludeSymbol" checked /> Nome do ativo</label>
-          <label><input type="checkbox" id="telegramIncludeDiff" checked /> Diferença (%)</label>
-          <label><input type="checkbox" id="telegramIncludeVolumes" /> Volumes (3 níveis)</label>
-        </div>
-        <div class="quote-actions">
-          <button id="executeTrade">Executar Ordem Simultânea</button>
-        </div>
-      </div>
-      <pre id="status" class="mono status" style="margin-top:10px;"></pre>
-    </div>
-
-    <!-- Saldos -->
-    <div class="card w33">
-      <h3>Saldos</h3>
-
-      <div><b>Gate:</b></div>
-      <pre id="gateBalText" class="mono">—</pre>
-
-      <div style="margin-top:6px;"><b>MEXC:</b></div>
-      <pre id="mexcBalText" class="mono">—</pre>
-
-      <div style="margin-top:10px;">
-        <button id="refreshBalances">Atualizar saldos</button>
-      </div>
-    </div>
-
-    <!-- Meta & Progresso da Posição -->
-    <div class="card w33">
-      <h3>Meta &amp; Progresso da Posição</h3>
-      <div style="display:flex; align-items:center; gap:8px; flex-wrap:wrap;">
-        <label for="targetQty">Meta (qtd total moeda base):</label>
-        <input id="targetQty" type="number" step="1" min="0" class="mono" />
-        <button id="setTarget">Definir meta</button>
-      </div>
-
-      <div class="mono" style="margin-top:10px;">
-        <div>Alvo: <span id="ppTarget">0</span></div>
-        <div style="margin-top:6px;"><strong>Gate</strong></div>
-        <div>Preenchido: <span id="ppGateFilled">0</span></div>
-        <div>Preço Médio: <span id="ppGateAvg">0</span></div>
-        <div style="margin-top:6px;"><strong>MEXC</strong></div>
-        <div>Preenchido: <span id="ppMexcFilled">0</span></div>
-        <div>Preço Médio: <span id="ppMexcAvg">0</span></div>
-        <div style="margin-top:6px;">Arb. Média (%): <span id="ppArb">0</span></div>
-        <div>PnL Geral (USDT): <span id="ppPnl">0</span></div>
-      </div>
-
-      <div style="margin-top:10px;">
-        <canvas id="progressChart" width="600" height="260"></canvas>
-      </div>
-    </div>
-  </div>
-
-  <div class="card" style="margin-top:16px;">
-    <h3>Editar estado da posição</h3>
-    <div class="position-edit-grid">
-      <div>
-        <label>Meta total
-          <input id="posEditTarget" type="number" step="any" class="mono" />
-        </label>
-        <label>Arb média (%)
-          <input id="posEditArb" type="number" step="any" class="mono" />
-        </label>
-        <label>PnL acumulado (USDT)
-          <input id="posEditPnl" type="number" step="any" class="mono" />
-        </label>
-      </div>
-      <div>
-        <div class="muted" style="margin-bottom:4px;"><strong>Gate</strong></div>
-        <label>Preenchido
-          <input id="posEditGateFilled" type="number" step="any" class="mono" />
-        </label>
-        <label>Preço médio
-          <input id="posEditGateAvg" type="number" step="any" class="mono" />
-        </label>
-      </div>
-      <div>
-        <div class="muted" style="margin-bottom:4px;"><strong>MEXC</strong></div>
-        <label>Preenchido
-          <input id="posEditMexcFilled" type="number" step="any" class="mono" />
-        </label>
-        <label>Preço médio
-          <input id="posEditMexcAvg" type="number" step="any" class="mono" />
-        </label>
-      </div>
-    </div>
-    <div class="position-edit-actions">
-      <textarea id="positionNote" placeholder="Anotação (opcional, usada ao desmontar)"></textarea>
-      <div class="position-edit-buttons">
-        <button id="positionSaveBtn">Salvar posição</button>
-        <button id="positionDismantleBtn">Desmontar posição</button>
-      </div>
-    </div>
-    <div class="position-summaries">
-      <h4>Resumos recentes</h4>
-      <table>
-        <thead>
-          <tr>
-            <th>ID</th>
-            <th>Ativo</th>
-            <th>Data/Hora Abertura</th>
-            <th>Data/Hora Fechamento</th>
-            <th>Tempo Total da posição</th>
-            <th>Meta</th>
-            <th>Gate</th>
-            <th>MEXC</th>
-            <th>Gate Abertura</th>
-            <th>MEXC Abertura</th>
-            <th>Gate Fechamento</th>
-            <th>MEXC Fechamento</th>
-            <th>Arb final (%)</th>
-            <th>PnL</th>
-            <th>Nota</th>
-          </tr>
-        </thead>
-        <tbody id="positionSummariesBody"></tbody>
-      </table>
-    </div>
-  </div>
-
-  <!-- Histórico -->
-  <div class="card" style="margin-top:16px;">
-    <h3>Histórico (ordens criadas pelo sistema)</h3>
-    <table>
-      <thead>
-        <tr>
-          <th>Local ID</th>
-          <th>Hora</th>
-          <th>Sentido</th>
-          <th>Gate Price</th>
-          <th>MEXC Price</th>
-          <th>Volume (moeda base)</th>
-          <th>%Arb</th>
-          <th>$PnL</th>
-          <th>Gate Order ID</th>
-          <th>Gate Status</th>
-          <th>GRO</th>
-          <th>MEXC Order ID</th>
-          <th>MEXC Status</th>
-          <th>MRO</th>
-          <th>Status</th>
-          <th>Ações</th>
-        </tr>
-      </thead>
-      <tbody id="historyBody"></tbody>
-    </table>
-  </div>
-
   <div class="card" id="spreadCard">
-    <h3>
-      Gráfico de Spreads
-      <button id="toggleSpreadCard" class="card-toggle">Ocultar</button>
-    </h3>
+    <h3>Gráfico de Spreads</h3>
     <div class="card-body">
       <div class="spread-controls">
         <strong>Mostrar:</strong>
         <button data-spread-filter="all" class="active">Todos</button>
-      <button data-spread-filter="open">Abertura</button>
-      <button data-spread-filter="close">Fechamento</button>
-      <button data-spread-filter="cross">Cruzamentos</button>
-      <strong style="margin-left:12px;">Intervalo:</strong>
-      <button data-spread-range="all" class="active">Tudo</button>
-      <button data-spread-range="5min">5min</button>
-      <button data-spread-range="15min">15min</button>
-      <button data-spread-range="30min">30min</button>
-      <button data-spread-range="1H">1H</button>
-      <button data-spread-range="4H">4H</button>
-      <button data-spread-range="6H">6H</button>
-      <button data-spread-range="12H">12H</button>
-      <button data-spread-range="24H">24H</button>
-      <button id="resetSpreadZoom" style="margin-left:auto;">Resetar zoom</button>
-      <button id="clearSpreadData">Limpar dados do ativo</button>
-    </div>
+        <button data-spread-filter="open">Abertura</button>
+        <button data-spread-filter="close">Fechamento</button>
+        <button data-spread-filter="cross">Cruzamentos</button>
+        <strong style="margin-left:12px;">Intervalo:</strong>
+        <button data-spread-range="all" class="active">Tudo</button>
+        <button data-spread-range="5min">5min</button>
+        <button data-spread-range="15min">15min</button>
+        <button data-spread-range="30min">30min</button>
+        <button data-spread-range="1H">1H</button>
+        <button data-spread-range="4H">4H</button>
+        <button data-spread-range="6H">6H</button>
+        <button data-spread-range="12H">12H</button>
+        <button data-spread-range="24H">24H</button>
+        <button id="resetSpreadZoom" style="margin-left:auto;">Resetar zoom</button>
+        <button id="clearSpreadData">Limpar dados do ativo</button>
+      </div>
       <div class="spread-chart-wrapper">
         <canvas id="spreadChart"></canvas>
       </div>
@@ -367,6 +127,328 @@
           <span class="label">Arbitragem final (diferença)</span>
           <span id="spreadFinalArb">-</span>
         </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="card top" id="configCard">
+    <h3>Par &amp; Configurações</h3>
+    <div class="card-body">
+      <div style="display:flex; align-items:center; gap:8px; flex-wrap:wrap;">
+        <label class="inline" for="symbolInput">Par (BASE_QUOTE):</label>
+        <input id="symbolInput" type="text" value="BASE_USDT" class="mono" />
+        <button id="applySymbol">Usar</button>
+        <button id="autoCfg">Auto-configurar</button>
+        <span id="metaBadge" class="mono muted">meta: —</span>
+      </div>
+
+      <details style="margin-top:10px;">
+        <summary>Overrides manuais (opcional)</summary>
+        <div style="display:grid; grid-template-columns: repeat(3, minmax(180px, 1fr)); gap:10px; margin-top:10px;">
+          <div>
+            <div class="muted" style="margin-bottom:6px;"><strong>Gate</strong></div>
+            <label>priceScale <input id="ov_gate_price" type="number" step="1" class="mono" /></label><br/>
+            <label>qtyScale <input id="ov_gate_qty" type="number" step="1" class="mono" /></label><br/>
+            <label>minQty <input id="ov_gate_minqty" type="number" step="any" class="mono" /></label><br/>
+            <label>minQuote <input id="ov_gate_minquote" type="number" step="any" class="mono" /></label>
+          </div>
+          <div>
+            <div class="muted" style="margin-bottom:6px;"><strong>MEXC</strong></div>
+            <label>priceScale <input id="ov_mexc_price" type="number" step="1" class="mono" /></label><br/>
+            <label>volPrecision <input id="ov_mexc_volp" type="number" step="1" class="mono" /></label><br/>
+            <label>contractSize <input id="ov_mexc_cs" type="number" step="any" class="mono" /></label><br/>
+            <label>minContracts <input id="ov_mexc_minc" type="number" step="1" class="mono" /></label>
+          </div>
+          <div>
+            <div class="muted" style="margin-bottom:6px;"><strong>Settings</strong></div>
+            <label>margem (%) <input id="ov_set_margin" type="number" step="any" class="mono" /></label><br/>
+            <label>leverage <input id="ov_set_lev" type="number" step="any" class="mono" /></label><br/>
+            <label>Gate extra (%) <input id="ov_set_gate_extra" type="number" step="any" class="mono" /></label>
+          </div>
+        </div>
+        <div style="margin-top:10px;">
+          <button id="saveOverride">Salvar override</button>
+        </div>
+        <pre id="metaText" class="mono" style="margin-top:10px;">(meta não carregada)</pre>
+      </details>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="card w33 quotes-card" id="quotesCard">
+      <h3>Cotações</h3>
+      <div class="card-body">
+        <div class="quote-summary">
+          <div><strong>Modo atual:</strong> <span id="quoteModeLabel">Abrir</span></div>
+          <div><strong>Diferença selecionada:</strong> <span id="diff">-%</span></div>
+        </div>
+        <div class="quote-summary">
+          <div>Open selecionado: <span id="openSummary">-</span></div>
+          <div>Close selecionado: <span id="closeSummary">-</span></div>
+        </div>
+
+        <div class="quotes-section">
+          <h4>Open — Gate (asks) vs MEXC (bids)</h4>
+          <table class="quotes-table">
+            <thead>
+              <tr>
+                <th class="col-check">Usar</th>
+                <th>Nível</th>
+                <th>Gate preço</th>
+                <th>Gate base</th>
+                <th>Gate USDT</th>
+                <th>MEXC preço</th>
+                <th>MEXC base</th>
+                <th>MEXC USDT</th>
+                <th>Dif.%</th>
+              </tr>
+            </thead>
+            <tbody id="openQuotesBody"></tbody>
+          </table>
+        </div>
+
+        <div class="quotes-section">
+          <h4>Close — Gate (bids) vs MEXC (asks)</h4>
+          <table class="quotes-table">
+            <thead>
+              <tr>
+                <th class="col-check">Usar</th>
+                <th>Nível</th>
+                <th>Gate preço</th>
+                <th>Gate base</th>
+                <th>Gate USDT</th>
+                <th>MEXC preço</th>
+                <th>MEXC base</th>
+                <th>MEXC USDT</th>
+                <th>Dif.%</th>
+              </tr>
+            </thead>
+            <tbody id="closeQuotesBody"></tbody>
+          </table>
+        </div>
+
+        <div class="quote-controls">
+          <div class="quote-control-row">
+            <label><input type="checkbox" id="modeClose" /> Fechar posições (inverter lógica)</label>
+          </div>
+          <div class="quote-control-row">
+            <label><input type="checkbox" id="scientificToggle" /> Notação científica (&gt;6 decimais)</label>
+          </div>
+          <div class="quote-control-row">
+            <span>Alerta de dif. (%):</span>
+            <input id="alertMin" type="number" step="any" class="mono" placeholder="min" />
+            <input id="alertMax" type="number" step="any" class="mono" placeholder="max" />
+            <label><input type="checkbox" id="soundToggle" /> Som</label>
+            <label><input type="checkbox" id="telegramToggle" /> Telegram</label>
+          </div>
+          <div class="quote-control-row telegram-template-row">
+            <label><input type="checkbox" id="telegramVolumeGuard" /> Somente se volume ≥ mínimos</label>
+            <label><input type="checkbox" id="telegramIncludeSymbol" checked /> Nome do ativo</label>
+            <label><input type="checkbox" id="telegramIncludeDiff" checked /> Diferença (%)</label>
+            <label><input type="checkbox" id="telegramIncludeVolumes" /> Volumes (3 níveis)</label>
+          </div>
+          <div class="quote-actions">
+            <button id="executeTrade">Executar Ordem Simultânea</button>
+          </div>
+        </div>
+        <pre id="status" class="mono status" style="margin-top:10px;"></pre>
+      </div>
+    </div>
+
+    <div class="card w66" id="positionCard">
+      <h3>Meta, Progresso &amp; Saldos</h3>
+      <div class="card-body">
+        <div style="display:flex; align-items:center; gap:8px; flex-wrap:wrap;">
+          <label for="targetQty">Meta (qtd total moeda base):</label>
+          <input id="targetQty" type="number" step="1" min="0" class="mono" />
+          <button id="setTarget">Definir meta</button>
+        </div>
+
+        <div class="progress-section" style="margin-top:12px;">
+          <div class="progress-bar">
+            <div class="progress-bar-fill" id="positionProgressFill"></div>
+            <div class="progress-bar-label" id="positionProgressLabel">0%</div>
+          </div>
+          <div class="progress-metrics">
+            <div>
+              <span class="label">Meta</span>
+              <span id="ppTarget">0</span>
+            </div>
+            <div>
+              <span class="label">Preenchido Gate</span>
+              <span id="ppGateFilled">0</span>
+            </div>
+            <div>
+              <span class="label">Preço médio Gate</span>
+              <span id="ppGateAvg">0</span>
+            </div>
+            <div>
+              <span class="label">Preenchido MEXC</span>
+              <span id="ppMexcFilled">0</span>
+            </div>
+            <div>
+              <span class="label">Preço médio MEXC</span>
+              <span id="ppMexcAvg">0</span>
+            </div>
+            <div>
+              <span class="label">Arb. média (%)</span>
+              <span id="ppArb">0</span>
+            </div>
+            <div>
+              <span class="label">PnL geral (USDT)</span>
+              <span id="ppPnl">0</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="balance-section">
+          <div class="balance-column">
+            <h4>Gate</h4>
+            <div class="balance-line">
+              <span class="balance-label">USDT</span>
+              <div class="balance-values">
+                <span>disp <span id="gateUsdtAvailable">—</span></span>
+                <span>ordem <span id="gateUsdtLocked">—</span></span>
+              </div>
+              <div class="balance-max">
+                <span id="gateMaxBaseValue">Max: —</span>
+                <button type="button" class="balance-target-button" id="gateMaxBaseBtn" title="Definir meta com este volume">&gt;</button>
+              </div>
+            </div>
+            <div class="balance-line">
+              <span class="balance-label" id="gateBaseLabel">BASE</span>
+              <div class="balance-values">
+                <span>disp <span id="gateBaseAvailable">—</span></span>
+                <span>ordem <span id="gateBaseLocked">—</span></span>
+              </div>
+            </div>
+            <div class="balance-message" id="gateBalanceMessage"></div>
+          </div>
+          <div class="balance-column">
+            <h4>MEXC</h4>
+            <div class="balance-line">
+              <span class="balance-label">USDT</span>
+              <div class="balance-values">
+                <span>disp <span id="mexcUsdtAvailable">—</span></span>
+                <span>ordem <span id="mexcUsdtLocked">—</span></span>
+              </div>
+              <div class="balance-max">
+                <span id="mexcMaxBaseValue">Max: —</span>
+                <button type="button" class="balance-target-button" id="mexcMaxBaseBtn" title="Definir meta com este volume">&gt;</button>
+              </div>
+            </div>
+            <div class="balance-line">
+              <span class="balance-label" id="mexcBaseLabel">BASE</span>
+              <div class="balance-values">
+                <span>disp <span id="mexcBaseAvailable">—</span></span>
+                <span>ordem <span id="mexcBaseLocked">—</span></span>
+              </div>
+            </div>
+            <div class="balance-message" id="mexcBalanceMessage"></div>
+          </div>
+        </div>
+
+        <div class="balance-actions">
+          <button id="refreshBalances">Atualizar saldos</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="card" id="historyCard">
+    <h3>Histórico (ordens criadas pelo sistema)</h3>
+    <div class="card-body">
+      <table>
+        <thead>
+          <tr>
+            <th>Local ID</th>
+            <th>Hora</th>
+            <th>Sentido</th>
+            <th>Gate Price</th>
+            <th>MEXC Price</th>
+            <th>Volume (moeda base)</th>
+            <th>%Arb</th>
+            <th>$PnL</th>
+            <th>Gate Order ID</th>
+            <th>Gate Status</th>
+            <th>GRO</th>
+            <th>MEXC Order ID</th>
+            <th>MEXC Status</th>
+            <th>MRO</th>
+            <th>Status</th>
+            <th>Ações</th>
+          </tr>
+        </thead>
+        <tbody id="historyBody"></tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="card" id="positionEditCard">
+    <h3>Editar estado da posição</h3>
+    <div class="card-body">
+      <div class="position-edit-grid">
+        <div>
+          <label>Meta total
+            <input id="posEditTarget" type="number" step="any" class="mono" />
+          </label>
+          <label>Arb média (%)
+            <input id="posEditArb" type="number" step="any" class="mono" />
+          </label>
+          <label>PnL acumulado (USDT)
+            <input id="posEditPnl" type="number" step="any" class="mono" />
+          </label>
+        </div>
+        <div>
+          <div class="muted" style="margin-bottom:4px;"><strong>Gate</strong></div>
+          <label>Preenchido
+            <input id="posEditGateFilled" type="number" step="any" class="mono" />
+          </label>
+          <label>Preço médio
+            <input id="posEditGateAvg" type="number" step="any" class="mono" />
+          </label>
+        </div>
+        <div>
+          <div class="muted" style="margin-bottom:4px;"><strong>MEXC</strong></div>
+          <label>Preenchido
+            <input id="posEditMexcFilled" type="number" step="any" class="mono" />
+          </label>
+          <label>Preço médio
+            <input id="posEditMexcAvg" type="number" step="any" class="mono" />
+          </label>
+        </div>
+      </div>
+      <div class="position-edit-actions">
+        <textarea id="positionNote" placeholder="Anotação (opcional, usada ao desmontar)"></textarea>
+        <div class="position-edit-buttons">
+          <button id="positionSaveBtn">Salvar posição</button>
+          <button id="positionDismantleBtn">Desmontar posição</button>
+        </div>
+      </div>
+      <div class="position-summaries">
+        <h4>Resumos recentes</h4>
+        <table>
+          <thead>
+            <tr>
+              <th>ID</th>
+              <th>Ativo</th>
+              <th>Data/Hora Abertura</th>
+              <th>Data/Hora Fechamento</th>
+              <th>Tempo Total da posição</th>
+              <th>Meta</th>
+              <th>Gate</th>
+              <th>MEXC</th>
+              <th>Gate Abertura</th>
+              <th>MEXC Abertura</th>
+              <th>Gate Fechamento</th>
+              <th>MEXC Fechamento</th>
+              <th>Arb final (%)</th>
+              <th>PnL</th>
+              <th>Nota</th>
+            </tr>
+          </thead>
+          <tbody id="positionSummariesBody"></tbody>
+        </table>
       </div>
     </div>
   </div>

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -10,8 +10,23 @@ function safeJson(res) {
   return res.text().then(t => { throw new Error(`Resposta não-JSON (${res.status}): ${t.slice(0,120)}...`); });
 }
 
+let currentSymbol = null;
+let currentBaseSymbol = null;
+
+function setCurrentSymbol(sym) {
+  if (!sym) return;
+  currentSymbol = sym;
+  const base = String(sym).split('_')[0] || '';
+  const normalized = base ? base.toUpperCase() : null;
+  if (normalized) currentBaseSymbol = normalized;
+  updateBaseSymbolUI();
+}
+
 async function getSymbol() {
-  const r = await fetch('/api/symbol'); return (await r.json()).symbol;
+  const r = await fetch('/api/symbol');
+  const sym = (await r.json()).symbol;
+  if (sym) setCurrentSymbol(sym);
+  return sym;
 }
 async function setSymbol(sym) {
   const r = await fetch('/api/symbol', {
@@ -19,79 +34,214 @@ async function setSymbol(sym) {
     body: JSON.stringify({symbol: sym})
   });
   const out = await safeJson(r);
-  return out.symbol;
+  const normalized = out.symbol || sym;
+  if (normalized) setCurrentSymbol(normalized);
+  return normalized;
 }
 
-function renderGateBalance(b) {
-  if (!b || typeof b !== 'object') return '—';
-  if (b.error) return `Erro: ${JSON.stringify(b.error)}`;
-  const keys = Object.keys(b).sort();
-  if (!keys.length) return '—';
-  return keys.map(k => `${k}: disponível ${b[k].available} | em ordem ${b[k].locked}`).join('\n');
+function getCurrentBaseSymbol() {
+  if (currentBaseSymbol) return currentBaseSymbol;
+  const input = document.getElementById('symbolInput');
+  const raw = input ? input.value : '';
+  const base = raw && raw.includes('_') ? raw.split('_')[0] : raw;
+  return base ? base.toUpperCase() : 'BASE';
 }
-function renderMexcBalance(b) {
-  if (!b) return '—';
-  if (b.unknown) {
-    return (b.reason === 'client_not_initialized' || b.reason === 'no_web_token')
+
+function updateBaseSymbolUI() {
+  const baseDefault = getCurrentBaseSymbol();
+  const gateLabel = document.getElementById('gateBaseLabel');
+  if (gateLabel) gateLabel.textContent = lastBalanceData.gate.baseLabel || baseDefault;
+  const mexcLabel = document.getElementById('mexcBaseLabel');
+  if (mexcLabel) mexcLabel.textContent = lastBalanceData.mexc.baseLabel || baseDefault;
+}
+
+const lastBalanceData = {
+  gate: { usdtAvailable: null, usdtLocked: null, baseAvailable: null, baseLocked: null, message: null },
+  mexc: { usdtAvailable: null, usdtLocked: null, baseAvailable: null, baseLocked: null, message: null }
+};
+const lastReferencePrices = { gate: null, mexc: null };
+const lastMaxBaseVolumes = { gate: null, mexc: null };
+let useScientificNotation = false;
+
+function toNumberOrNull(value) {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+}
+
+function formatTwoDecimals(value) {
+  if (!Number.isFinite(value)) return '—';
+  return value.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 2 });
+}
+
+function setBalanceValue(id, value) {
+  const el = document.getElementById(id);
+  if (!el) return;
+  el.textContent = formatTwoDecimals(value);
+}
+
+function applyBalanceDisplay(prefix) {
+  const data = lastBalanceData[prefix] || {};
+  setBalanceValue(`${prefix}UsdtAvailable`, data.usdtAvailable);
+  setBalanceValue(`${prefix}UsdtLocked`, data.usdtLocked);
+  setBalanceValue(`${prefix}BaseAvailable`, data.baseAvailable);
+  setBalanceValue(`${prefix}BaseLocked`, data.baseLocked);
+  const messageEl = document.getElementById(`${prefix}BalanceMessage`);
+  if (messageEl) messageEl.textContent = data.message || '';
+}
+
+function parseGateBalance(raw) {
+  if (!raw || typeof raw !== 'object') {
+    return { usdtAvailable: null, usdtLocked: null, baseAvailable: null, baseLocked: null, message: 'Saldo indisponível.', baseLabel: null };
+  }
+  if (raw.error) {
+    const msg = typeof raw.error === 'string' ? raw.error : JSON.stringify(raw.error);
+    return { usdtAvailable: null, usdtLocked: null, baseAvailable: null, baseLocked: null, message: `Erro: ${msg}`, baseLabel: null };
+  }
+  const baseSymbol = getCurrentBaseSymbol();
+  const usdtEntry = raw.USDT || {};
+  const baseEntry = raw[baseSymbol] || {};
+  const usdtAvailable = toNumberOrNull(usdtEntry.available);
+  const usdtLocked = toNumberOrNull(usdtEntry.locked);
+  const baseAvailable = toNumberOrNull(baseEntry.available);
+  const baseLocked = toNumberOrNull(baseEntry.locked);
+  let message = null;
+  if (!Number.isFinite(baseAvailable) && !Number.isFinite(baseLocked)) {
+    message = 'Saldo da moeda base indisponível.';
+  }
+  return { usdtAvailable, usdtLocked, baseAvailable, baseLocked, message, baseLabel: baseSymbol };
+}
+
+function parseMexcBalance(raw) {
+  if (!raw || typeof raw !== 'object') {
+    return { usdtAvailable: null, usdtLocked: null, baseAvailable: null, baseLocked: null, message: 'Saldo indisponível.', baseLabel: null };
+  }
+  if (raw.unknown) {
+    const msg = raw.reason === 'no_web_token'
       ? 'Token/chaves não configurados (config.mexc).'
       : 'Saldo indisponível via API.';
+    return { usdtAvailable: null, usdtLocked: null, baseAvailable: null, baseLocked: null, message: msg, baseLabel: null };
   }
-  if (b.error) return `Erro: ${JSON.stringify(b.error)}`;
-  if (b.reason === 'unexpected_assets_shape') return 'Saldo indisponível (formato inesperado).';
-
-  const fmt = (v) => {
-    if (v == null) return '—';
-    const n = Number(v);
-    return Number.isFinite(n) ? n : v;
-  };
-
-  const assets = (b.assets && typeof b.assets === 'object') ? b.assets : {};
-  const buildLine = (currency, availableRaw, lockedRaw, source) => {
-    if (!currency) return null;
-    const available = fmt(availableRaw);
-    const locked = fmt(lockedRaw);
-    let line = `${currency}: disponível ${available} | em ordem ${locked}`;
-    if (source && source !== 'api') line += ` (${source === 'estimado' ? 'estimado' : source})`;
-    return line;
-  };
-
-  const baseCurrency = (b.base?.currency || '').toString().toUpperCase();
-  let baseLine = null;
-  if (baseCurrency) {
-    const assetEntry = assets[baseCurrency] || {};
-    const availableRaw = (b.base?.available != null) ? b.base.available : assetEntry.available;
-    const lockedRaw = (b.base?.locked != null) ? b.base.locked : assetEntry.locked;
-    const source = b.base?.source || ((assetEntry.available != null || assetEntry.locked != null) ? 'api' : null);
-    baseLine = buildLine(baseCurrency, availableRaw, lockedRaw, source);
+  if (raw.error) {
+    const msg = typeof raw.error === 'string' ? raw.error : JSON.stringify(raw.error);
+    return { usdtAvailable: null, usdtLocked: null, baseAvailable: null, baseLocked: null, message: `Erro: ${msg}`, baseLabel: null };
+  }
+  if (raw.reason === 'unexpected_assets_shape') {
+    return { usdtAvailable: null, usdtLocked: null, baseAvailable: null, baseLocked: null, message: 'Saldo indisponível (formato inesperado).', baseLabel: null };
   }
 
-  const usdtAsset = assets.USDT || {};
-  const usdtAvailableRaw = (b.availableUSDT != null) ? b.availableUSDT : usdtAsset.available;
-  const usdtLockedRaw = usdtAsset.locked;
-  const usdtLine = (usdtAvailableRaw != null || usdtLockedRaw != null)
-    ? buildLine('USDT', usdtAvailableRaw, usdtLockedRaw, null)
-    : null;
+  const baseSymbol = getCurrentBaseSymbol();
+  const assets = raw.assets && typeof raw.assets === 'object' ? raw.assets : {};
+  const usdtEntry = assets.USDT || {};
+  const usdtAvailable = raw.availableUSDT != null ? toNumberOrNull(raw.availableUSDT) : toNumberOrNull(usdtEntry.available);
+  const usdtLocked = toNumberOrNull(usdtEntry.locked);
+  const baseInfo = raw.base || assets[baseSymbol] || {};
+  const baseAvailable = toNumberOrNull(baseInfo.available);
+  const baseLocked = toNumberOrNull(baseInfo.locked);
+  let message = null;
+  if (!Number.isFinite(baseAvailable) && !Number.isFinite(baseLocked)) {
+    message = 'Saldo da moeda base indisponível.';
+  }
+  const source = (raw.base && raw.base.source) || baseInfo.source || null;
+  const baseLabel = source && source !== 'api' && source !== 'sem dados'
+    ? `${baseSymbol} (${source})`
+    : baseSymbol;
+  return { usdtAvailable, usdtLocked, baseAvailable, baseLocked, message, baseLabel };
+}
 
-  const lines = [];
-  if (usdtLine) lines.push(usdtLine);
-  if (baseLine) lines.push(baseLine);
+function computeMaxBaseVolume(usdtAvailable, price) {
+  if (!Number.isFinite(usdtAvailable) || !Number.isFinite(price) || price <= 0) return null;
+  return usdtAvailable / price;
+}
 
-  if (!lines.length) return 'Saldo da moeda base indisponível.';
-  return lines.join('\n');
+function updateMaxBaseDisplays() {
+  const baseSymbol = getCurrentBaseSymbol();
+  const apply = (prefix, price) => {
+    const usdtAvailable = lastBalanceData[prefix]?.usdtAvailable;
+    const maxBase = computeMaxBaseVolume(usdtAvailable, price);
+    lastMaxBaseVolumes[prefix] = Number.isFinite(maxBase) ? maxBase : null;
+    const valueEl = document.getElementById(`${prefix}MaxBaseValue`);
+    if (valueEl) {
+      valueEl.textContent = Number.isFinite(maxBase)
+        ? `Max: ${formatTwoDecimals(maxBase)} ${baseSymbol}`
+        : 'Max: —';
+    }
+    const btn = document.getElementById(`${prefix}MaxBaseBtn`);
+    if (btn) {
+      const enabled = Number.isFinite(maxBase) && maxBase > 0;
+      btn.disabled = !enabled;
+      btn.dataset.targetQty = enabled ? String(maxBase) : '';
+    }
+  };
+  apply('gate', lastReferencePrices.gate);
+  apply('mexc', lastReferencePrices.mexc);
 }
 
 async function refreshBalances() {
   try {
     const r = await fetch('/api/balances');
     const d = await r.json();
-    document.getElementById('gateBalText').textContent = renderGateBalance(d.gate);
-    document.getElementById('mexcBalText').textContent = renderMexcBalance(d.mexc);
-  } catch {
-    document.getElementById('gateBalText').textContent = 'erro';
-    document.getElementById('mexcBalText').textContent = 'erro';
+    lastBalanceData.gate = parseGateBalance(d.gate);
+    lastBalanceData.mexc = parseMexcBalance(d.mexc);
+    updateBaseSymbolUI();
+    applyBalanceDisplay('gate');
+    applyBalanceDisplay('mexc');
+    updateMaxBaseDisplays();
+  } catch (err) {
+    lastBalanceData.gate = { usdtAvailable: null, usdtLocked: null, baseAvailable: null, baseLocked: null, message: 'Erro ao carregar saldos.', baseLabel: null };
+    lastBalanceData.mexc = { usdtAvailable: null, usdtLocked: null, baseAvailable: null, baseLocked: null, message: 'Erro ao carregar saldos.', baseLabel: null };
+    updateBaseSymbolUI();
+    applyBalanceDisplay('gate');
+    applyBalanceDisplay('mexc');
+    updateMaxBaseDisplays();
+    console.warn('refreshBalances falhou:', err);
   }
 }
-document.getElementById('refreshBalances').addEventListener('click', refreshBalances);
+
+const refreshBalancesBtn = document.getElementById('refreshBalances');
+if (refreshBalancesBtn) refreshBalancesBtn.addEventListener('click', refreshBalances);
+
+function setupCardToggles() {
+  const cards = document.querySelectorAll('.card');
+  cards.forEach((card) => {
+    const header = card.querySelector('h3');
+    if (!header) return;
+    let btn = header.querySelector('.card-toggle');
+    if (!btn) {
+      btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'card-toggle';
+      btn.textContent = 'Ocultar';
+      header.appendChild(btn);
+    }
+    if (btn.dataset.toggleBound === '1') return;
+    btn.dataset.toggleBound = '1';
+    btn.addEventListener('click', () => {
+      card.classList.toggle('collapsed');
+      const collapsed = card.classList.contains('collapsed');
+      btn.textContent = collapsed ? 'Mostrar' : 'Ocultar';
+      if (!collapsed && card.id === 'spreadCard') {
+        renderSpreadChart();
+      }
+    });
+  });
+}
+
+function updateProgressBar(targetQty, filledQty) {
+  const fillEl = document.getElementById('positionProgressFill');
+  const labelEl = document.getElementById('positionProgressLabel');
+  const target = Number(targetQty);
+  const filled = Number(filledQty);
+  let pct = 0;
+  if (Number.isFinite(target) && target > 0 && Number.isFinite(filled) && filled >= 0) {
+    pct = (filled / target) * 100;
+  } else if (Number.isFinite(filled) && filled > 0 && (!Number.isFinite(target) || target <= 0)) {
+    pct = 100;
+  }
+  const validPct = Number.isFinite(pct) ? pct : 0;
+  const clamped = Math.max(0, Math.min(validPct, 100));
+  if (fillEl) fillEl.style.width = `${clamped}%`;
+  if (labelEl) labelEl.textContent = Number.isFinite(validPct) ? `${validPct.toFixed(1)}%` : '0%';
+}
 
 // ======== Meta UI
 function fillOverridesUI(merged) {
@@ -135,6 +285,8 @@ document.getElementById('applySymbol').addEventListener('click', async () => {
   localStorage.setItem('lastSymbol', sym);
   document.getElementById('titleSymbol').textContent = sym;
   await refreshMetaUI(sym);
+  await refreshBalances();
+  await fetchData();
   await fetchSpreadData(true);
 });
 
@@ -278,6 +430,7 @@ if (Number.isFinite(alertMax)) {
   const el = document.getElementById('alertMax');
   if (el) el.value = alertMax;
 }
+useScientificNotation = localStorage.getItem('quotesScientific') === '1';
 const soundToggleEl = document.getElementById('soundToggle');
 if (soundToggleEl) soundToggleEl.checked = soundEnabled;
 const telegramToggleEl = document.getElementById('telegramToggle');
@@ -290,6 +443,8 @@ const telegramIncludeDiffEl = document.getElementById('telegramIncludeDiff');
 if (telegramIncludeDiffEl) telegramIncludeDiffEl.checked = telegramIncludeDiff;
 const telegramIncludeVolumesEl = document.getElementById('telegramIncludeVolumes');
 if (telegramIncludeVolumesEl) telegramIncludeVolumesEl.checked = telegramIncludeVolumes;
+const scientificToggleEl = document.getElementById('scientificToggle');
+if (scientificToggleEl) scientificToggleEl.checked = useScientificNotation;
 
 function playBeep() {
   try {
@@ -439,6 +594,11 @@ telegramIncludeVolumesEl?.addEventListener('change', e => {
   telegramIncludeVolumes = e.target.checked;
   localStorage.setItem('tgIncludeVolumes', telegramIncludeVolumes ? '1' : '0');
 });
+scientificToggleEl?.addEventListener('change', e => {
+  useScientificNotation = e.target.checked;
+  try { localStorage.setItem('quotesScientific', useScientificNotation ? '1' : '0'); } catch {}
+  renderQuotes();
+});
 
 function persistSelections() {
   localStorage.setItem('levels_open', JSON.stringify(Array.from(levelSelections.open).sort((a, b) => a - b)));
@@ -458,23 +618,53 @@ function syncSelectionWithLevels(mode, maxLevels) {
   if (changed) persistSelections();
 }
 
+function shouldUseScientific(num) {
+  if (!useScientificNotation) return false;
+  const str = num.toString().toLowerCase();
+  if (str.includes('e')) return true;
+  const parts = str.split('.');
+  if (parts.length !== 2) return false;
+  const decimals = parts[1].replace(/0+$/, '');
+  return decimals.length > 6;
+}
+
 function formatNumberValue(value, digits = 6) {
   const num = Number(value);
-  if (!Number.isFinite(num)) return '-';
+  if (!Number.isFinite(num)) return '—';
+  if (shouldUseScientific(num)) {
+    return num.toExponential(2);
+  }
   return num.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: digits });
 }
 
 function formatVolumeValue(value, digits, unit) {
   const num = Number(value);
-  if (!Number.isFinite(num)) return '-';
-  const base = num.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: digits });
+  if (!Number.isFinite(num)) return '—';
+  const base = shouldUseScientific(num)
+    ? num.toExponential(2)
+    : num.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: digits });
   return unit ? `${base} ${unit}` : base;
 }
 
-function formatDiffValue(value) {
+function formatDiffValue(value, digits = 2) {
   const num = Number(value);
   if (!Number.isFinite(num)) return '-%';
-  return `${num.toFixed(6)}%`;
+  return `${num.toFixed(digits)}%`;
+}
+
+function updateReferencePrices(openLevels, closeLevels) {
+  const pickPrice = (levels, extractor) => {
+    for (const lvl of levels) {
+      const val = Number(extractor(lvl));
+      if (Number.isFinite(val) && val > 0) return val;
+    }
+    return null;
+  };
+  const gatePrice = pickPrice(openLevels, lvl => lvl?.gate?.price) ?? pickPrice(closeLevels, lvl => lvl?.gate?.price);
+  const mexcPrice = pickPrice(openLevels, lvl => lvl?.mexc?.price) ?? pickPrice(closeLevels, lvl => lvl?.mexc?.price);
+  lastReferencePrices.gate = Number.isFinite(gatePrice) ? gatePrice : null;
+  lastReferencePrices.mexc = Number.isFinite(mexcPrice) ? mexcPrice : null;
+  updateMaxBaseDisplays();
 }
 
 function renderLevelsTable(mode, levels, baseSymbol, tbodyId) {
@@ -583,6 +773,13 @@ function getSelectedLevelsPayload() {
 
 function renderQuotes() {
   if (!lastQuotes) return;
+  if (lastQuotes.baseSymbol) {
+    const normalized = String(lastQuotes.baseSymbol).toUpperCase();
+    if (normalized && normalized !== currentBaseSymbol) {
+      currentBaseSymbol = normalized;
+      updateBaseSymbolUI();
+    }
+  }
   const baseSymbol = lastQuotes.baseSymbol || (lastQuotes.symbol ? String(lastQuotes.symbol).split('_')[0] : 'BASE');
   const openLevels = lastQuotes.open?.levels || [];
   const closeLevels = lastQuotes.close?.levels || [];
@@ -592,6 +789,8 @@ function renderQuotes() {
 
   renderLevelsTable('open', openLevels, baseSymbol, 'openQuotesBody');
   renderLevelsTable('close', closeLevels, baseSymbol, 'closeQuotesBody');
+
+  updateReferencePrices(openLevels, closeLevels);
 
   const openStats = computeSelectionStats('open');
   const closeStats = computeSelectionStats('close');
@@ -1096,6 +1295,7 @@ async function fetchData() {
     const r = await fetch('/api/data');
     const d = await r.json();
     lastQuotes = d;
+    if (d.symbol) setCurrentSymbol(d.symbol);
     document.getElementById('titleSymbol').textContent = d.symbol || '-';
     renderQuotes();
     fetchSpreadData();
@@ -1142,18 +1342,6 @@ if (resetSpreadZoomBtn) {
     if (chart && typeof chart.resetZoom === 'function') {
       chart.resetZoom();
     }
-  });
-}
-
-const toggleSpreadCardBtn = document.getElementById('toggleSpreadCard');
-if (toggleSpreadCardBtn) {
-  toggleSpreadCardBtn.addEventListener('click', () => {
-    const card = document.getElementById('spreadCard');
-    if (!card) return;
-    card.classList.toggle('collapsed');
-    const collapsed = card.classList.contains('collapsed');
-    toggleSpreadCardBtn.textContent = collapsed ? 'Mostrar' : 'Ocultar';
-    if (!collapsed) renderSpreadChart();
   });
 }
 
@@ -1537,14 +1725,35 @@ async function refreshPosition() {
     const s = payload?.state || payload || {};
     const g = s.gate || {};
     const m = s.mexc || {};
-    document.getElementById('ppTarget').textContent = s.targetQty || 0;
-    document.getElementById('ppGateFilled').textContent = g.filledQty || 0;
-    document.getElementById('ppGateAvg').textContent = (g.avgPrice || 0).toFixed ? g.avgPrice.toFixed(11) : g.avgPrice;
-    document.getElementById('ppMexcFilled').textContent = m.filledQty || 0;
-    document.getElementById('ppMexcAvg').textContent = (m.avgPrice || 0).toFixed ? m.avgPrice.toFixed(11) : m.avgPrice;
-    document.getElementById('ppArb').textContent = (s.arbPctAvg || 0).toFixed ? s.arbPctAvg.toFixed(6) : s.arbPctAvg;
-    document.getElementById('ppPnl').textContent = (s.pnlUsd || 0).toFixed ? s.pnlUsd.toFixed(6) : s.pnlUsd;
-    drawProgressChart(s.series || []);
+    const baseSymbol = getCurrentBaseSymbol();
+    const targetQty = toNumberOrNull(s.targetQty);
+    const gateFilled = toNumberOrNull(g.filledQty);
+    const gateAvg = toNumberOrNull(g.avgPrice);
+    const mexcFilled = toNumberOrNull(m.filledQty);
+    const mexcAvg = toNumberOrNull(m.avgPrice);
+    const arbPct = toNumberOrNull(s.arbPctAvg);
+    const pnl = toNumberOrNull(s.pnlUsd);
+    const totalFilledRaw = toNumberOrNull(s.filledQty);
+    const totalFilled = Number.isFinite(totalFilledRaw)
+      ? totalFilledRaw
+      : Math.max(gateFilled ?? 0, mexcFilled ?? 0);
+
+    const targetEl = document.getElementById('ppTarget');
+    if (targetEl) targetEl.textContent = formatVolumeValue(targetQty, 6, baseSymbol);
+    const gateFilledEl = document.getElementById('ppGateFilled');
+    if (gateFilledEl) gateFilledEl.textContent = formatVolumeValue(gateFilled, 6, baseSymbol);
+    const gateAvgEl = document.getElementById('ppGateAvg');
+    if (gateAvgEl) gateAvgEl.textContent = formatNumberValue(gateAvg, 8);
+    const mexcFilledEl = document.getElementById('ppMexcFilled');
+    if (mexcFilledEl) mexcFilledEl.textContent = formatVolumeValue(mexcFilled, 6, baseSymbol);
+    const mexcAvgEl = document.getElementById('ppMexcAvg');
+    if (mexcAvgEl) mexcAvgEl.textContent = formatNumberValue(mexcAvg, 8);
+    const arbEl = document.getElementById('ppArb');
+    if (arbEl) arbEl.textContent = formatDiffValue(arbPct, 4);
+    const pnlEl = document.getElementById('ppPnl');
+    if (pnlEl) pnlEl.textContent = formatTwoDecimals(pnl);
+
+    updateProgressBar(targetQty, totalFilled);
     fillPositionForm(s);
     renderPositionSummaries(payload?.summaries || []);
   } catch {}
@@ -1614,22 +1823,56 @@ document.getElementById('executeTrade').addEventListener('click', async () => {
 });
 
 // [FIX] handler "Definir meta"
-document.getElementById('setTarget').addEventListener('click', async () => {
-  const val = Number(document.getElementById('targetQty').value);
-  if (!Number.isFinite(val) || val < 0) { alert('Valor inválido para a meta.'); return; }
-  try {
-    const resp = await fetch('/api/position-target', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ targetQty: val })
-    });
-    const out = await safeJson(resp);
-    if (!resp.ok || !out.ok) { alert('Falha ao definir meta.'); return; }
-    document.getElementById('ppTarget').textContent = out.targetQty ?? val;
-  } catch (e) {
-    alert('Erro ao definir meta: ' + (e.message || e));
-  }
-});
+async function submitTargetQty(val) {
+  const num = Number(val);
+  if (!Number.isFinite(num) || num < 0) throw new Error('Valor inválido para a meta.');
+  const resp = await fetch('/api/position-target', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ targetQty: num })
+  });
+  const out = await safeJson(resp);
+  if (!resp.ok || !out.ok) throw new Error('Falha ao definir meta.');
+  const final = out.targetQty ?? num;
+  const targetEl = document.getElementById('ppTarget');
+  if (targetEl) targetEl.textContent = formatVolumeValue(final, 6, getCurrentBaseSymbol());
+  return final;
+}
+
+const setTargetBtn = document.getElementById('setTarget');
+if (setTargetBtn) {
+  setTargetBtn.addEventListener('click', async () => {
+    const input = document.getElementById('targetQty');
+    const val = input ? Number(input.value) : NaN;
+    try {
+      const final = await submitTargetQty(val);
+      if (input) input.value = final;
+      await refreshPosition();
+    } catch (e) {
+      alert('Erro ao definir meta: ' + (e.message || e));
+    }
+  });
+}
+
+function bindMaxTargetButton(id) {
+  const btn = document.getElementById(id);
+  if (!btn) return;
+  btn.addEventListener('click', async () => {
+    const raw = Number(btn.dataset.targetQty);
+    if (!Number.isFinite(raw) || raw <= 0) return;
+    const input = document.getElementById('targetQty');
+    if (input) input.value = raw;
+    try {
+      await submitTargetQty(raw);
+      await refreshPosition();
+    } catch (e) {
+      alert('Erro ao definir meta: ' + (e.message || e));
+    }
+  });
+}
+
+bindMaxTargetButton('gateMaxBaseBtn');
+bindMaxTargetButton('mexcMaxBaseBtn');
 
 const positionSaveBtn = document.getElementById('positionSaveBtn');
 if (positionSaveBtn) {
@@ -1684,32 +1927,12 @@ if (positionDismantleBtn) {
 }
 
 // ======== Gráfico simples
-function drawProgressChart(series) {
-  const canvas = document.getElementById('progressChart');
-  const ctx = canvas.getContext('2d');
-  const W = canvas.width, H = canvas.height;
-  ctx.clearRect(0,0,W,H);
-  ctx.beginPath(); ctx.moveTo(40,H-30); ctx.lineTo(W-10,H-30); ctx.moveTo(40,H-30); ctx.lineTo(40,10); ctx.stroke();
-  if (!series.length) { ctx.fillText('Sem dados de preenchimento ainda', 60, H/2); return; }
-  const filledOf = p => {
-    if (typeof p.filledQty === 'number') return p.filledQty;
-    if (p.gate && typeof p.gate.filledQty === 'number') return p.gate.filledQty;
-    if (p.mexc && typeof p.mexc.filledQty === 'number') return p.mexc.filledQty;
-    return 0;
-  };
-  const xs = series.map(p=>p.t), ys = series.map(p=>filledOf(p));
-  const minX = Math.min(...xs), maxX = Math.max(...xs), maxY = Math.max(...ys)||1;
-  const x = (t)=> 40 + (t-minX)*(W-60)/(maxX-minX || 1);
-  const y = (v)=> (H-30) - v*(H-50)/(maxY || 1);
-  ctx.beginPath(); series.forEach((p,i)=>{ const X=x(p.t), Y=y(filledOf(p)); if(!i) ctx.moveTo(X,Y); else ctx.lineTo(X,Y); }); ctx.stroke();
-  series.forEach(p=>{ const X=x(p.t), Y=y(filledOf(p)); ctx.beginPath(); ctx.arc(X,Y,2,0,Math.PI*2); ctx.fill(); });
-}
-
 // ======== Init
 (async function init() {
   const last = localStorage.getItem('lastSymbol');
   const serverSym = await getSymbol();
   const sym = last || serverSym || 'BASE_USDT';
+  setupCardToggles();
   document.getElementById('symbolInput').value = sym;
   document.getElementById('titleSymbol').textContent = sym;
   await setSymbol(sym);


### PR DESCRIPTION
## Summary
- move the spread card to the top of the page and convert the position section into a combined progress and balance card with a progress bar
- refresh and present exchange balances in a structured way, including USDT-first display, max volume shortcuts, and automatic updates when the trading pair changes
- add a scientific notation toggle for quotes and limit displayed difference percentages to two decimal places

## Testing
- not run (frontend change)

------
https://chatgpt.com/codex/tasks/task_e_68ddd75bb220832f91d027a054b793ef