### PR TITLE
Add residual guard and manual history management

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -35,6 +35,7 @@ module.exports = {
   // Políticas de execução (opcional). Você já usa a margem de 10%:
   execution: {
     marginPct: 10, // % de distância para evitar que a ordem seja consumida imediatamente
-    gateOpenExtraPct: 0 // % adicional aplicado apenas às ordens de abertura enviadas para a Gate
+    gateOpenExtraPct: 0, // % adicional aplicado apenas às ordens de abertura enviadas para a Gate
+    minCloseResidualQuote: 4 // valor mínimo (USDT) a manter na posição ao fechar se não der para zerar tudo
   }
 };

--- a/public/index.html
+++ b/public/index.html
@@ -133,7 +133,10 @@
             <div class="muted" style="margin-bottom:6px;"><strong>Settings</strong></div>
             <label>margem (%) <input id="ov_set_margin" type="number" step="any" class="mono" /></label><br/>
             <label>leverage <input id="ov_set_lev" type="number" step="any" class="mono" /></label><br/>
-            <label>Gate extra (%) <input id="ov_set_gate_extra" type="number" step="any" class="mono" /></label>
+            <label>Gate extra (%) <input id="ov_set_gate_extra" type="number" step="any" class="mono" /></label><br/>
+            <label>Saldo mínimo p/ fechar (USDT)
+              <input id="ov_set_min_residual" type="number" step="any" class="mono" />
+            </label>
           </div>
         </div>
         <div style="margin-top:10px;">
@@ -385,6 +388,37 @@
   <div class="card" id="historyCard">
     <h3>Histórico (ordens criadas pelo sistema)</h3>
     <div class="card-body">
+      <details id="manualHistoryDetails" class="manual-history">
+        <summary>Adicionar/editar ordem manual</summary>
+        <div class="manual-history-form">
+          <div class="manual-history-grid">
+            <label>Modo
+              <select id="manualHistoryMode" class="mono">
+                <option value="open">Open</option>
+                <option value="close">Close</option>
+              </select>
+            </label>
+            <label>Volume (base)
+              <input id="manualHistoryVolume" type="number" step="any" class="mono" />
+            </label>
+            <label>Gate preço
+              <input id="manualHistoryGatePrice" type="number" step="any" class="mono" />
+            </label>
+            <label>MEXC preço
+              <input id="manualHistoryMexcPrice" type="number" step="any" class="mono" />
+            </label>
+            <label>Data/Hora (opcional)
+              <input id="manualHistoryCreatedAt" type="text" class="mono" placeholder="Ex.: 01/01/2024 10:00:00" />
+            </label>
+          </div>
+          <div id="manualHistoryEditingLabel" class="manual-history-editing"></div>
+          <div class="manual-history-actions">
+            <button id="manualHistorySave">Salvar ordem manual</button>
+            <button type="button" id="manualHistoryCancel">Cancelar edição</button>
+          </div>
+          <div id="manualHistoryStatus" class="manual-history-status"></div>
+        </div>
+      </details>
       <table>
         <thead>
           <tr>

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -438,13 +438,16 @@ function fillOverridesUI(merged) {
   set('ov_set_margin', s.marginPct);
   set('ov_set_lev', s.leverage);
   set('ov_set_gate_extra', s.gateOpenExtraPct);
+  const minResidual = (s.minCloseResidualQuote != null) ? s.minCloseResidualQuote : 4;
+  set('ov_set_min_residual', minResidual);
 }
 function metaToText(label, meta) {
   const gateExtra = (meta.settings && meta.settings.gateOpenExtraPct != null) ? meta.settings.gateOpenExtraPct : 0;
+  const minResidual = meta.settings?.minCloseResidualQuote != null ? meta.settings.minCloseResidualQuote : 0;
   return `${label}
 Gate: priceScale=${meta.gate.priceScale}, qtyScale=${meta.gate.qtyScale}, minQty=${meta.gate.minQty}, minQuote=${meta.gate.minQuote}
 MEXC: priceScale=${meta.mexc.priceScale}, volPrecision=${meta.mexc.volPrecision}, contractSize=${meta.mexc.contractSize}, minContracts=${meta.mexc.minContracts}
-Settings: margem=${meta.settings.marginPct}%, lev=${meta.settings.leverage}, gateExtra=${gateExtra}%, parity=${meta.settings.parityVolumes}`;
+Settings: margem=${meta.settings.marginPct}%, lev=${meta.settings.leverage}, gateExtra=${gateExtra}%, minCloseResidualQuote=${minResidual}`;
 }
 async function refreshMetaUI(symbol) {
   const r = await fetch('/api/market-meta?symbol=' + encodeURIComponent(symbol));
@@ -496,6 +499,7 @@ document.getElementById('saveOverride').addEventListener('click', async () => {
       marginPct: numOrUndef('ov_set_margin'),
       leverage: numOrUndef('ov_set_lev'),
       gateOpenExtraPct: numOrUndef('ov_set_gate_extra'),
+      minCloseResidualQuote: numOrUndef('ov_set_min_residual'),
       parityVolumes: true
     }
   };
@@ -625,6 +629,59 @@ const telegramIncludeVolumesEl = document.getElementById('telegramIncludeVolumes
 if (telegramIncludeVolumesEl) telegramIncludeVolumesEl.checked = telegramIncludeVolumes;
 const scientificToggleEl = document.getElementById('scientificToggle');
 if (scientificToggleEl) scientificToggleEl.checked = useScientificNotation;
+
+const manualHistoryState = {
+  editingId: null,
+  elements: {
+    details: document.getElementById('manualHistoryDetails'),
+    mode: document.getElementById('manualHistoryMode'),
+    volume: document.getElementById('manualHistoryVolume'),
+    gatePrice: document.getElementById('manualHistoryGatePrice'),
+    mexcPrice: document.getElementById('manualHistoryMexcPrice'),
+    createdAt: document.getElementById('manualHistoryCreatedAt'),
+    status: document.getElementById('manualHistoryStatus'),
+    editingLabel: document.getElementById('manualHistoryEditingLabel'),
+    saveBtn: document.getElementById('manualHistorySave'),
+    cancelBtn: document.getElementById('manualHistoryCancel')
+  }
+};
+
+function setManualHistoryStatus(message, isError = false) {
+  const el = manualHistoryState.elements.status;
+  if (!el) return;
+  el.textContent = message || '';
+  el.style.color = isError ? '#c0392b' : '#2c3e50';
+}
+
+function resetManualHistoryForm() {
+  const { mode, volume, gatePrice, mexcPrice, createdAt, editingLabel } = manualHistoryState.elements;
+  manualHistoryState.editingId = null;
+  if (mode) mode.value = 'open';
+  if (volume) volume.value = '';
+  if (gatePrice) gatePrice.value = '';
+  if (mexcPrice) mexcPrice.value = '';
+  if (createdAt) createdAt.value = '';
+  if (editingLabel) editingLabel.textContent = '';
+  setManualHistoryStatus('');
+}
+
+function openManualHistoryForm(entry) {
+  const { details, mode, volume, gatePrice, mexcPrice, createdAt, editingLabel } = manualHistoryState.elements;
+  manualHistoryState.editingId = entry?.localId || null;
+  if (mode && entry?.mode) mode.value = entry.mode;
+  if (volume) volume.value = entry?.volume != null ? entry.volume : '';
+  if (gatePrice) gatePrice.value = entry?.priceUsedGate != null ? entry.priceUsedGate : '';
+  if (mexcPrice) mexcPrice.value = entry?.priceUsedMexc != null ? entry.priceUsedMexc : '';
+  if (createdAt) createdAt.value = entry?.createdAt || '';
+  if (editingLabel) {
+    editingLabel.textContent = entry?.localId ? `Editando ordem ${entry.localId}` : '';
+  }
+  setManualHistoryStatus('');
+  if (details) {
+    details.open = true;
+    try { details.scrollIntoView({ behavior: 'smooth', block: 'center' }); } catch {}
+  }
+}
 
 function playBeep() {
   try {
@@ -780,6 +837,66 @@ scientificToggleEl?.addEventListener('change', e => {
   renderQuotes();
 });
 
+manualHistoryState.elements.saveBtn?.addEventListener('click', async () => {
+  const { saveBtn, mode, volume, gatePrice, mexcPrice, createdAt } = manualHistoryState.elements;
+  if (!mode || !volume || !gatePrice || !mexcPrice || !saveBtn) return;
+  const modeValue = mode.value === 'close' ? 'close' : 'open';
+  const volNum = Number(volume.value);
+  if (!Number.isFinite(volNum) || volNum <= 0) { setManualHistoryStatus('Informe um volume válido.', true); return; }
+  const gatePriceNum = Number(gatePrice.value);
+  if (!Number.isFinite(gatePriceNum) || gatePriceNum <= 0) { setManualHistoryStatus('Informe um preço Gate válido.', true); return; }
+  const mexcPriceNum = Number(mexcPrice.value);
+  if (!Number.isFinite(mexcPriceNum) || mexcPriceNum <= 0) { setManualHistoryStatus('Informe um preço MEXC válido.', true); return; }
+  const entry = {
+    mode: modeValue,
+    volume: volNum,
+    gatePrice: gatePriceNum,
+    mexcPrice: mexcPriceNum,
+    symbol: currentSymbol
+  };
+  const createdRaw = createdAt?.value?.trim();
+  if (createdRaw) entry.createdAt = createdRaw;
+  if (manualHistoryState.editingId) entry.localId = manualHistoryState.editingId;
+
+  setManualHistoryStatus('Salvando ordem manual...');
+  saveBtn.disabled = true;
+  try {
+    const resp = await fetch('/api/history/manual', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ entry })
+    });
+    const out = await safeJson(resp);
+    if (!resp.ok || out?.ok === false) {
+      const msg = typeof out?.error === 'string' ? out.error : 'Falha ao salvar ordem manual.';
+      setManualHistoryStatus(msg, true);
+      return;
+    }
+    resetManualHistoryForm();
+    setManualHistoryStatus('Ordem manual salva com sucesso.');
+    manualHistoryState.elements.details?.removeAttribute('open');
+    await refreshHistory();
+    await refreshPosition();
+  } catch (e) {
+    setManualHistoryStatus(`Erro ao salvar: ${e?.message || e}`, true);
+  } finally {
+    saveBtn.disabled = false;
+  }
+});
+
+manualHistoryState.elements.cancelBtn?.addEventListener('click', () => {
+  resetManualHistoryForm();
+  manualHistoryState.elements.details?.removeAttribute('open');
+});
+
+manualHistoryState.elements.details?.addEventListener('toggle', () => {
+  if (!manualHistoryState.elements.details.open) {
+    resetManualHistoryForm();
+  }
+});
+
+resetManualHistoryForm();
+
 function persistSelections() {
   localStorage.setItem('levels_open', JSON.stringify(Array.from(levelSelections.open).sort((a, b) => a - b)));
   localStorage.setItem('levels_close', JSON.stringify(Array.from(levelSelections.close).sort((a, b) => a - b)));
@@ -798,8 +915,8 @@ function syncSelectionWithLevels(mode, maxLevels) {
   if (changed) persistSelections();
 }
 
-function shouldUseScientific(num) {
-  if (!useScientificNotation) return false;
+function shouldUseScientific(num, allowScientific = false) {
+  if (!useScientificNotation || !allowScientific) return false;
   const str = num.toString().toLowerCase();
   if (str.includes('e')) return true;
   const parts = str.split('.');
@@ -808,10 +925,10 @@ function shouldUseScientific(num) {
   return decimals.length > 6;
 }
 
-function formatNumberValue(value, digits = 6) {
+function formatNumberValue(value, digits = 6, allowScientific = false) {
   const num = Number(value);
   if (!Number.isFinite(num)) return '—';
-  if (shouldUseScientific(num)) {
+  if (shouldUseScientific(num, allowScientific)) {
     return num.toExponential(2);
   }
   return num.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: digits });
@@ -876,10 +993,10 @@ function renderLevelsTable(mode, levels, baseSymbol, tbodyId) {
       tr.appendChild(td);
     };
 
-    addCell(formatNumberValue(lvl.gate?.price));
+    addCell(formatNumberValue(lvl.gate?.price, 6, true));
     addCell(formatVolumeValue(lvl.gate?.baseVolume, 6, baseSymbol));
     addCell(formatVolumeValue(lvl.gate?.usdtVolume, 2, 'USDT'));
-    addCell(formatNumberValue(lvl.mexc?.price));
+    addCell(formatNumberValue(lvl.mexc?.price, 6, true));
     addCell(formatVolumeValue(lvl.mexc?.baseVolume, 6, baseSymbol));
     addCell(formatVolumeValue(lvl.mexc?.usdtVolume, 2, 'USDT'));
     addCell(formatDiffValue(lvl.diffPct));
@@ -1582,6 +1699,20 @@ async function refreshHistory() {
         }
       });
 
+      const editBtn = document.createElement('button');
+      editBtn.textContent = 'Editar';
+      editBtn.addEventListener('click', () => {
+        const clone = { ...h };
+        if (clone.volume != null && typeof clone.volume === 'number') clone.volume = clone.volume.toString();
+        if (clone.priceUsedGate != null && typeof clone.priceUsedGate === 'number') {
+          clone.priceUsedGate = clone.priceUsedGate.toString();
+        }
+        if (clone.priceUsedMexc != null && typeof clone.priceUsedMexc === 'number') {
+          clone.priceUsedMexc = clone.priceUsedMexc.toString();
+        }
+        openManualHistoryForm(clone);
+      });
+
       const groBtn = document.createElement('button');
       groBtn.textContent = 'Reposicionar';
       groBtn.disabled = !h.gateOrderId || h.gateStatus === 'filled' || h.gateStatus === 'cancelled';
@@ -1651,7 +1782,10 @@ async function refreshHistory() {
       tr.appendChild(td(h.mexcStatus || '-'));
       const mroTd = document.createElement('td'); mroTd.appendChild(mroBtn); tr.appendChild(mroTd);
       tr.appendChild(td(h.status || '-'));
-      const act = document.createElement('td'); act.appendChild(cancelBtn); tr.appendChild(act);
+      const act = document.createElement('td');
+      act.appendChild(editBtn);
+      act.appendChild(cancelBtn);
+      tr.appendChild(act);
 
       tbody.appendChild(tr);
     });

--- a/server.js
+++ b/server.js
@@ -742,7 +742,8 @@ async function autoDiscoverMeta(symbol) {
   const settings = {
     marginPct: Number(config.execution?.marginPct ?? 10),
     leverage: Number(config.mexc?.leverage ?? 1),
-    gateOpenExtraPct: Number(config.execution?.gateOpenExtraPct ?? 0)
+    gateOpenExtraPct: Number(config.execution?.gateOpenExtraPct ?? 0),
+    minCloseResidualQuote: Number(config.execution?.minCloseResidualQuote ?? 4)
   };
   return { symbolSpot: symbol, symbolFut: symbol, gate, mexc, settings };
 }
@@ -801,6 +802,44 @@ function computeGateOrderQty(baseQty, meta, mode) {
     }
   }
   return qty;
+}
+
+function enforceCloseResidualGuard(mode, contracts, meta, gatePrice, normalizeContracts, floorContracts) {
+  if (mode !== 'close') return { ok: true, contracts };
+  const minQuote = Number(meta?.settings?.minCloseResidualQuote || 0);
+  if (!Number.isFinite(minQuote) || minQuote <= 0) return { ok: true, contracts };
+  const positionBase = Number(positionState?.gate?.filledQty || 0);
+  if (!Number.isFinite(positionBase) || positionBase <= 0) return { ok: true, contracts };
+  const gatePriceNum = Number(gatePrice);
+  if (!Number.isFinite(gatePriceNum) || gatePriceNum <= 0) return { ok: true, contracts };
+
+  const cs = Number(meta?.mexc?.contractSize || 1);
+  const currentBase = Number(contracts) * cs;
+  if (!Number.isFinite(currentBase) || currentBase <= 0) return { ok: false, reason: 'invalid_guard_base' };
+  if (currentBase >= positionBase) return { ok: true, contracts };
+
+  const minResidualBase = minQuote / gatePriceNum;
+  if (!Number.isFinite(minResidualBase) || minResidualBase <= 0) return { ok: true, contracts };
+  if (minResidualBase >= positionBase) return { ok: true, contracts };
+
+  const maxClosableBase = positionBase - minResidualBase;
+  if (!Number.isFinite(maxClosableBase) || maxClosableBase <= 0) return { ok: true, contracts };
+
+  let maxContracts = normalizeContracts(floorContracts(maxClosableBase / cs));
+  if (!Number.isFinite(maxContracts) || maxContracts <= 0) {
+    return { ok: false, reason: 'min_residual_guard', minResidualQuote: minQuote };
+  }
+
+  const minContracts = Number(meta?.mexc?.minContracts || 1);
+  if (Number.isFinite(minContracts) && minContracts > 0 && maxContracts < minContracts) {
+    return { ok: false, reason: 'min_residual_guard', minResidualQuote: minQuote };
+  }
+
+  if (maxContracts < contracts) {
+    return { ok: true, contracts: maxContracts, applied: true, minResidualQuote: minQuote };
+  }
+
+  return { ok: true, contracts };
 }
 
 function normalizeLevelSelection(raw, maxGateLevels, maxMexcLevels) {
@@ -1388,10 +1427,15 @@ app.post('/api/position-dismantle', (req, res) => {
   }
 });
 
-function updatePositionFromOrder(item, gFilled, gAvg, mFilled, mAvg) {
+function updatePositionFromOrder(item, gFilled, gAvg, mFilled, mAvg, options = {}) {
+  const state = options.state || positionState;
+  if (!state.gate) state.gate = { filledQty: 0, avgPrice: 0 };
+  if (!state.mexc) state.mexc = { filledQty: 0, avgPrice: 0, positionId: null };
+  const persist = options.persist !== false;
   const meta = item?.metaUsed || {};
-  if (item?.symbol) positionState.symbol = item.symbol;
-  else if (!positionState.symbol && currentSymbol) positionState.symbol = currentSymbol;
+  if (item?.symbol) state.symbol = item.symbol;
+  else if (!state.symbol && currentSymbol) state.symbol = currentSymbol;
+
   const gateQty = Number(gFilled || 0);
   const mexcContracts = Number(mFilled || 0);
 
@@ -1404,7 +1448,7 @@ function updatePositionFromOrder(item, gFilled, gAvg, mFilled, mAvg) {
   }
 
   const qty = Math.min(gateQty, mexcQty);
-  if (!qty || qty <= 0) return;
+  if (!qty || qty <= 0) return state;
 
   const gatePrice = Number(gAvg || item.priceUsedGate || 0);
   const mexcPrice = Number(mAvg || item.priceUsedMexc || 0);
@@ -1417,7 +1461,7 @@ function updatePositionFromOrder(item, gFilled, gAvg, mFilled, mAvg) {
   item.arbPct = roundTo(arbRaw * sign, 6);
   item.pnlUsd = roundTo(pnlUsd, 6);
 
-  positionState.trades.push({
+  state.trades.push({
     t: Date.now(),
     mode: item.mode === 'close' ? 'close' : 'open',
     qty: Number(qty),
@@ -1426,49 +1470,80 @@ function updatePositionFromOrder(item, gFilled, gAvg, mFilled, mAvg) {
     pnlUsd: Number.isFinite(item.pnlUsd) ? Number(item.pnlUsd) : 0,
     diffPct: Number.isFinite(item.arbPct) ? Number(item.arbPct) : null
   });
-  if (positionState.trades.length > TRADES_LIMIT) {
-    positionState.trades = positionState.trades.slice(-TRADES_LIMIT);
+  if (state.trades.length > TRADES_LIMIT) {
+    state.trades = state.trades.slice(-TRADES_LIMIT);
   }
 
   // Gate stats
-  const gPrevQty = positionState.gate.filledQty;
-  const gPrevAvg = positionState.gate.avgPrice;
+  const gPrevQty = state.gate.filledQty;
+  const gPrevAvg = state.gate.avgPrice;
   const gNewQty = gPrevQty + adjQty;
   const gNewAvg = gNewQty > 0 ? ((gPrevAvg * gPrevQty) + (gatePrice * adjQty)) / gNewQty : 0;
-  positionState.gate.filledQty = gNewQty;
-  positionState.gate.avgPrice = gNewAvg;
+  state.gate.filledQty = gNewQty;
+  state.gate.avgPrice = gNewAvg;
 
   // MEXC stats
-  const mPrevQty = positionState.mexc.filledQty;
-  const mPrevAvg = positionState.mexc.avgPrice;
+  const mPrevQty = state.mexc.filledQty;
+  const mPrevAvg = state.mexc.avgPrice;
   const mNewQty = mPrevQty + adjQty;
   const mNewAvg = mNewQty > 0 ? ((mPrevAvg * mPrevQty) + (mexcPrice * adjQty)) / mNewQty : 0;
-  positionState.mexc.filledQty = mNewQty;
-  positionState.mexc.avgPrice = mNewAvg;
-  if (mNewQty <= 0) positionState.mexc.positionId = null;
+  state.mexc.filledQty = mNewQty;
+  state.mexc.avgPrice = mNewAvg;
+  if (mNewQty <= 0) state.mexc.positionId = null;
 
   // Aggregates
-  const prevQty = positionState.filledQty;
-  const prevAvg = positionState.avgPrice;
+  const prevQty = state.filledQty;
+  const prevAvg = state.avgPrice;
   const newQty = prevQty + adjQty;
   const newAvg = newQty > 0 ? ((prevAvg * prevQty) + (gatePrice * adjQty)) / newQty : 0;
-  const newArb = newQty > 0 ? (((positionState.arbPctAvg || 0) * prevQty) + (arbRaw * adjQty)) / newQty : 0;
-  positionState.filledQty = newQty;
-  positionState.avgPrice = newAvg;
-  positionState.arbPctAvg = newArb;
-  positionState.pnlUsd = (positionState.pnlUsd || 0) + item.pnlUsd;
+  const newArb = newQty > 0 ? (((state.arbPctAvg || 0) * prevQty) + (arbRaw * adjQty)) / newQty : 0;
+  state.filledQty = newQty;
+  state.avgPrice = newAvg;
+  state.arbPctAvg = newArb;
+  state.pnlUsd = (state.pnlUsd || 0) + item.pnlUsd;
 
-  positionState.series.push({
+  state.series.push({
     t: Date.now(),
     filledQty: newQty,
     avgPrice: Number(newAvg.toFixed(11)),
     arbPctAvg: Number(newArb.toFixed(6)),
-    pnlUsd: Number(positionState.pnlUsd.toFixed(6)),
+    pnlUsd: Number(state.pnlUsd.toFixed(6)),
     gate: { filledQty: gNewQty, avgPrice: Number(gNewAvg.toFixed(11)) },
     mexc: { filledQty: mNewQty, avgPrice: Number(mNewAvg.toFixed(11)) }
   });
+  state.series = sanitizeSeries(state.series);
+  state.trades = sanitizeTrades(state.trades);
+
+  if (persist && state === positionState) {
+    persistPositionState('update-position');
+  }
+  return state;
+}
+
+function rebuildPositionFromHistory() {
+  const baseState = createEmptyPositionState();
+  baseState.targetQty = Number(positionState?.targetQty || 0);
+  if (positionState?.symbol) baseState.symbol = positionState.symbol;
+  if (positionState?.mexc?.positionId) baseState.mexc.positionId = positionState.mexc.positionId;
+
+  const sorted = orderHistory
+    .slice()
+    .filter((item) => item && item.status === 'filled')
+    .sort((a, b) => Number(a?.localId || 0) - Number(b?.localId || 0));
+
+  for (const item of sorted) {
+    const gateQty = Number(item.volume ?? item.gateOrderBaseQty ?? item.mexcDisplayVolume ?? 0);
+    if (!Number.isFinite(gateQty) || gateQty <= 0) continue;
+    const gateAvg = Number(item.priceUsedGate ?? 0);
+    const mexcAvg = Number(item.priceUsedMexc ?? 0);
+    updatePositionFromOrder(item, gateQty, gateAvg, 0, mexcAvg, { state: baseState, persist: false });
+  }
+
+  positionState = recalcPositionAggregates(baseState);
   positionState.series = sanitizeSeries(positionState.series);
-  persistPositionState('update-position');
+  positionState.trades = sanitizeTrades(positionState.trades);
+  persistPositionState('rebuild-history');
+  return positionState;
 }
 
 // ===== Precheck (respeita modo open/close do front)
@@ -1575,6 +1650,21 @@ app.post('/api/precheck', async (req, res) => {
       return res.json({ ok: true, blocked: true, reason: 'min_contracts_not_met', minContracts, mode });
     }
 
+    const guard = enforceCloseResidualGuard(mode, contracts, meta, gatePrice, normalizeContracts, floorContracts);
+    if (!guard.ok) {
+      const minResidualQuote = guard.minResidualQuote ?? Number(meta?.settings?.minCloseResidualQuote || 0);
+      const message = `Saldo residual ficaria abaixo de ${Number(minResidualQuote).toFixed(2)} USDT.`;
+      return res.json({
+        ok: true,
+        blocked: true,
+        reason: `${message} Ajuste o volume ou reduza o mínimo manual nas configurações.`,
+        code: 'min_residual_guard',
+        minResidualQuote,
+        mode
+      });
+    }
+    contracts = guard.contracts;
+
     let finalBaseQtyRaw = contracts * cs;
     let rounded = applyRoundingMeta(gatePrice, mexcPrice, finalBaseQtyRaw, meta);
     let adjustedContracts = normalizeContracts(floorContracts(rounded.q / cs));
@@ -1590,6 +1680,24 @@ app.post('/api/precheck', async (req, res) => {
 
     if (minContracts > 0 && contracts < minContracts) {
       return res.json({ ok: true, blocked: true, reason: 'min_contracts_not_met', minContracts, mode });
+    }
+
+    if (mode === 'close') {
+      const minResidualQuote = Number(meta?.settings?.minCloseResidualQuote || 0);
+      const leftover = Number(positionState?.gate?.filledQty || 0) - Number(rounded.q || 0);
+      const leftoverQuote = Number.isFinite(leftover) && Number.isFinite(rounded.pg) ? leftover * rounded.pg : null;
+      if (minResidualQuote > 0 && Number.isFinite(leftover) && leftover > 0 && Number.isFinite(leftoverQuote) && leftoverQuote < minResidualQuote) {
+        const friendly = `Saldo residual estimado: ${Number(leftoverQuote.toFixed(6))} USDT (mínimo exigido: ${Number(minResidualQuote).toFixed(2)} USDT).`;
+        return res.json({
+          ok: true,
+          blocked: true,
+          reason: `${friendly} Ajuste o volume ou reduza o mínimo manual nas configurações.`,
+          code: 'min_residual_guard',
+          minResidualQuote,
+          leftoverQuote: Number(leftoverQuote.toFixed(6)),
+          mode
+        });
+      }
     }
 
     const gateOrderBaseQty = computeGateOrderQty(rounded.q, meta, mode);
@@ -1617,6 +1725,7 @@ app.post('/api/precheck', async (req, res) => {
         leverage: meta.settings.leverage,
         marginPct: meta.settings.marginPct,
         gateOpenExtraPct: appliedGateExtraPct,
+        minCloseResidualQuote: meta?.settings?.minCloseResidualQuote,
         requiredUSDT: Number(required.toFixed(6)),
         levelsUsed: selectedLevels
       };
@@ -1633,6 +1742,7 @@ app.post('/api/precheck', async (req, res) => {
         leverage: meta.settings.leverage,
         marginPct: meta.settings.marginPct,
         gateOpenExtraPct: appliedGateExtraPct,
+        minCloseResidualQuote: meta?.settings?.minCloseResidualQuote,
         requiredUSDT: 0,
         levelsUsed: selectedLevels
       };
@@ -1683,7 +1793,8 @@ app.post('/api/execute-trade', async (req, res) => {
       settings: {
         marginPct: meta?.settings?.marginPct,
         leverage: meta?.settings?.leverage,
-        gateOpenExtraPct: meta?.settings?.gateOpenExtraPct
+        gateOpenExtraPct: meta?.settings?.gateOpenExtraPct,
+        minCloseResidualQuote: meta?.settings?.minCloseResidualQuote
       }
     });
 
@@ -1869,6 +1980,29 @@ app.post('/api/execute-trade', async (req, res) => {
       });
     }
 
+    const guard = enforceCloseResidualGuard(mode, contracts, meta, gatePrice, normalizeContracts, floorContracts);
+    if (!guard.ok) {
+      const minResidualQuote = guard.minResidualQuote ?? Number(meta?.settings?.minCloseResidualQuote || 0);
+      const message = `Saldo residual ficaria abaixo de ${Number(minResidualQuote).toFixed(2)} USDT.`;
+      return abort(400, {
+        error: `${message} Ajuste o volume ou reduza o mínimo manual nas configurações.`,
+        code: 'min_residual_guard',
+        minResidualQuote
+      }, {
+        reason: 'min_residual_guard',
+        contracts,
+        minResidualQuote
+      });
+    }
+    if (guard.applied) {
+      timelineRecorder.push('calc', 'Regra de saldo mínimo aplicada', {
+        previousContracts: contracts,
+        adjustedContracts: guard.contracts,
+        minResidualQuote: guard.minResidualQuote ?? Number(meta?.settings?.minCloseResidualQuote || 0)
+      });
+    }
+    contracts = guard.contracts;
+
     let finalBaseQtyRaw = contracts * cs;
     let rounded = applyRoundingMeta(gatePrice, mexcPrice, finalBaseQtyRaw, meta);
     let adjustedContracts = normalizeContracts(floorContracts(rounded.q / cs));
@@ -1890,6 +2024,26 @@ app.post('/api/execute-trade', async (req, res) => {
       });
     }
 
+    if (mode === 'close') {
+      const minResidualQuote = Number(meta?.settings?.minCloseResidualQuote || 0);
+      const leftover = Number(positionState?.gate?.filledQty || 0) - Number(rounded.q || 0);
+      const leftoverQuote = Number.isFinite(leftover) && Number.isFinite(rounded.pg) ? leftover * rounded.pg : null;
+      if (minResidualQuote > 0 && Number.isFinite(leftover) && leftover > 0 && Number.isFinite(leftoverQuote) && leftoverQuote < minResidualQuote) {
+        const friendly = `Saldo residual estimado: ${Number(leftoverQuote.toFixed(6))} USDT (mínimo exigido: ${Number(minResidualQuote).toFixed(2)} USDT).`;
+        return abort(400, {
+          error: `${friendly} Ajuste o volume ou reduza o mínimo manual nas configurações.`,
+          code: 'min_residual_guard',
+          minResidualQuote,
+          leftoverQuote: Number(leftoverQuote.toFixed(6))
+        }, {
+          reason: 'min_residual_guard_post',
+          leftover,
+          leftoverQuote,
+          minResidualQuote
+        });
+      }
+    }
+
     const gateOrderBaseQty = computeGateOrderQty(rounded.q, meta, mode);
 
     timelineRecorder.push('calc', 'Quantidades calculadas', {
@@ -1898,7 +2052,8 @@ app.post('/api/execute-trade', async (req, res) => {
       finalBaseQty: rounded.q,
       gateOrderBaseQty,
       gatePrice: rounded.pg,
-      mexcPrice: rounded.pm
+      mexcPrice: rounded.pm,
+      minCloseResidualQuote: meta?.settings?.minCloseResidualQuote
     });
 
     const minQuote = Number(meta.gate.minQuote || 0);
@@ -2541,6 +2696,83 @@ setInterval(() => {
 app.get('/api/history', async (_req, res) => {
   try { await pollOpenOrders(); } catch {}
   res.json(orderHistory);
+});
+
+app.post('/api/history/manual', async (req, res) => {
+  try {
+    const entry = req.body?.entry;
+    if (!entry || typeof entry !== 'object') {
+      return res.status(400).json({ ok: false, error: 'invalid_entry' });
+    }
+    const symbolRaw = typeof entry.symbol === 'string' ? entry.symbol.trim().toUpperCase() : currentSymbol;
+    if (!symbolRaw || !symbolRaw.includes('_')) {
+      return res.status(400).json({ ok: false, error: 'symbol_invalid' });
+    }
+    const mode = entry.mode === 'close' ? 'close' : 'open';
+    const volume = Number(entry.volume);
+    if (!Number.isFinite(volume) || volume <= 0) {
+      return res.status(400).json({ ok: false, error: 'volume_invalid' });
+    }
+    const gatePrice = Number(entry.gatePrice);
+    if (!Number.isFinite(gatePrice) || gatePrice <= 0) {
+      return res.status(400).json({ ok: false, error: 'gate_price_invalid' });
+    }
+    const mexcPrice = Number(entry.mexcPrice);
+    if (!Number.isFinite(mexcPrice) || mexcPrice <= 0) {
+      return res.status(400).json({ ok: false, error: 'mexc_price_invalid' });
+    }
+
+    const createdAtRaw = typeof entry.createdAt === 'string' && entry.createdAt.trim()
+      ? entry.createdAt.trim()
+      : null;
+    const createdAt = createdAtRaw || nowBR();
+    const localId = entry.localId ? String(entry.localId) : Date.now().toString();
+
+    let existing = orderHistory.find((item) => item.localId === localId);
+    const isEdit = !!existing;
+    const metaUsed = await getMergedMeta(symbolRaw);
+
+    if (!existing) {
+      existing = { localId };
+      orderHistory.unshift(existing);
+    }
+
+    existing.symbol = symbolRaw;
+    existing.mode = mode;
+    existing.sentido = mode === 'close' ? 'Close' : 'Open';
+    existing.priceUsedGate = String(gatePrice);
+    existing.priceUsedMexc = String(mexcPrice);
+    existing.volume = String(volume);
+    existing.mexcDisplayVolume = String(volume);
+    existing.gateOrderBaseQty = volume;
+    existing.gateOrderVolume = String(volume);
+    existing.mexcOrderContracts = existing.mexcOrderContracts ?? null;
+    existing.createdAt = createdAt;
+    existing.executedAt = createdAt;
+    existing.gateStatus = 'filled';
+    existing.mexcStatus = 'filled';
+    existing.status = 'filled';
+    existing.gateOrderId = isEdit ? existing.gateOrderId ?? null : null;
+    existing.mexcOrderId = isEdit ? existing.mexcOrderId ?? null : null;
+    existing.gatePartialFilled = 0;
+    existing.mexcPartialFilled = 0;
+    existing.metaUsed = metaUsed;
+    existing.manual = true;
+
+    const diff = mexcPrice - gatePrice;
+    const sign = mode === 'close' ? -1 : 1;
+    existing.arbPct = roundTo(((diff / gatePrice) * 100) * sign, 6);
+    existing.pnlUsd = roundTo(diff * volume * sign, 6);
+
+    try { db.saveHistoryItem(existing); } catch (e) { console.warn('[SQLite] save history (manual):', e?.message || e); }
+
+    rebuildPositionFromHistory();
+
+    res.json({ ok: true, item: existing, state: positionState });
+  } catch (e) {
+    console.error('[API] history-manual:', e?.message || e);
+    res.status(500).json({ ok: false, error: 'internal_error' });
+  }
 });
 
 app.listen(PORT, () => console.log(`Servidor rodando em http://localhost:${PORT}`));


### PR DESCRIPTION
## Summary
- add a configurable minimum close residual to execution defaults, overrides UI, and precheck/execute safeguards so small leftovers are blocked or adjusted
- expose a manual order form in the history card with client-side helpers and a backend endpoint that records filled orders and rebuilds position metrics when rows are added or edited
- limit the scientific notation toggle to the Gate/MEXC price columns in the quotes tables

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e431258c28832fae5ff440d683df50