### PR TITLE
Add execution timeline logging and surface logs in UI

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -74,12 +74,75 @@
     .balance-message { font-size: 12px; color: #b00; }
     .balance-actions { margin-top: 10px; display:flex; justify-content:flex-end; }
     .quotes-card .quote-controls { margin-top: 12px; }
+    .execution-logs { display: flex; flex-direction: column; gap: 12px; }
+    .log-block { border: 1px solid #e0e0e0; border-radius: 6px; background: #fafafa; }
+    .log-block > summary { cursor: pointer; padding: 8px 12px; display: flex; flex-wrap: wrap; gap: 8px; align-items: center; font-weight: 600; font-size: 14px; }
+    .log-block > summary span.meta { font-weight: 400; font-size: 12px; color: #444; margin-left: auto; }
+    .log-block-content { padding: 10px 12px 12px; display: flex; flex-direction: column; gap: 10px; }
+    .log-metrics { display: flex; flex-wrap: wrap; gap: 10px; font-size: 12px; color: #333; }
+    .log-metrics span { background: #fff; border: 1px solid #ddd; border-radius: 4px; padding: 4px 6px; }
+    .log-timeline { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 8px; }
+    .log-step { border-left: 3px solid #bbb; padding-left: 10px; font-size: 12px; display: flex; flex-direction: column; gap: 4px; }
+    .log-step.system { border-color: #2ca02c; }
+    .log-step.calc { border-color: #9467bd; }
+    .log-step.network { border-color: #ff7f0e; }
+    .log-step.gate { border-color: #1f77b4; }
+    .log-step.mexc { border-color: #d62728; }
+    .log-step.error { border-color: #b00020; }
+    .log-step-header { display: flex; flex-wrap: wrap; justify-content: space-between; gap: 8px; font-weight: 600; }
+    .log-step-header span.times { font-weight: 400; color: #555; }
+    .log-step-body { color: #333; display: flex; flex-wrap: wrap; gap: 6px; }
+    .log-step-body span { background: #fff; border: 1px solid #ddd; border-radius: 4px; padding: 2px 4px; }
+    .log-empty { font-size: 13px; color: #666; }
   </style>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.4/dist/chart.umd.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom@2.0.1/dist/chartjs-plugin-zoom.umd.min.js"></script>
 </head>
 <body>
   <h1>Arbitragem Gate.io x MEXC — <span id="titleSymbol">BASE_USDT</span></h1>
+
+  <div class="card top" id="configCard">
+    <h3>Par &amp; Configurações</h3>
+    <div class="card-body">
+      <div style="display:flex; align-items:center; gap:8px; flex-wrap:wrap;">
+        <label class="inline" for="symbolInput">Par (BASE_QUOTE):</label>
+        <input id="symbolInput" type="text" value="BASE_USDT" class="mono" />
+        <button id="applySymbol">Usar</button>
+        <button id="autoCfg">Auto-configurar</button>
+        <span id="metaBadge" class="mono muted">meta: —</span>
+      </div>
+
+      <details style="margin-top:10px;">
+        <summary>Overrides manuais (opcional)</summary>
+        <div style="display:grid; grid-template-columns: repeat(3, minmax(180px, 1fr)); gap:10px; margin-top:10px;">
+          <div>
+            <div class="muted" style="margin-bottom:6px;"><strong>Gate</strong></div>
+            <label>priceScale <input id="ov_gate_price" type="number" step="1" class="mono" /></label><br/>
+            <label>qtyScale <input id="ov_gate_qty" type="number" step="1" class="mono" /></label><br/>
+            <label>minQty <input id="ov_gate_minqty" type="number" step="any" class="mono" /></label><br/>
+            <label>minQuote <input id="ov_gate_minquote" type="number" step="any" class="mono" /></label>
+          </div>
+          <div>
+            <div class="muted" style="margin-bottom:6px;"><strong>MEXC</strong></div>
+            <label>priceScale <input id="ov_mexc_price" type="number" step="1" class="mono" /></label><br/>
+            <label>volPrecision <input id="ov_mexc_volp" type="number" step="1" class="mono" /></label><br/>
+            <label>contractSize <input id="ov_mexc_cs" type="number" step="any" class="mono" /></label><br/>
+            <label>minContracts <input id="ov_mexc_minc" type="number" step="1" class="mono" /></label>
+          </div>
+          <div>
+            <div class="muted" style="margin-bottom:6px;"><strong>Settings</strong></div>
+            <label>margem (%) <input id="ov_set_margin" type="number" step="any" class="mono" /></label><br/>
+            <label>leverage <input id="ov_set_lev" type="number" step="any" class="mono" /></label><br/>
+            <label>Gate extra (%) <input id="ov_set_gate_extra" type="number" step="any" class="mono" /></label>
+          </div>
+        </div>
+        <div style="margin-top:10px;">
+          <button id="saveOverride">Salvar override</button>
+        </div>
+        <pre id="metaText" class="mono" style="margin-top:10px;">(meta não carregada)</pre>
+      </details>
+    </div>
+  </div>
 
   <div class="card" id="spreadCard">
     <h3>Gráfico de Spreads</h3>
@@ -128,49 +191,6 @@
           <span id="spreadFinalArb">-</span>
         </div>
       </div>
-    </div>
-  </div>
-
-  <div class="card top" id="configCard">
-    <h3>Par &amp; Configurações</h3>
-    <div class="card-body">
-      <div style="display:flex; align-items:center; gap:8px; flex-wrap:wrap;">
-        <label class="inline" for="symbolInput">Par (BASE_QUOTE):</label>
-        <input id="symbolInput" type="text" value="BASE_USDT" class="mono" />
-        <button id="applySymbol">Usar</button>
-        <button id="autoCfg">Auto-configurar</button>
-        <span id="metaBadge" class="mono muted">meta: —</span>
-      </div>
-
-      <details style="margin-top:10px;">
-        <summary>Overrides manuais (opcional)</summary>
-        <div style="display:grid; grid-template-columns: repeat(3, minmax(180px, 1fr)); gap:10px; margin-top:10px;">
-          <div>
-            <div class="muted" style="margin-bottom:6px;"><strong>Gate</strong></div>
-            <label>priceScale <input id="ov_gate_price" type="number" step="1" class="mono" /></label><br/>
-            <label>qtyScale <input id="ov_gate_qty" type="number" step="1" class="mono" /></label><br/>
-            <label>minQty <input id="ov_gate_minqty" type="number" step="any" class="mono" /></label><br/>
-            <label>minQuote <input id="ov_gate_minquote" type="number" step="any" class="mono" /></label>
-          </div>
-          <div>
-            <div class="muted" style="margin-bottom:6px;"><strong>MEXC</strong></div>
-            <label>priceScale <input id="ov_mexc_price" type="number" step="1" class="mono" /></label><br/>
-            <label>volPrecision <input id="ov_mexc_volp" type="number" step="1" class="mono" /></label><br/>
-            <label>contractSize <input id="ov_mexc_cs" type="number" step="any" class="mono" /></label><br/>
-            <label>minContracts <input id="ov_mexc_minc" type="number" step="1" class="mono" /></label>
-          </div>
-          <div>
-            <div class="muted" style="margin-bottom:6px;"><strong>Settings</strong></div>
-            <label>margem (%) <input id="ov_set_margin" type="number" step="any" class="mono" /></label><br/>
-            <label>leverage <input id="ov_set_lev" type="number" step="any" class="mono" /></label><br/>
-            <label>Gate extra (%) <input id="ov_set_gate_extra" type="number" step="any" class="mono" /></label>
-          </div>
-        </div>
-        <div style="margin-top:10px;">
-          <button id="saveOverride">Salvar override</button>
-        </div>
-        <pre id="metaText" class="mono" style="margin-top:10px;">(meta não carregada)</pre>
-      </details>
     </div>
   </div>
 
@@ -352,6 +372,13 @@
           <button id="refreshBalances">Atualizar saldos</button>
         </div>
       </div>
+    </div>
+  </div>
+
+  <div class="card" id="executionLogsCard">
+    <h3>Logs de execução de ordens</h3>
+    <div class="card-body">
+      <div id="executionLogs" class="execution-logs"></div>
     </div>
   </div>
 

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -73,6 +73,186 @@ function formatTwoDecimals(value) {
   return value.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 2 });
 }
 
+function formatDuration(ms) {
+  const num = Number(ms);
+  if (!Number.isFinite(num) || num < 0) return '—';
+  if (num < 1) return `${(num * 1000).toFixed(0)} µs`;
+  if (num < 1000) return `${num.toFixed(0)} ms`;
+  const seconds = num / 1000;
+  if (seconds < 60) return `${seconds.toFixed(seconds < 10 ? 2 : 1)} s`;
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds - minutes * 60;
+  if (minutes < 60) return `${minutes}m ${remainingSeconds.toFixed(1)}s`;
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  return `${hours}h ${remainingMinutes}m ${Math.round(remainingSeconds)}s`;
+}
+
+function formatLogValue(value) {
+  if (value === undefined || value === null) return '—';
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) return String(value);
+    const abs = Math.abs(value);
+    if (abs === 0) return '0';
+    if (abs >= 1000) return value.toLocaleString('en-US', { maximumFractionDigits: 2 });
+    if (abs >= 1) return value.toFixed(2);
+    if (abs >= 0.01) return value.toFixed(4);
+    return value.toExponential(2);
+  }
+  if (typeof value === 'boolean') return value ? 'sim' : 'não';
+  if (Array.isArray(value)) return value.map(formatLogValue).join(', ');
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === 'object') {
+    try { return JSON.stringify(value); }
+    catch { return String(value); }
+  }
+  return String(value);
+}
+
+function resolveTimelineTimestamp(entry) {
+  if (!entry) return NaN;
+  if (Number.isFinite(entry.ts)) return Number(entry.ts);
+  if (Number.isFinite(entry.timestamp)) return Number(entry.timestamp);
+  if (entry.iso) {
+    const parsed = Date.parse(entry.iso);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return NaN;
+}
+
+function renderExecutionLogs(historyItems) {
+  const container = document.getElementById('executionLogs');
+  if (!container) return;
+  container.innerHTML = '';
+
+  if (!Array.isArray(historyItems) || historyItems.length === 0) {
+    const empty = document.createElement('div');
+    empty.className = 'log-empty';
+    empty.textContent = 'Nenhuma execução registrada ainda.';
+    container.appendChild(empty);
+    return;
+  }
+
+  const maxItems = Math.min(historyItems.length, 6);
+  for (let i = 0; i < maxItems; i += 1) {
+    const item = historyItems[i];
+    const timeline = Array.isArray(item?.timeline) ? item.timeline : [];
+    const startMsRaw = Number(item?.timelineMeta?.startMs);
+    const firstTs = resolveTimelineTimestamp(timeline[0]);
+    const startMs = Number.isFinite(startMsRaw) ? startMsRaw : firstTs;
+    const endTs = resolveTimelineTimestamp(timeline[timeline.length - 1]);
+    const totalMs = Number.isFinite(startMs) && Number.isFinite(endTs) ? Math.max(0, endTs - startMs) : null;
+    const clientLatency = Number(item?.timelineMeta?.clientLatencyMs ?? timeline[0]?.details?.clientLatencyMs);
+
+    const gateApiEntry = timeline.find((entry) => entry?.category === 'gate' && entry?.details && entry.details.durationMs != null && /resposta/i.test(entry.label || ''));
+    const mexcApiEntry = timeline.find((entry) => entry?.category === 'mexc' && entry?.details && entry.details.durationMs != null && /resposta/i.test(entry.label || ''));
+    const gateFillEntry = timeline.find((entry) => entry?.category === 'gate' && /preenchida/i.test(entry?.label || ''));
+    const mexcFillEntry = timeline.find((entry) => entry?.category === 'mexc' && /preenchida/i.test(entry?.label || ''));
+
+    const gateFillMs = Number.isFinite(startMs) && gateFillEntry ? Math.max(0, resolveTimelineTimestamp(gateFillEntry) - startMs) : null;
+    const mexcFillMs = Number.isFinite(startMs) && mexcFillEntry ? Math.max(0, resolveTimelineTimestamp(mexcFillEntry) - startMs) : null;
+
+    const detailsEl = document.createElement('details');
+    detailsEl.className = 'log-block';
+    if (i === 0) detailsEl.open = true;
+
+    const summary = document.createElement('summary');
+    const summaryTitle = document.createElement('span');
+    summaryTitle.textContent = `${item?.localId || '-'} • ${item?.sentido || item?.mode || '-'} • ${item?.status || '-'}`;
+    summary.appendChild(summaryTitle);
+    const summaryMeta = document.createElement('span');
+    summaryMeta.className = 'meta';
+    summaryMeta.textContent = totalMs != null ? `Total ${formatDuration(totalMs)}` : 'Total —';
+    summary.appendChild(summaryMeta);
+    detailsEl.appendChild(summary);
+
+    const content = document.createElement('div');
+    content.className = 'log-block-content';
+
+    const metrics = document.createElement('div');
+    metrics.className = 'log-metrics';
+    const metricsData = [
+      ['Início', item?.createdAt || '-'],
+      ['Gate ID', item?.gateOrderId || '-'],
+      ['MEXC ID', item?.mexcOrderId || '-'],
+      ['Latência clique → servidor', Number.isFinite(clientLatency) ? formatDuration(clientLatency) : '—'],
+      ['Tempo total', totalMs != null ? formatDuration(totalMs) : '—'],
+      ['Gate API', gateApiEntry?.details?.durationMs != null ? formatDuration(gateApiEntry.details.durationMs) : '—'],
+      ['MEXC API', mexcApiEntry?.details?.durationMs != null ? formatDuration(mexcApiEntry.details.durationMs) : '—'],
+      ['Gate preenchida', gateFillMs != null ? formatDuration(gateFillMs) : '—'],
+      ['MEXC preenchida', mexcFillMs != null ? formatDuration(mexcFillMs) : '—']
+    ];
+    metricsData.forEach(([label, value]) => {
+      const span = document.createElement('span');
+      span.textContent = `${label}: ${value}`;
+      metrics.appendChild(span);
+    });
+    content.appendChild(metrics);
+
+    const list = document.createElement('ol');
+    list.className = 'log-timeline';
+
+    if (!timeline.length) {
+      const emptyStep = document.createElement('div');
+      emptyStep.className = 'log-empty';
+      emptyStep.textContent = 'Nenhum evento registrado.';
+      content.appendChild(emptyStep);
+    } else {
+      timeline.forEach((entry, idx) => {
+        const ts = resolveTimelineTimestamp(entry);
+        const prevTs = idx === 0 ? startMs : resolveTimelineTimestamp(timeline[idx - 1]);
+        const elapsed = Number.isFinite(startMs) && Number.isFinite(ts) ? Math.max(0, ts - startMs) : null;
+        const delta = Number.isFinite(prevTs) && Number.isFinite(ts) ? Math.max(0, ts - prevTs) : null;
+
+        const li = document.createElement('li');
+        li.className = 'log-step';
+        const cat = entry?.category || 'system';
+        li.classList.add(cat);
+        if (cat === 'error') li.classList.add('error');
+
+        const header = document.createElement('div');
+        header.className = 'log-step-header';
+        const labelSpan = document.createElement('span');
+        labelSpan.textContent = entry?.label || '(sem descrição)';
+        header.appendChild(labelSpan);
+        const timesSpan = document.createElement('span');
+        timesSpan.className = 'times';
+        const elapsedText = elapsed != null ? formatDuration(elapsed) : '—';
+        const deltaText = delta != null ? formatDuration(delta) : '—';
+        timesSpan.textContent = `${elapsedText} (Δ ${deltaText})`;
+        header.appendChild(timesSpan);
+        li.appendChild(header);
+
+        const body = document.createElement('div');
+        body.className = 'log-step-body';
+        const details = entry?.details;
+        if (details && typeof details === 'object' && Object.keys(details).length) {
+          Object.entries(details).forEach(([key, value]) => {
+            const span = document.createElement('span');
+            span.textContent = `${key}: ${formatLogValue(value)}`;
+            body.appendChild(span);
+          });
+        } else if (details != null) {
+          const span = document.createElement('span');
+          span.textContent = formatLogValue(details);
+          body.appendChild(span);
+        }
+        if (!body.childNodes.length) {
+          const span = document.createElement('span');
+          span.textContent = 'Sem detalhes adicionais';
+          body.appendChild(span);
+        }
+        li.appendChild(body);
+        list.appendChild(li);
+      });
+      content.appendChild(list);
+    }
+
+    detailsEl.appendChild(content);
+    container.appendChild(detailsEl);
+  }
+}
+
 function setBalanceValue(id, value) {
   const el = document.getElementById(id);
   if (!el) return;
@@ -1475,6 +1655,7 @@ async function refreshHistory() {
 
       tbody.appendChild(tr);
     });
+    renderExecutionLogs(hist);
   } catch {}
 }
 setInterval(refreshHistory, 5000); refreshHistory();
@@ -1798,9 +1979,10 @@ document.getElementById('executeTrade').addEventListener('click', async () => {
     }
 
     document.getElementById('status').textContent = 'Executando...';
+    const executePayload = { mode, levels: getSelectedLevelsPayload(), clientSentAt: Date.now() };
     const r = await fetch('/api/execute-trade', {
       method: 'POST', headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ mode, levels: getSelectedLevelsPayload() })
+      body: JSON.stringify(executePayload)
     });
     const out = await safeJson(r);
     if (r.ok) {

--- a/server.js
+++ b/server.js
@@ -28,6 +28,66 @@ const SERIES_LIMIT = 500;
 const TRADES_LIMIT = 500;
 const POSITION_SUMMARY_LIMIT = 50;
 
+function normalizeTimelineDetails(details) {
+  if (details === undefined || details === null) return {};
+  if (typeof details !== 'object' || Array.isArray(details)) {
+    return { value: details };
+  }
+  const out = {};
+  for (const [key, value] of Object.entries(details)) {
+    if (value === undefined) continue;
+    out[key] = value;
+  }
+  return out;
+}
+
+function createTimelineRecorder(clientSentAt) {
+  const startMs = Date.now();
+  const entries = [];
+  const clientLatencyMs = Number.isFinite(clientSentAt) ? Math.max(0, startMs - clientSentAt) : null;
+  const push = (category, label, details) => {
+    const now = Date.now();
+    entries.push({
+      ts: now,
+      iso: new Date(now).toISOString(),
+      category,
+      label,
+      details: normalizeTimelineDetails(details)
+    });
+    return now;
+  };
+  return { startMs, entries, clientLatencyMs, push };
+}
+
+function attachTimeline(item, recorder) {
+  if (!item || !recorder) return;
+  item.timeline = recorder.entries;
+  item.timelineMeta = { startMs: recorder.startMs };
+  if (Number.isFinite(recorder.clientLatencyMs)) {
+    item.timelineMeta.clientLatencyMs = recorder.clientLatencyMs;
+  }
+}
+
+function appendTimelineEntry(item, category, label, details) {
+  if (!item) return null;
+  if (!Array.isArray(item.timeline)) item.timeline = [];
+  const now = Date.now();
+  item.timeline.push({
+    ts: now,
+    iso: new Date(now).toISOString(),
+    category,
+    label,
+    details: normalizeTimelineDetails(details)
+  });
+  if (!item.timelineMeta || typeof item.timelineMeta !== 'object') {
+    item.timelineMeta = { startMs: item.timeline[0]?.ts ?? now };
+  } else if (!Number.isFinite(Number(item.timelineMeta.startMs))) {
+    item.timelineMeta.startMs = item.timeline[0]?.ts ?? now;
+  }
+  item.timelineMeta.lastTs = now;
+  return now;
+}
+
 function createEmptyPositionState() {
   return {
     symbol: currentSymbol || null,
@@ -1586,37 +1646,128 @@ app.post('/api/precheck', async (req, res) => {
 
 // ===== Execução (respeita modo open/close)
 app.post('/api/execute-trade', async (req, res) => {
+  const timelineRecorder = createTimelineRecorder(Number(req.body?.clientSentAt));
   try {
     const mode = (req.body?.mode === 'close') ? 'close' : 'open';
     const symbol = currentSymbol;
+    const baseCurrency = symbol.split('_')[0] || null;
+    const requestedLevels = req.body?.levels || {};
+
+    const abort = (statusCode, payload, logDetails) => {
+      timelineRecorder.push('system', 'Execução abortada', logDetails || { reason: payload?.error || 'Erro' });
+      return res.status(statusCode).json(payload);
+    };
+
+    timelineRecorder.push('system', 'Solicitação recebida', {
+      mode,
+      symbol,
+      requestedLevels,
+      clientLatencyMs: timelineRecorder.clientLatencyMs
+    });
+
+    const metaStart = Date.now();
     const meta = await getMergedMeta(symbol);
+    timelineRecorder.push('calc', 'Metadados carregados', {
+      durationMs: Date.now() - metaStart,
+      gate: {
+        priceScale: meta?.gate?.priceScale,
+        qtyScale: meta?.gate?.qtyScale,
+        minQuote: meta?.gate?.minQuote
+      },
+      mexc: {
+        priceScale: meta?.mexc?.priceScale,
+        volPrecision: meta?.mexc?.volPrecision,
+        contractSize: meta?.mexc?.contractSize,
+        minContracts: meta?.mexc?.minContracts
+      },
+      settings: {
+        marginPct: meta?.settings?.marginPct,
+        leverage: meta?.settings?.leverage,
+        gateOpenExtraPct: meta?.settings?.gateOpenExtraPct
+      }
+    });
 
-    const g = await axios.get(`https://api.gateio.ws/api/v4/spot/order_book?currency_pair=${symbol}`);
-    const m = await axios.get(`https://contract.mexc.com/api/v1/contract/depth/${symbol}?limit=5`);
+    let gateAsks = [], gateBids = [];
+    const gateBookStart = Date.now();
+    timelineRecorder.push('network', 'Consultando livro de ordens Gate', { side: mode === 'open' ? 'asks' : 'bids' });
+    try {
+      const g = await axios.get(`https://api.gateio.ws/api/v4/spot/order_book?currency_pair=${symbol}`);
+      gateAsks = g.data?.asks || [];
+      gateBids = g.data?.bids || [];
+      timelineRecorder.push('gate', 'Livro Gate recebido', {
+        durationMs: Date.now() - gateBookStart,
+        asks: gateAsks.length,
+        bids: gateBids.length
+      });
+    } catch (err) {
+      timelineRecorder.push('error', 'Falha ao obter livro Gate', {
+        durationMs: Date.now() - gateBookStart,
+        message: err?.response?.data || err?.message || err
+      });
+      throw err;
+    }
 
-    const gateAsks = g.data?.asks || [];
-    const gateBids = g.data?.bids || [];
-    const mexcBids = m.data?.data?.bids || [];
-    const mexcAsks = m.data?.data?.asks || [];
+    let mexcBids = [], mexcAsks = [];
+    const mexcBookStart = Date.now();
+    timelineRecorder.push('network', 'Consultando livro de ordens MEXC', { side: mode === 'open' ? 'bids' : 'asks' });
+    try {
+      const m = await axios.get(`https://contract.mexc.com/api/v1/contract/depth/${symbol}?limit=5`);
+      mexcBids = m.data?.data?.bids || [];
+      mexcAsks = m.data?.data?.asks || [];
+      timelineRecorder.push('mexc', 'Livro MEXC recebido', {
+        durationMs: Date.now() - mexcBookStart,
+        bids: mexcBids.length,
+        asks: mexcAsks.length
+      });
+    } catch (err) {
+      timelineRecorder.push('error', 'Falha ao obter livro MEXC', {
+        durationMs: Date.now() - mexcBookStart,
+        message: err?.response?.data || err?.message || err
+      });
+      throw err;
+    }
 
-    const selections = req.body?.levels || {};
-    const openSelection = normalizeLevelSelection(selections.open, gateAsks.length, mexcBids.length);
-    const closeSelection = normalizeLevelSelection(selections.close, gateBids.length, mexcAsks.length);
+    const openSelection = normalizeLevelSelection(requestedLevels.open, gateAsks.length, mexcBids.length);
+    const closeSelection = normalizeLevelSelection(requestedLevels.close, gateBids.length, mexcAsks.length);
     const selectedLevels = mode === 'open' ? openSelection : closeSelection;
 
     const gateSide = mode === 'open' ? gateAsks : gateBids;
     const mexcSide = mode === 'open' ? mexcBids : mexcAsks;
 
+    timelineRecorder.push('calc', 'Seleções normalizadas', {
+      mode,
+      selectedLevels,
+      rawSelections: requestedLevels,
+      gateDepth: gateSide.length,
+      mexcDepth: mexcSide.length
+    });
+
     if (!selectedLevels.length || !gateSide.length || !mexcSide.length) {
-      return res.status(400).json({ error: 'Profundidade insuficiente para as seleções escolhidas.' });
+      return abort(400, { error: 'Profundidade insuficiente para as seleções escolhidas.' }, {
+        reason: 'Profundidade insuficiente',
+        selectedLevels
+      });
     }
 
     const gateAgg = aggregateGateLevels(selectedLevels, gateSide);
     const mexcAgg = aggregateMexcLevels(selectedLevels, mexcSide, meta.mexc.contractSize);
 
     if (gateAgg.totalBase <= 0 || mexcAgg.totalBase <= 0 || mexcAgg.totalContracts <= 0) {
-      return res.status(400).json({ error: 'Profundidade insuficiente para as seleções escolhidas.' });
+      return abort(400, { error: 'Profundidade insuficiente para as seleções escolhidas.' }, {
+        reason: 'Agregação sem volume',
+        gateTotalBase: gateAgg.totalBase,
+        mexcTotalBase: mexcAgg.totalBase,
+        mexcContracts: mexcAgg.totalContracts
+      });
     }
+
+    timelineRecorder.push('calc', 'Agregação concluída', {
+      gateAvgPrice: gateAgg.avgPrice,
+      gateTotalBase: gateAgg.totalBase,
+      mexcAvgPrice: mexcAgg.avgPrice,
+      mexcTotalBase: mexcAgg.totalBase,
+      mexcContracts: mexcAgg.totalContracts
+    });
 
     const marginPct = Number(meta.settings.marginPct || 0);
     const baseGate = gateAgg.avgPrice;
@@ -1628,6 +1779,14 @@ app.post('/api/execute-trade', async (req, res) => {
     let mexcPrice = (mode === 'open')
       ? baseMexc * (1 + (marginPct / 100))
       : baseMexc * (1 - (marginPct / 100));
+
+    timelineRecorder.push('calc', 'Preços ajustados', {
+      gateBase: baseGate,
+      mexcBase: baseMexc,
+      gatePrice,
+      mexcPrice,
+      marginPct
+    });
 
     let gateBaseAvail = gateAgg.totalBase;
     const mexcContractsAvail = mexcAgg.totalContracts;
@@ -1650,8 +1809,22 @@ app.post('/api/execute-trade', async (req, res) => {
     let gateBalances = null;
     let availableToClose = null;
     if (mode === 'close') {
-      gateBalances = await getGateBalances(symbol);
-      const baseCurrency = symbol.split('_')[0];
+      const closeBalStart = Date.now();
+      timelineRecorder.push('network', 'Consultando saldo Gate para fechamento', { currency: baseCurrency });
+      try {
+        gateBalances = await getGateBalances(symbol);
+        timelineRecorder.push('gate', 'Saldo Gate obtido para fechamento', {
+          durationMs: Date.now() - closeBalStart,
+          baseAvailable: baseCurrency ? Number(gateBalances?.[baseCurrency]?.available ?? 0) : null,
+          usdtAvailable: Number(gateBalances?.USDT?.available ?? 0)
+        });
+      } catch (err) {
+        timelineRecorder.push('error', 'Falha ao consultar saldo Gate para fechamento', {
+          durationMs: Date.now() - closeBalStart,
+          message: err?.response?.data || err?.message || err
+        });
+        throw err;
+      }
       const baseAvail = Number(gateBalances?.[baseCurrency]?.available || 0);
       const remQty = Math.min(baseAvail, positionState.gate.filledQty);
       availableToClose = remQty;
@@ -1660,40 +1833,47 @@ app.post('/api/execute-trade', async (req, res) => {
 
     let maxBaseQty = Math.min(gateBaseAvail, mexcBaseAvail);
     if (!Number.isFinite(maxBaseQty) || maxBaseQty <= 0) {
-      return res.status(400).json({ error: 'Profundidade insuficiente após ajustes.' });
+      return abort(400, { error: 'Profundidade insuficiente após ajustes.' }, {
+        reason: 'maxBaseQty inválido',
+        maxBaseQty
+      });
     }
 
     let contracts = Math.min(mexcContractsAvail, maxBaseQty / cs);
     contracts = normalizeContracts(floorContracts(contracts));
 
     if (contracts <= 0) {
-      return res.status(400).json({ error: 'Contratos indisponíveis nas seleções escolhidas.' });
+      return abort(400, { error: 'Contratos indisponíveis nas seleções escolhidas.' }, { reason: 'contracts <= 0' });
     }
 
     if (mode === 'open' && positionState.targetQty > 0) {
       const remainingBase = Math.max(positionState.targetQty - positionState.gate.filledQty, 0);
       const remainingContracts = normalizeContracts(floorContracts(remainingBase / cs));
       if (remainingContracts <= 0) {
-        return res.status(400).json({ error: 'Meta de posição já atingida.' });
+        return abort(400, { error: 'Meta de posição já atingida.' }, { reason: 'target_reached' });
       }
       if (contracts > remainingContracts) contracts = remainingContracts;
     } else if (mode === 'close') {
       const remainingContracts = normalizeContracts(floorContracts(positionState.gate.filledQty / cs));
       if (remainingContracts <= 0 || (availableToClose != null && availableToClose <= 0)) {
-        return res.status(400).json({ error: 'Sem quantidade disponível para fechar.' });
+        return abort(400, { error: 'Sem quantidade disponível para fechar.' }, { reason: 'no_position' });
       }
       if (contracts > remainingContracts) contracts = remainingContracts;
     }
 
     if (contracts < minContracts) {
-      return res.status(400).json({ error: `Volume abaixo do mínimo de contratos (${minContracts}).` });
+      return abort(400, { error: `Volume abaixo do mínimo de contratos (${minContracts}).` }, {
+        reason: 'min_contracts',
+        contracts,
+        minContracts
+      });
     }
 
     let finalBaseQtyRaw = contracts * cs;
     let rounded = applyRoundingMeta(gatePrice, mexcPrice, finalBaseQtyRaw, meta);
     let adjustedContracts = normalizeContracts(floorContracts(rounded.q / cs));
     if (adjustedContracts <= 0) {
-      return res.status(400).json({ error: 'Quantidade arredondada resultou em zero.' });
+      return abort(400, { error: 'Quantidade arredondada resultou em zero.' }, { reason: 'rounded_zero' });
     }
     if (adjustedContracts < contracts) {
       contracts = adjustedContracts;
@@ -1703,20 +1883,80 @@ app.post('/api/execute-trade', async (req, res) => {
     contracts = normalizeContracts(contracts);
 
     if (minContracts > 0 && contracts < minContracts) {
-      return res.status(400).json({ error: `Volume abaixo do mínimo de contratos (${minContracts}).` });
+      return abort(400, { error: `Volume abaixo do mínimo de contratos (${minContracts}).` }, {
+        reason: 'min_contracts_post_round',
+        contracts,
+        minContracts
+      });
     }
 
     const gateOrderBaseQty = computeGateOrderQty(rounded.q, meta, mode);
 
+    timelineRecorder.push('calc', 'Quantidades calculadas', {
+      contracts,
+      contractSize: cs,
+      finalBaseQty: rounded.q,
+      gateOrderBaseQty,
+      gatePrice: rounded.pg,
+      mexcPrice: rounded.pm
+    });
+
     const minQuote = Number(meta.gate.minQuote || 0);
     if (minQuote > 0 && gateOrderBaseQty * rounded.pg < minQuote) {
-      return res.status(400).json({ error: `Mínimo da Gate não atendido (>= ${minQuote} USDT). Tente aumentar contratos.` });
+      return abort(400, { error: `Mínimo da Gate não atendido (>= ${minQuote} USDT). Tente aumentar contratos.` }, {
+        reason: 'min_quote',
+        minQuote,
+        gateQuote: gateOrderBaseQty * rounded.pg
+      });
     }
 
-    const [gateBalancesFinal, mexcBal] = await Promise.all([
-      gateBalances ? Promise.resolve(gateBalances) : getGateBalances(symbol),
-      getMexcAvailableUSDT(symbol)
-    ]);
+    const gateBalancePromise = (async () => {
+      if (gateBalances) {
+        timelineRecorder.push('gate', 'Saldo Gate reutilizado', {
+          usdtAvailable: Number(gateBalances?.USDT?.available ?? 0),
+          baseAvailable: baseCurrency ? Number(gateBalances?.[baseCurrency]?.available ?? 0) : null
+        });
+        return gateBalances;
+      }
+      const start = Date.now();
+      timelineRecorder.push('network', 'Consultando saldo Gate', { currency: baseCurrency });
+      try {
+        const result = await getGateBalances(symbol);
+        timelineRecorder.push('gate', 'Saldo Gate obtido', {
+          durationMs: Date.now() - start,
+          usdtAvailable: Number(result?.USDT?.available ?? 0),
+          baseAvailable: baseCurrency ? Number(result?.[baseCurrency]?.available ?? 0) : null
+        });
+        return result;
+      } catch (err) {
+        timelineRecorder.push('error', 'Falha ao consultar saldo Gate', {
+          durationMs: Date.now() - start,
+          message: err?.response?.data || err?.message || err
+        });
+        throw err;
+      }
+    })();
+
+    const mexcBalancePromise = (async () => {
+      const start = Date.now();
+      timelineRecorder.push('network', 'Consultando saldo MEXC', {});
+      try {
+        const result = await getMexcAvailableUSDT(symbol);
+        timelineRecorder.push('mexc', 'Saldo MEXC obtido', {
+          durationMs: Date.now() - start,
+          availableUSDT: result?.availableUSDT ?? null
+        });
+        return result;
+      } catch (err) {
+        timelineRecorder.push('error', 'Falha ao consultar saldo MEXC', {
+          durationMs: Date.now() - start,
+          message: err?.response?.data || err?.message || err
+        });
+        throw err;
+      }
+    })();
+
+    const [gateBalancesFinal, mexcBal] = await Promise.all([gateBalancePromise, mexcBalancePromise]);
     gateBalances = gateBalancesFinal;
 
     const leverage = Number(meta.settings.leverage) || 1;
@@ -1727,35 +1967,54 @@ app.post('/api/execute-trade', async (req, res) => {
 
     if (mode === 'open') {
       if (mexcBal.availableUSDT == null || mexcBal.availableUSDT < requiredMexcUSDT) {
-        return res.status(400).json({
+        return abort(400, {
           error: 'Saldo MEXC insuficiente',
           requiredUSDT: Number(requiredMexcUSDT.toFixed(6)),
+          availableUSDT: mexcBal.availableUSDT
+        }, {
+          reason: 'mexc_balance',
+          requiredUSDT: requiredMexcUSDT,
           availableUSDT: mexcBal.availableUSDT
         });
       }
     }
 
+    let neededGateUSDT = null;
     if (mode === 'open') {
-      const neededGateUSDT = rounded.pg * gateOrderBaseQty;
+      neededGateUSDT = rounded.pg * gateOrderBaseQty;
       const gateUSDTAvail = Number(gateBalances?.USDT?.available || 0);
       if (gateUSDTAvail < neededGateUSDT) {
-        return res.status(400).json({
+        return abort(400, {
           error: 'Saldo Gate USDT insuficiente',
           requiredUSDT: Number(neededGateUSDT.toFixed(6)),
+          availableUSDT: gateUSDTAvail
+        }, {
+          reason: 'gate_usdt_insuficiente',
+          requiredUSDT: neededGateUSDT,
           availableUSDT: gateUSDTAvail
         });
       }
     } else {
-      const baseCurrency = symbol.split('_')[0];
       const gateBaseAvailable = Number(gateBalances?.[baseCurrency]?.available || 0);
       if (gateBaseAvailable < gateOrderBaseQty) {
-        return res.status(400).json({
+        return abort(400, {
           error: `Saldo Gate ${baseCurrency} insuficiente`,
           requiredBase: Number(gateOrderBaseQty.toFixed(meta.gate.qtyScale)),
+          availableBase: gateBaseAvailable
+        }, {
+          reason: 'gate_base_insuficiente',
+          requiredBase: gateOrderBaseQty,
           availableBase: gateBaseAvailable
         });
       }
     }
+
+    timelineRecorder.push('calc', 'Checagens de saldo concluídas', {
+      requiredMexcUSDT,
+      mexcAvailableUSDT: mexcBal.availableUSDT,
+      neededGateUSDT,
+      mode
+    });
 
     console.log('[EXECUTAR] Modo:', mode);
     console.log('[EXECUTAR] Preço Gate:', rounded.pg);
@@ -1782,37 +2041,69 @@ app.post('/api/execute-trade', async (req, res) => {
       gateStatus: 'creating', mexcStatus: 'creating',
       status: 'creating'
     };
+
+    attachTimeline(histItem, timelineRecorder);
+    timelineRecorder.push('system', 'Histórico criado', {
+      localId,
+      volume: Number(histItem.volume),
+      contracts,
+      gateOrderBaseQty
+    });
+
     orderHistory.unshift(histItem);
     try { db.saveHistoryItem(histItem); } catch (e) { console.warn('[SQLite] save history (create):', e?.message || e); }
 
     // Gate: open=buy | close=sell
     let gateOk = false;
+    const gateSideType = (mode === 'open') ? 'buy' : 'sell';
+    const gatePriceStr = String(rounded.pg.toFixed(meta.gate.priceScale));
+    const gateQtyStr = String(gateOrderBaseQty.toFixed(meta.gate.qtyScale));
+    timelineRecorder.push('gate', 'Enviando ordem Gate', {
+      side: gateSideType,
+      price: Number(gatePriceStr),
+      amount: Number(gateQtyStr)
+    });
+    const gateSendStart = Date.now();
     try {
-      const side = (mode === 'open') ? 'buy' : 'sell';
       const go = await placeGateOrderSdk(
         symbol,
-        side,
-        String(rounded.pg.toFixed(meta.gate.priceScale)),
-        String(gateOrderBaseQty.toFixed(meta.gate.qtyScale))
+        gateSideType,
+        gatePriceStr,
+        gateQtyStr
       );
       histItem.gateOrderId = (go?.id != null) ? String(go.id) : null;
-      const gateQtyStr = String(gateOrderBaseQty.toFixed(meta.gate.qtyScale));
       histItem.gateOrderVolume = gateQtyStr;
       histItem.gateOrderBaseQty = Number(gateQtyStr);
       gateOk = !!histItem.gateOrderId;
       histItem.gateStatus = gateOk ? 'open' : 'error';
+      timelineRecorder.push('gate', 'Resposta Gate', {
+        durationMs: Date.now() - gateSendStart,
+        orderId: histItem.gateOrderId,
+        success: gateOk
+      });
     } catch (e) {
       console.error('[ERRO AO ENVIAR GATE]:', e.response?.data || e.message);
       histItem.gateStatus = 'error';
+      timelineRecorder.push('error', 'Erro ao enviar ordem Gate', {
+        durationMs: Date.now() - gateSendStart,
+        message: e.response?.data || e.message || e
+      });
     }
 
     // MEXC: open=3 | close=2
     let mexcOk = false;
+    const sideCode = (mode === 'open') ? 3 : 2;
+    const mexcPriceNum = Number(rounded.pm.toFixed(meta.mexc.priceScale));
+    timelineRecorder.push('mexc', 'Enviando ordem MEXC', {
+      sideCode,
+      price: mexcPriceNum,
+      contracts
+    });
+    const mexcSendStart = Date.now();
     try {
-      const sideCode = (mode === 'open') ? 3 : 2;
       const mres = await mexcSubmitOrder(
         symbol,
-        Number(rounded.pm.toFixed(meta.mexc.priceScale)),
+        mexcPriceNum,
         contracts,
         meta.settings.leverage,
         sideCode,
@@ -1825,13 +2116,33 @@ app.post('/api/execute-trade', async (req, res) => {
         console.error('[MEXC SDK] falhou:', mres?.error || mres);
       }
       histItem.mexcStatus = mexcOk ? 'open' : 'error';
+      timelineRecorder.push('mexc', 'Resposta MEXC', {
+        durationMs: Date.now() - mexcSendStart,
+        orderId: histItem.mexcOrderId,
+        success: mexcOk
+      });
     } catch (e) {
       console.error('[ERRO AO ENVIAR MEXC]:', e?.message || e);
       histItem.mexcStatus = 'error';
+      timelineRecorder.push('error', 'Erro ao enviar ordem MEXC', {
+        durationMs: Date.now() - mexcSendStart,
+        message: e?.message || e
+      });
     }
 
     histItem.status = gateOk && mexcOk ? 'open' : gateOk && !mexcOk ? 'mexc_error' : !gateOk && mexcOk ? 'gate_error' : 'error';
+    timelineRecorder.push('system', 'Status após criação', {
+      status: histItem.status,
+      gateStatus: histItem.gateStatus,
+      mexcStatus: histItem.mexcStatus
+    });
+
     histItem.executedAt = nowBR();
+    timelineRecorder.push('system', 'Execução finalizada', {
+      status: histItem.status,
+      totalDurationMs: Date.now() - timelineRecorder.startMs
+    });
+
     try { db.saveHistoryItem(histItem); } catch (e) { console.warn('[SQLite] save history (update):', e?.message || e); }
 
     res.json({
@@ -1846,6 +2157,9 @@ app.post('/api/execute-trade', async (req, res) => {
       status: histItem.status
     });
   } catch (e) {
+    timelineRecorder.push('error', 'Falha na execução', {
+      message: e?.response?.data || e?.message || e
+    });
     console.error('[ERRO /api/execute-trade]:', e.response?.data || e.message);
     res.status(500).json({ error: 'Erro ao executar ordens.' });
   }
@@ -2151,6 +2465,15 @@ async function pollOpenOrders() {
     if (mIsFilled) item.mexcStatus = 'filled';
     else if (item.mexcStatus === 'creating') item.mexcStatus = 'open';
 
+    if (item.timeline) {
+      if (prevGateStatus === 'creating' && item.gateStatus === 'open') {
+        appendTimelineEntry(item, 'gate', 'Ordem Gate confirmada', { status: item.gateStatus });
+      }
+      if (prevMexcStatus === 'creating' && item.mexcStatus === 'open') {
+        appendTimelineEntry(item, 'mexc', 'Ordem MEXC confirmada', { status: item.mexcStatus });
+      }
+    }
+
     if (gIsFilled && mIsFilled) {
       item.status = 'filled';
       item.filledAt = nowBR();
@@ -2174,6 +2497,32 @@ async function pollOpenOrders() {
       item.status = 'mexc_filled';
     } else {
       item.status = 'open';
+    }
+
+    if (item.timeline) {
+      if (item.gateStatus === 'filled' && prevGateStatus !== 'filled') {
+        appendTimelineEntry(item, 'gate', 'Ordem Gate preenchida', {
+          filledQty: totalGateFilled || Number(item.volume),
+          avgPrice: gAvg,
+          status: item.gateStatus
+        });
+      }
+      if (item.mexcStatus === 'filled' && prevMexcStatus !== 'filled') {
+        const contractSize = Number(item.metaUsed?.mexc?.contractSize || 1);
+        appendTimelineEntry(item, 'mexc', 'Ordem MEXC preenchida', {
+          filledContracts: totalMexcFilled || Number(item.mexcOrderContracts ?? 0),
+          baseFilled: contractSize * (totalMexcFilled || Number(item.mexcOrderContracts ?? 0)),
+          avgPrice: mAvg,
+          status: item.mexcStatus
+        });
+      }
+      if (item.status === 'filled' && prevStatus !== 'filled') {
+        appendTimelineEntry(item, 'system', 'Execução simultânea concluída', { status: item.status });
+      } else if (item.status === 'gate_filled' && prevStatus !== 'gate_filled') {
+        appendTimelineEntry(item, 'system', 'Aguardando preenchimento MEXC', { status: item.status });
+      } else if (item.status === 'mexc_filled' && prevStatus !== 'mexc_filled') {
+        appendTimelineEntry(item, 'system', 'Aguardando preenchimento Gate', { status: item.status });
+      }
     }
 
     if (


### PR DESCRIPTION
## Summary
- move the pair configuration card to the top of the dashboard and introduce a dedicated execution logs card
- render detailed execution timelines on the client, including duration formatting and client-side timestamps, and bind the history table to the new log view
- instrument the execute-trade flow and polling loop to capture timeline events, store them with each order, and expose broker/API timing information

## Testing
- node --check server.js
- node --check public/scripts.js

------
https://chatgpt.com/codex/tasks/task_e_68df396c56cc832fb8820e9845954df0