### PR TITLE
Add monitoring menu and admin tools

### DIFF
--- a/db.js
+++ b/db.js
@@ -57,6 +57,11 @@ CREATE TABLE IF NOT EXISTS spread_snapshots (
   open_mexc_volumes TEXT,
   close_mexc_volumes TEXT
 );
+CREATE TABLE IF NOT EXISTS monitoring_symbols (
+  symbol TEXT PRIMARY KEY,
+  meta_json TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
 `);
 
 // Migração simples: garante colunas gate_status e mexc_status
@@ -74,6 +79,7 @@ try { db.exec('ALTER TABLE spread_snapshots ADD COLUMN close_spot_volumes TEXT')
 try { db.exec('ALTER TABLE spread_snapshots ADD COLUMN open_mexc_volumes TEXT'); } catch {}
 try { db.exec('ALTER TABLE spread_snapshots ADD COLUMN close_mexc_volumes TEXT'); } catch {}
 try { db.exec('CREATE INDEX IF NOT EXISTS idx_spread_symbol_exchange_ts ON spread_snapshots(symbol, spot_exchange, ts)'); } catch {}
+try { db.exec('CREATE TABLE IF NOT EXISTS monitoring_symbols (symbol TEXT PRIMARY KEY, meta_json TEXT NOT NULL, updated_at TEXT NOT NULL)'); } catch {}
 
 const upsertOverrideStmt = db.prepare(`
 INSERT INTO overrides(symbol, override_json, updated_at)
@@ -299,6 +305,42 @@ function clearSpreadSnapshots(symbol, spotExchange) {
   });
 }
 
+const upsertMonitoringSymbolStmt = db.prepare(`
+INSERT INTO monitoring_symbols(symbol, meta_json, updated_at)
+VALUES (@symbol, @json, @updated_at)
+ON CONFLICT(symbol) DO UPDATE SET
+  meta_json = excluded.meta_json,
+  updated_at = excluded.updated_at
+`);
+
+function upsertMonitoringSymbol(symbol, meta) {
+  if (!symbol) return;
+  upsertMonitoringSymbolStmt.run({
+    symbol: String(symbol).toUpperCase(),
+    json: JSON.stringify(meta || {}),
+    updated_at: new Date().toISOString()
+  });
+}
+
+const deleteMonitoringSymbolStmt = db.prepare('DELETE FROM monitoring_symbols WHERE symbol = ?');
+function deleteMonitoringSymbol(symbol) {
+  if (!symbol) return;
+  deleteMonitoringSymbolStmt.run(String(symbol).toUpperCase());
+}
+
+const loadMonitoringSymbolsStmt = db.prepare('SELECT symbol, meta_json FROM monitoring_symbols');
+function loadMonitoringSymbols() {
+  const arr = [];
+  for (const row of loadMonitoringSymbolsStmt.all()) {
+    try {
+      arr.push({ symbol: row.symbol, meta: JSON.parse(row.meta_json) });
+    } catch {
+      continue;
+    }
+  }
+  return arr;
+}
+
 module.exports = {
   DB_PATH,
   upsertOverride,
@@ -312,5 +354,8 @@ module.exports = {
   saveSpreadSnapshot,
   loadSpreadSnapshots,
   pruneSpreadSnapshots,
-  clearSpreadSnapshots
+  clearSpreadSnapshots,
+  upsertMonitoringSymbol,
+  deleteMonitoringSymbol,
+  loadMonitoringSymbols
 };

--- a/public/index.html
+++ b/public/index.html
@@ -510,13 +510,13 @@
 
     .admin-grid {
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
       gap: 18px;
     }
 
     .admin-grid-wrapper {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      display: flex;
+      flex-direction: column;
       gap: 20px;
       width: 100%;
     }
@@ -535,6 +535,33 @@
       display: flex;
       flex-direction: column;
       gap: 8px;
+    }
+
+    .admin-form select[multiple] {
+      min-height: 120px;
+      border-radius: 10px;
+    }
+
+    .discovery-exchanges {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 10px;
+    }
+
+    .exchange-group {
+      background: rgba(255, 255, 255, 0.03);
+      border: 1px solid rgba(125, 97, 255, 0.15);
+      border-radius: 12px;
+      padding: 10px 12px;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .exchange-group h4 {
+      margin: 0 0 4px 0;
+      font-size: 0.95rem;
+      color: var(--muted);
     }
 
     .blacklist-list {
@@ -2134,22 +2161,6 @@
                 <option value="1000000">≥ 1M USDT</option>
               </select>
             </div>
-            <div class="filter-group">
-              <label>Perfil de risco</label>
-              <div class="chip-list">
-                <label><input type="checkbox" class="filter-risk" value="Baixo" checked /> Baixo</label>
-                <label><input type="checkbox" class="filter-risk" value="Médio" checked /> Médio</label>
-                <label><input type="checkbox" class="filter-risk" value="Alto" /> Alto</label>
-              </div>
-            </div>
-            <div class="filter-group">
-              <label for="filterStability">Estabilidade mínima</label>
-              <select id="filterStability">
-                <option value="flex">Qualquer</option>
-                <option value="Estável">Estável</option>
-                <option value="Volátil">Volátil apenas</option>
-              </select>
-            </div>
           </div>
         </div>
 
@@ -2170,10 +2181,6 @@
               <div class="summary-pill">
                 <span class="label">Melhor arb</span>
                 <strong id="monitoringSummaryBest">-</strong>
-              </div>
-              <div class="summary-pill">
-                <span class="label">Média filtrada</span>
-                <strong id="monitoringSummaryAvg">0%</strong>
               </div>
               <div class="summary-pill">
                 <span class="label">Blacklist ativa</span>
@@ -2204,9 +2211,6 @@
                     <th>Corretoras SPOT</th>
                     <th>Corretoras FUTUROS</th>
                     <th>Volume 24h</th>
-                    <th>Profundidade</th>
-                    <th>Funding</th>
-                    <th>Risco</th>
                     <th>Favorito</th>
                     <th>Ações</th>
                   </tr>
@@ -2305,23 +2309,24 @@
                   <label>Moeda
                     <input type="text" id="adminCoinSymbol" placeholder="FARM_USDT" required />
                   </label>
-                  <label>Nome amigável
-                    <input type="text" id="adminCoinName" placeholder="Harvest Finance" required />
+                  <label>Corretoras SPOT
+                    <select id="adminCoinSpot" multiple>
+                      <option value="Gate.io" selected>Gate.io</option>
+                      <option value="MEXC">MEXC</option>
+                      <option value="Bitget">Bitget</option>
+                      <option value="KuCoin">KuCoin</option>
+                      <option value="Binance">Binance</option>
+                      <option value="Bybit">Bybit</option>
+                    </select>
                   </label>
-                  <label>Corretoras spot (separadas por vírgula)
-                    <input type="text" id="adminCoinSpot" placeholder="Gate.io, Binance" />
-                  </label>
-                  <label>Corretoras futuros (separadas por vírgula)
-                    <input type="text" id="adminCoinFutures" placeholder="MEXC Futures" />
-                  </label>
-                  <label>Meta de % arb
-                    <input type="number" id="adminCoinArb" min="0" step="0.1" value="1.5" />
-                  </label>
-                  <label>Nível de risco
-                    <select id="adminCoinRisk">
-                      <option value="Baixo">Baixo</option>
-                      <option value="Médio">Médio</option>
-                      <option value="Alto">Alto</option>
+                  <label>Corretoras FUTUROS
+                    <select id="adminCoinFutures" multiple>
+                      <option value="Gate.io Futures" selected>Gate.io Futures</option>
+                      <option value="MEXC Futures">MEXC Futures</option>
+                      <option value="Bitget Futures">Bitget Futures</option>
+                      <option value="KuCoin Futures">KuCoin Futures</option>
+                      <option value="Binance Futures">Binance Futures</option>
+                      <option value="Bybit Futures">Bybit Futures</option>
                     </select>
                   </label>
                   <button type="submit">Cadastrar moeda</button>
@@ -2349,18 +2354,24 @@
               <p class="muted">Escolha as corretoras e busque os pares com maior volume para adicioná-los rapidamente.</p>
               <div class="discovery-controls">
                 <div class="discovery-exchanges">
-                  <label><input type="checkbox" class="top-exchange" value="gate_spot" checked />Gate.io Spot</label>
-                  <label><input type="checkbox" class="top-exchange" value="mexc_spot" checked />MEXC Spot</label>
-                  <label><input type="checkbox" class="top-exchange" value="bitget_spot" checked />Bitget Spot</label>
-                  <label><input type="checkbox" class="top-exchange" value="kucoin_spot" checked />KuCoin Spot</label>
-                  <label><input type="checkbox" class="top-exchange" value="binance_spot" checked />Binance Spot</label>
-                  <label><input type="checkbox" class="top-exchange" value="bybit_spot" checked />Bybit Spot</label>
-                  <label><input type="checkbox" class="top-exchange" value="gate_futures" checked />Gate.io Futures</label>
-                  <label><input type="checkbox" class="top-exchange" value="mexc_futures" checked />MEXC Futures</label>
-                  <label><input type="checkbox" class="top-exchange" value="bitget_futures" checked />Bitget Futures</label>
-                  <label><input type="checkbox" class="top-exchange" value="kucoin_futures" checked />KuCoin Futures</label>
-                  <label><input type="checkbox" class="top-exchange" value="binance_futures" checked />Binance Futures</label>
-                  <label><input type="checkbox" class="top-exchange" value="bybit_futures" checked />Bybit Futures</label>
+                  <div class="exchange-group">
+                    <h4>SPOT</h4>
+                    <label><input type="checkbox" class="top-exchange" value="gate_spot" checked />Gate.io Spot</label>
+                    <label><input type="checkbox" class="top-exchange" value="mexc_spot" checked />MEXC Spot</label>
+                    <label><input type="checkbox" class="top-exchange" value="bitget_spot" checked />Bitget Spot</label>
+                    <label><input type="checkbox" class="top-exchange" value="kucoin_spot" checked />KuCoin Spot</label>
+                    <label><input type="checkbox" class="top-exchange" value="binance_spot" checked />Binance Spot</label>
+                    <label><input type="checkbox" class="top-exchange" value="bybit_spot" checked />Bybit Spot</label>
+                  </div>
+                  <div class="exchange-group">
+                    <h4>FUTUROS</h4>
+                    <label><input type="checkbox" class="top-exchange" value="gate_futures" checked />Gate.io Futures</label>
+                    <label><input type="checkbox" class="top-exchange" value="mexc_futures" checked />MEXC Futures</label>
+                    <label><input type="checkbox" class="top-exchange" value="bitget_futures" checked />Bitget Futures</label>
+                    <label><input type="checkbox" class="top-exchange" value="kucoin_futures" checked />KuCoin Futures</label>
+                    <label><input type="checkbox" class="top-exchange" value="binance_futures" checked />Binance Futures</label>
+                    <label><input type="checkbox" class="top-exchange" value="bybit_futures" checked />Bybit Futures</label>
+                  </div>
                 </div>
                 <div class="discovery-actions">
                   <button type="button" id="discoverTopAssets">Buscar top 24h</button>

--- a/public/index.html
+++ b/public/index.html
@@ -588,6 +588,20 @@
       align-items: center;
     }
 
+    .inline-input {
+      display: inline-flex;
+      flex-direction: column;
+      gap: 4px;
+      font-size: 12px;
+      color: var(--muted);
+    }
+
+    .admin-exchange-groups {
+      display: flex;
+      gap: 16px;
+      flex-wrap: wrap;
+    }
+
     .top-assets-results {
       display: flex;
       flex-direction: column;
@@ -605,7 +619,7 @@
     .top-assets-head,
     .top-assets-row {
       display: grid;
-      grid-template-columns: 0.7fr 1.4fr 1.1fr 1fr 1.3fr;
+      grid-template-columns: 0.6fr 1.4fr 2fr 1fr;
       gap: 12px;
       padding: 10px 14px;
       align-items: center;
@@ -643,6 +657,23 @@
 
     .top-assets-row .asset-volume {
       font-variant-numeric: tabular-nums;
+    }
+
+    .volume-badges {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+
+    .volume-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 6px 10px;
+      border-radius: 10px;
+      background: rgba(125, 97, 255, 0.12);
+      border: 1px solid rgba(125, 97, 255, 0.2);
+      font-size: 12px;
     }
 
     .top-assets-footer {
@@ -2309,26 +2340,26 @@
                   <label>Moeda
                     <input type="text" id="adminCoinSymbol" placeholder="FARM_USDT" required />
                   </label>
-                  <label>Corretoras SPOT
-                    <select id="adminCoinSpot" multiple>
-                      <option value="Gate.io" selected>Gate.io</option>
-                      <option value="MEXC">MEXC</option>
-                      <option value="Bitget">Bitget</option>
-                      <option value="KuCoin">KuCoin</option>
-                      <option value="Binance">Binance</option>
-                      <option value="Bybit">Bybit</option>
-                    </select>
-                  </label>
-                  <label>Corretoras FUTUROS
-                    <select id="adminCoinFutures" multiple>
-                      <option value="Gate.io Futures" selected>Gate.io Futures</option>
-                      <option value="MEXC Futures">MEXC Futures</option>
-                      <option value="Bitget Futures">Bitget Futures</option>
-                      <option value="KuCoin Futures">KuCoin Futures</option>
-                      <option value="Binance Futures">Binance Futures</option>
-                      <option value="Bybit Futures">Bybit Futures</option>
-                    </select>
-                  </label>
+                  <div class="admin-exchange-groups">
+                    <div class="exchange-group">
+                      <h5>Corretoras SPOT</h5>
+                      <label><input type="checkbox" class="admin-spot-option" value="Gate.io" checked />Gate.io</label>
+                      <label><input type="checkbox" class="admin-spot-option" value="MEXC" />MEXC</label>
+                      <label><input type="checkbox" class="admin-spot-option" value="Bitget" />Bitget</label>
+                      <label><input type="checkbox" class="admin-spot-option" value="KuCoin" />KuCoin</label>
+                      <label><input type="checkbox" class="admin-spot-option" value="Binance" />Binance</label>
+                      <label><input type="checkbox" class="admin-spot-option" value="Bybit" />Bybit</label>
+                    </div>
+                    <div class="exchange-group">
+                      <h5>Corretoras FUTUROS</h5>
+                      <label><input type="checkbox" class="admin-futures-option" value="Gate.io Futures" checked />Gate.io Futures</label>
+                      <label><input type="checkbox" class="admin-futures-option" value="MEXC Futures" />MEXC Futures</label>
+                      <label><input type="checkbox" class="admin-futures-option" value="Bitget Futures" />Bitget Futures</label>
+                      <label><input type="checkbox" class="admin-futures-option" value="KuCoin Futures" />KuCoin Futures</label>
+                      <label><input type="checkbox" class="admin-futures-option" value="Binance Futures" />Binance Futures</label>
+                      <label><input type="checkbox" class="admin-futures-option" value="Bybit Futures" />Bybit Futures</label>
+                    </div>
+                  </div>
                   <button type="submit">Cadastrar moeda</button>
                 </form>
                 <form id="adminRemoveCoinForm" class="admin-form">
@@ -2348,14 +2379,14 @@
             </div>
           </div>
 
-          <div class="card" id="adminDiscoveryCard">
-            <h3>Ativos mais negociados (24h)</h3>
-            <div class="card-body admin-tools hidden" id="adminDiscoveryTools">
-              <p class="muted">Escolha as corretoras e busque os pares com maior volume para adicioná-los rapidamente.</p>
-              <div class="discovery-controls">
-                <div class="discovery-exchanges">
-                  <div class="exchange-group">
-                    <h4>SPOT</h4>
+            <div class="card" id="adminDiscoveryCard">
+              <h3>Ativos mais negociados (24h)</h3>
+              <div class="card-body admin-tools hidden" id="adminDiscoveryTools">
+                <p class="muted">Escolha as corretoras e busque os pares com maior volume para adicioná-los rapidamente.</p>
+                <div class="discovery-controls">
+                  <div class="discovery-exchanges">
+                    <div class="exchange-group">
+                      <h4>SPOT</h4>
                     <label><input type="checkbox" class="top-exchange" value="gate_spot" checked />Gate.io Spot</label>
                     <label><input type="checkbox" class="top-exchange" value="mexc_spot" checked />MEXC Spot</label>
                     <label><input type="checkbox" class="top-exchange" value="bitget_spot" checked />Bitget Spot</label>
@@ -2370,22 +2401,40 @@
                     <label><input type="checkbox" class="top-exchange" value="bitget_futures" checked />Bitget Futures</label>
                     <label><input type="checkbox" class="top-exchange" value="kucoin_futures" checked />KuCoin Futures</label>
                     <label><input type="checkbox" class="top-exchange" value="binance_futures" checked />Binance Futures</label>
-                    <label><input type="checkbox" class="top-exchange" value="bybit_futures" checked />Bybit Futures</label>
+                      <label><input type="checkbox" class="top-exchange" value="bybit_futures" checked />Bybit Futures</label>
+                    </div>
+                  </div>
+                  <div class="discovery-actions">
+                    <button type="button" id="discoverTopAssets">Buscar top 24h</button>
+                    <label class="inline-input">
+                      Resultados/página
+                      <select id="topAssetsPageSize">
+                        <option value="6">6</option>
+                        <option value="8" selected>8</option>
+                        <option value="12">12</option>
+                        <option value="20">20</option>
+                      </select>
+                    </label>
+                    <label class="inline-input">
+                      Quantidade de ativos buscados
+                      <select id="topAssetsLimit">
+                        <option value="20">20</option>
+                        <option value="40">40</option>
+                        <option value="60" selected>60</option>
+                        <option value="100">100</option>
+                        <option value="150">150</option>
+                      </select>
+                    </label>
+                    <span id="topAssetsStatus" class="muted"></span>
                   </div>
                 </div>
-                <div class="discovery-actions">
-                  <button type="button" id="discoverTopAssets">Buscar top 24h</button>
-                  <span id="topAssetsStatus" class="muted"></span>
-                </div>
-              </div>
-              <div id="topAssetsResults" class="top-assets-results hidden">
-                <div class="top-assets-card">
+                <div id="topAssetsResults" class="top-assets-results hidden">
+                  <div class="top-assets-card">
                   <div class="top-assets-head">
                     <span>Selecionar</span>
                     <span>Ativo</span>
-                    <span>Símbolo</span>
-                    <span>Volume 24h</span>
-                    <span>Corretoras</span>
+                    <span>Volumes 24h por corretora</span>
+                    <span>Maior volume</span>
                   </div>
                   <div class="top-assets-list" id="topAssetsList"></div>
                   <div class="top-assets-footer">

--- a/public/index.html
+++ b/public/index.html
@@ -247,6 +247,33 @@
       color: var(--text-muted);
     }
 
+    .monitoring-sources {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      padding: 12px;
+      border-radius: 14px;
+      border: 1px dashed rgba(125, 97, 255, 0.35);
+      background: rgba(17, 20, 46, 0.55);
+      font-size: 12px;
+      line-height: 1.4;
+      margin-bottom: 16px;
+    }
+
+    .monitoring-sources strong {
+      font-size: 11px;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      color: var(--text-muted);
+    }
+
+    .monitoring-history-hint {
+      margin-top: 12px;
+      font-size: 12px;
+      line-height: 1.5;
+      color: var(--text-muted);
+    }
+
     .monitoring-table {
       width: 100%;
       border-collapse: collapse;
@@ -1839,6 +1866,12 @@
         <div class="card" id="monitoringTableCard">
           <h3>Oportunidades ativas</h3>
           <div class="card-body">
+            <div class="monitoring-sources">
+              <strong>Fontes em tempo real</strong>
+              <span>SPOT: Gate.io, MEXC, Bitget, KuCoin, Binance e Bybit.</span>
+              <span>FUTUROS perp: Gate.io, MEXC, Bitget, KuCoin, Binance e Bybit.</span>
+              <span>Os dados são normalizados pelo backend em <code>/api/monitoring/markets</code> e exibidos sem amostras artificiais.</span>
+            </div>
             <div class="monitoring-summary">
               <div class="summary-pill">
                 <span class="label">Moedas elegíveis</span>
@@ -1889,7 +1922,9 @@
             <div class="monitoring-chart-wrapper">
               <canvas id="monitoringChart"></canvas>
             </div>
-            <p class="muted" style="margin-top:12px;">Linhas de abertura/fechamento e barras de volume SPOT x FUTUROS ajudam a visualizar onde a arbitragem ganha força.</p>
+            <p class="monitoring-history-hint">
+              <strong>Fonte do histórico:</strong> candles de 1h da Gate.io (<code>/spot/candlesticks</code> x <code>/futures/usdt/candlesticks</code>). Para cada hora calculamos a % de arbitragem comparando o preço de fechamento (e abrimos a linha de abertura com o dado de abertura dos mesmos candles) entre o par SPOT e o contrato perp USDT correspondente. Os volumes plotados representam os volumes reportados pela Gate.io para cada candle SPOT e FUTUROS.
+            </p>
           </div>
         </div>
 

--- a/public/index.html
+++ b/public/index.html
@@ -1966,7 +1966,7 @@
             <div class="monitoring-history-controls">
               <label>Intervalo do candle
                 <select id="monitoringHistoryInterval">
-                  <option value="1m">1 min</option>
+                  <option value="3m">3 min</option>
                   <option value="5m">5 min</option>
                   <option value="15m">15 min</option>
                   <option value="30m">30 min</option>

--- a/public/index.html
+++ b/public/index.html
@@ -2008,11 +2008,11 @@
           <div class="quote-control-row">
             <label><input type="checkbox" id="modeClose" /> Fechar posições (inverter lógica)</label>
           </div>
-          <div class="quote-control-row">
-            <label><input type="checkbox" id="scientificToggle" /> Notação científica (&gt;6 decimais)</label>
-          </div>
-          <div class="quote-control-row">
-            <span>Alerta de dif. (%):</span>
+        <div class="quote-control-row">
+          <label><input type="checkbox" id="scientificToggle" /> Notação científica (&gt;6 decimais)</label>
+        </div>
+        <div class="quote-control-row">
+          <span>Alerta de dif. (%):</span>
             <input id="alertMin" type="number" step="any" class="mono" placeholder="min" />
             <input id="alertMax" type="number" step="any" class="mono" placeholder="max" />
             <label><input type="checkbox" id="soundToggle" /> Som</label>
@@ -2023,6 +2023,11 @@
           <label><input type="checkbox" id="telegramIncludeSymbol" checked /> Nome do ativo</label>
           <label><input type="checkbox" id="telegramIncludeDiff" checked /> Diferença (%)</label>
           <label><input type="checkbox" id="telegramIncludeVolumes" /> Vol. (3 níveis)</label>
+        </div>
+        <div class="quote-control-row">
+          <span>Volume mínimo p/ Telegram (USDT):</span>
+          <input id="telegramMinVolume" type="number" step="0.01" min="0" class="mono" placeholder="ex.: 150" />
+          <span class="hint">Aplica junto aos limites de diferença para disparar o alerta.</span>
         </div>
         <div class="risk-controls">
           <button id="discoverRiskBtn">Descobrir Risco MEXC</button>

--- a/public/index.html
+++ b/public/index.html
@@ -442,6 +442,29 @@
       gap: 18px;
     }
 
+    .admin-grid-wrapper {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      gap: 20px;
+      width: 100%;
+    }
+
+    .admin-form {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+      background: var(--surface-soft);
+      border: 1px solid rgba(125, 97, 255, 0.15);
+      border-radius: 12px;
+      padding: 12px;
+    }
+
+    .admin-access {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
     .blacklist-list {
       display: flex;
       flex-wrap: wrap;
@@ -1534,6 +1557,7 @@
       <nav class="sidebar-nav">
         <button class="sidebar-link active" data-view-target="executionView" id="navExecution">Execução</button>
         <button class="sidebar-link" data-view-target="monitoringView" id="navMonitoring">Monitoramento</button>
+        <button class="sidebar-link" data-view-target="adminView" id="navAdmin">Painel do administrador</button>
       </nav>
       <div class="sidebar-footer">
         <div>Status administrador: <strong id="adminStatusLabel">Visitante</strong></div>
@@ -2011,16 +2035,22 @@
               <label>Corretoras SPOT</label>
               <div class="chip-list">
                 <label><input type="checkbox" class="filter-spot" value="Gate.io" checked /> Gate.io</label>
-                <label><input type="checkbox" class="filter-spot" value="Binance" checked /> Binance</label>
+                <label><input type="checkbox" class="filter-spot" value="MEXC" checked /> MEXC</label>
+                <label><input type="checkbox" class="filter-spot" value="Bitget" checked /> Bitget</label>
                 <label><input type="checkbox" class="filter-spot" value="KuCoin" checked /> KuCoin</label>
+                <label><input type="checkbox" class="filter-spot" value="Binance" checked /> Binance</label>
+                <label><input type="checkbox" class="filter-spot" value="Bybit" checked /> Bybit</label>
               </div>
             </div>
             <div class="filter-group">
               <label>Corretoras FUTUROS</label>
               <div class="chip-list">
-                <label><input type="checkbox" class="filter-futures" value="MEXC Futures" checked /> MEXC</label>
                 <label><input type="checkbox" class="filter-futures" value="Gate.io Futures" checked /> Gate.io</label>
-                <label><input type="checkbox" class="filter-futures" value="Bybit" checked /> Bybit</label>
+                <label><input type="checkbox" class="filter-futures" value="MEXC Futures" checked /> MEXC</label>
+                <label><input type="checkbox" class="filter-futures" value="Bitget Futures" checked /> Bitget</label>
+                <label><input type="checkbox" class="filter-futures" value="KuCoin Futures" checked /> KuCoin</label>
+                <label><input type="checkbox" class="filter-futures" value="Binance Futures" checked /> Binance</label>
+                <label><input type="checkbox" class="filter-futures" value="Bybit Futures" checked /> Bybit</label>
               </div>
             </div>
             <div class="filter-group">
@@ -2171,19 +2201,31 @@
             </p>
           </div>
         </div>
+      </section>
 
-        <div class="card" id="adminCard">
-          <h3>Painel do administrador</h3>
-          <div class="card-body">
+      <section class="page view" id="adminView">
+        <h1>Painel do administrador</h1>
+
+        <div class="card" id="adminAccessCard">
+          <h3>Acesso</h3>
+          <div class="card-body admin-access">
             <form id="adminLoginForm" class="monitoring-actions" autocomplete="off">
               <label for="adminPassword">Senha de acesso:</label>
               <input id="adminPassword" type="password" placeholder="Digite a senha" />
               <button type="submit">Entrar</button>
               <span id="adminLoginFeedback" class="muted"></span>
             </form>
-            <div id="adminTools" class="admin-tools hidden">
+            <p class="muted">Status atual: <strong id="adminStatusLabelInline">Visitante</strong></p>
+          </div>
+        </div>
+
+        <div class="admin-grid-wrapper">
+          <div class="card" id="adminManagementCard">
+            <h3>Gestão de ativos monitorados</h3>
+            <div class="card-body admin-tools hidden" id="adminTools">
               <div class="admin-grid">
-                <form id="adminAddCoinForm">
+                <form id="adminAddCoinForm" class="admin-form">
+                  <h4>Cadastrar moeda</h4>
                   <label>Moeda
                     <input type="text" id="adminCoinSymbol" placeholder="FARM_USDT" required />
                   </label>
@@ -2208,64 +2250,67 @@
                   </label>
                   <button type="submit">Cadastrar moeda</button>
                 </form>
-                <form id="adminRemoveCoinForm">
-                  <label for="adminRemoveCoinSelect">Descadastrar moeda</label>
+                <form id="adminRemoveCoinForm" class="admin-form">
+                  <h4>Descadastrar moeda</h4>
+                  <label for="adminRemoveCoinSelect">Escolha o ativo</label>
                   <select id="adminRemoveCoinSelect"></select>
                   <button type="submit">Remover</button>
                 </form>
-                <form id="blacklistForm">
+                <form id="blacklistForm" class="admin-form">
+                  <h4>Blacklist</h4>
                   <label for="blacklistInput">Adicionar à blacklist</label>
                   <input type="text" id="blacklistInput" placeholder="Ex.: TOKEN_USDT" />
                   <button type="submit">Adicionar</button>
                   <div class="blacklist-list" id="blacklistList"></div>
                 </form>
-                <div class="admin-discovery">
-                  <div class="discovery-header">
-                    <h4>Ativos mais negociados (24h)</h4>
-                    <p class="muted">Escolha as corretoras e busque os pares com maior volume para adicioná-los rapidamente.</p>
+              </div>
+            </div>
+          </div>
+
+          <div class="card" id="adminDiscoveryCard">
+            <h3>Ativos mais negociados (24h)</h3>
+            <div class="card-body admin-tools hidden" id="adminDiscoveryTools">
+              <p class="muted">Escolha as corretoras e busque os pares com maior volume para adicioná-los rapidamente.</p>
+              <div class="discovery-controls">
+                <div class="discovery-exchanges">
+                  <label><input type="checkbox" class="top-exchange" value="gate_spot" checked />Gate.io Spot</label>
+                  <label><input type="checkbox" class="top-exchange" value="mexc_spot" checked />MEXC Spot</label>
+                  <label><input type="checkbox" class="top-exchange" value="bitget_spot" checked />Bitget Spot</label>
+                  <label><input type="checkbox" class="top-exchange" value="kucoin_spot" checked />KuCoin Spot</label>
+                  <label><input type="checkbox" class="top-exchange" value="binance_spot" checked />Binance Spot</label>
+                  <label><input type="checkbox" class="top-exchange" value="bybit_spot" checked />Bybit Spot</label>
+                  <label><input type="checkbox" class="top-exchange" value="gate_futures" checked />Gate.io Futures</label>
+                  <label><input type="checkbox" class="top-exchange" value="mexc_futures" checked />MEXC Futures</label>
+                  <label><input type="checkbox" class="top-exchange" value="bitget_futures" checked />Bitget Futures</label>
+                  <label><input type="checkbox" class="top-exchange" value="kucoin_futures" checked />KuCoin Futures</label>
+                  <label><input type="checkbox" class="top-exchange" value="binance_futures" checked />Binance Futures</label>
+                  <label><input type="checkbox" class="top-exchange" value="bybit_futures" checked />Bybit Futures</label>
+                </div>
+                <div class="discovery-actions">
+                  <button type="button" id="discoverTopAssets">Buscar top 24h</button>
+                  <span id="topAssetsStatus" class="muted"></span>
+                </div>
+              </div>
+              <div id="topAssetsResults" class="top-assets-results hidden">
+                <div class="top-assets-card">
+                  <div class="top-assets-head">
+                    <span>Selecionar</span>
+                    <span>Ativo</span>
+                    <span>Símbolo</span>
+                    <span>Volume 24h</span>
+                    <span>Corretoras</span>
                   </div>
-                  <div class="discovery-controls">
-                    <div class="discovery-exchanges">
-                      <label><input type="checkbox" class="top-exchange" value="gate_spot" checked />Gate.io Spot</label>
-                      <label><input type="checkbox" class="top-exchange" value="mexc_spot" checked />MEXC Spot</label>
-                      <label><input type="checkbox" class="top-exchange" value="bitget_spot" checked />Bitget Spot</label>
-                      <label><input type="checkbox" class="top-exchange" value="kucoin_spot" checked />KuCoin Spot</label>
-                      <label><input type="checkbox" class="top-exchange" value="binance_spot" checked />Binance Spot</label>
-                      <label><input type="checkbox" class="top-exchange" value="bybit_spot" checked />Bybit Spot</label>
-                      <label><input type="checkbox" class="top-exchange" value="gate_futures" checked />Gate.io Futures</label>
-                      <label><input type="checkbox" class="top-exchange" value="mexc_futures" checked />MEXC Futures</label>
-                      <label><input type="checkbox" class="top-exchange" value="bitget_futures" checked />Bitget Futures</label>
-                      <label><input type="checkbox" class="top-exchange" value="kucoin_futures" checked />KuCoin Futures</label>
-                      <label><input type="checkbox" class="top-exchange" value="binance_futures" checked />Binance Futures</label>
-                      <label><input type="checkbox" class="top-exchange" value="bybit_futures" checked />Bybit Futures</label>
+                  <div class="top-assets-list" id="topAssetsList"></div>
+                  <div class="top-assets-footer">
+                    <span id="topAssetsPaginationInfo" class="muted"></span>
+                    <div class="top-assets-pagination">
+                      <button type="button" id="topAssetsPrev">Anterior</button>
+                      <span id="topAssetsPaginationStatus" class="muted"></span>
+                      <button type="button" id="topAssetsNext">Próxima</button>
                     </div>
-                    <div class="discovery-actions">
-                      <button type="button" id="discoverTopAssets">Buscar top 24h</button>
-                      <span id="topAssetsStatus" class="muted"></span>
-                    </div>
-                  </div>
-                  <div id="topAssetsResults" class="top-assets-results hidden">
-                    <div class="top-assets-card">
-                      <div class="top-assets-head">
-                        <span>Selecionar</span>
-                        <span>Ativo</span>
-                        <span>Símbolo</span>
-                        <span>Volume 24h</span>
-                        <span>Corretoras</span>
-                      </div>
-                      <div class="top-assets-list" id="topAssetsList"></div>
-                      <div class="top-assets-footer">
-                        <span id="topAssetsPaginationInfo" class="muted"></span>
-                        <div class="top-assets-pagination">
-                          <button type="button" id="topAssetsPrev">Anterior</button>
-                          <span id="topAssetsPaginationStatus" class="muted"></span>
-                          <button type="button" id="topAssetsNext">Próxima</button>
-                        </div>
-                      </div>
-                    </div>
-                    <button type="button" id="addSelectedTopAssets">Adicionar selecionados</button>
                   </div>
                 </div>
+                <button type="button" id="addSelectedTopAssets">Adicionar selecionados</button>
               </div>
             </div>
           </div>

--- a/public/index.html
+++ b/public/index.html
@@ -553,46 +553,40 @@
 .quote-chip-container {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 6px;
 }
 
-.quote-chip {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 6px 8px;
-  border-radius: 10px;
-  margin-bottom: 6px;
+.quote-price {
   font-size: 12px;
-  gap: 10px;
-  background: rgba(125, 97, 255, 0.08);
-  border: 1px solid rgba(125, 97, 255, 0.25);
-}
-
-.quote-chip.ask {
-  border-color: rgba(63, 231, 195, 0.35);
-  background: rgba(63, 231, 195, 0.06);
-}
-
-.quote-chip.bid {
-  border-color: rgba(242, 183, 96, 0.45);
-  background: rgba(242, 183, 96, 0.06);
-}
-
-.quote-chip span {
-  font-size: 11px;
   color: var(--text-muted);
 }
 
-.quote-chip strong {
+.quote-price strong {
   color: var(--text);
-  letter-spacing: 0.02em;
 }
 
-.quote-chip em {
-  font-style: normal;
-  color: var(--text-muted);
-  font-size: 11px;
+.volume-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 10px;
+  border-radius: 12px;
+  font-size: 12px;
+  font-weight: 600;
+  gap: 6px;
+  width: fit-content;
+}
+
+.volume-chip.volume-spot {
+  background: rgba(80, 132, 233, 0.14);
+  border: 1px solid rgba(80, 132, 233, 0.35);
+  color: #2c73d2;
+}
+
+.volume-chip.volume-futures {
+  background: rgba(242, 183, 96, 0.18);
+  border: 1px solid rgba(242, 183, 96, 0.45);
+  color: #c76b08;
 }
 
 .volume-badges.compact {

--- a/public/index.html
+++ b/public/index.html
@@ -247,6 +247,69 @@
       color: var(--text-muted);
     }
 
+    .monitoring-refresh-bar {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 12px;
+      margin-bottom: 16px;
+      font-size: 13px;
+    }
+
+    .monitoring-refresh-bar label {
+      font-size: 11px;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      color: var(--text-muted);
+    }
+
+    .monitoring-refresh-bar select {
+      border-radius: 10px;
+      border: 1px solid rgba(125, 97, 255, 0.35);
+      background: rgba(9, 11, 32, 0.85);
+      color: var(--text);
+      padding: 6px 10px;
+      font-size: 13px;
+    }
+
+    .monitoring-refresh-note {
+      color: var(--text-muted);
+      font-size: 12px;
+    }
+
+    .monitoring-pagination {
+      margin-top: 12px;
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: space-between;
+      align-items: center;
+      gap: 12px;
+      font-size: 13px;
+      border-top: 1px solid rgba(125, 97, 255, 0.15);
+      padding-top: 12px;
+    }
+
+    .pagination-controls {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .pagination-controls button {
+      border-radius: 999px;
+      border: 1px solid rgba(125, 97, 255, 0.35);
+      background: rgba(18, 22, 54, 0.75);
+      color: var(--text);
+      padding: 6px 14px;
+      font-size: 12px;
+      cursor: pointer;
+    }
+
+    .pagination-controls button:disabled {
+      opacity: 0.45;
+      cursor: not-allowed;
+    }
+
     .monitoring-sources {
       display: flex;
       flex-direction: column;
@@ -1934,6 +1997,17 @@
                 <strong id="monitoringSummaryBlacklist">0</strong>
               </div>
             </div>
+            <div class="monitoring-refresh-bar">
+              <label for="monitoringRefreshInterval">Frequência de atualização</label>
+              <select id="monitoringRefreshInterval">
+                <option value="1">1s</option>
+                <option value="2">2s</option>
+                <option value="3" selected>3s</option>
+                <option value="4">4s</option>
+                <option value="5">5s</option>
+              </select>
+              <span class="monitoring-refresh-note">Atualiza automaticamente as oportunidades após os filtros ativos.</span>
+            </div>
             <div class="table-scroll">
               <table class="monitoring-table">
                 <thead>
@@ -1951,6 +2025,14 @@
                 </thead>
                 <tbody id="monitoringTableBody"></tbody>
               </table>
+            </div>
+            <div class="monitoring-pagination" id="monitoringPagination">
+              <div id="monitoringPaginationInfo">Nenhuma oportunidade encontrada</div>
+              <div class="pagination-controls">
+                <button type="button" id="monitoringPaginationPrev" disabled>Anterior</button>
+                <span id="monitoringPaginationStatus">Página 0 de 0</span>
+                <button type="button" id="monitoringPaginationNext" disabled>Próxima</button>
+              </div>
             </div>
           </div>
         </div>

--- a/public/index.html
+++ b/public/index.html
@@ -46,6 +46,107 @@
       display: flex;
       justify-content: center;
       line-height: 1.5;
+      padding: 0 16px;
+    }
+
+    .app-shell {
+      width: min(1400px, 100%);
+      display: flex;
+      gap: 24px;
+      align-items: flex-start;
+      padding: 56px 0 80px;
+      position: relative;
+      z-index: 1;
+      transition: padding-left 0.3s ease;
+    }
+
+    .app-shell.sidebar-hidden .sidebar {
+      transform: translateX(-120%);
+      opacity: 0;
+      pointer-events: none;
+    }
+
+    .app-shell.sidebar-hidden .sidebar-toggle {
+      left: 8px;
+    }
+
+    .sidebar {
+      width: 240px;
+      background: rgba(15, 18, 48, 0.85);
+      border: 1px solid rgba(125, 97, 255, 0.35);
+      border-radius: 20px;
+      padding: 20px;
+      box-shadow: 0 25px 50px -30px var(--card-glow);
+      backdrop-filter: blur(18px);
+      position: sticky;
+      top: 40px;
+      height: fit-content;
+      transition: transform 0.3s ease, opacity 0.3s ease;
+    }
+
+    .sidebar-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 24px;
+      gap: 12px;
+    }
+
+    .sidebar-header strong {
+      font-family: 'Rajdhani', 'Inter', sans-serif;
+      font-size: 20px;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+    }
+
+    .sidebar-toggle {
+      border-radius: 999px;
+      border: 1px solid rgba(125, 97, 255, 0.35);
+      background: rgba(125, 97, 255, 0.12);
+      color: var(--text);
+      padding: 6px 14px;
+      font-size: 12px;
+      letter-spacing: 0.05em;
+      cursor: pointer;
+    }
+
+    .sidebar-nav {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .sidebar-link {
+      width: 100%;
+      text-align: left;
+      background: rgba(18, 22, 54, 0.8);
+      border: 1px solid rgba(125, 97, 255, 0.25);
+      color: var(--text);
+      padding: 10px 14px;
+      border-radius: 12px;
+      font-weight: 600;
+      letter-spacing: 0.04em;
+    }
+
+    .sidebar-link.active {
+      background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+      color: #050712;
+      box-shadow: 0 12px 26px -12px var(--card-glow);
+    }
+
+    .sidebar-footer {
+      margin-top: 24px;
+      font-size: 12px;
+      color: var(--text-muted);
+      line-height: 1.4;
+    }
+
+    .app-main {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      gap: 32px;
+      align-items: center;
     }
 
     body::before {
@@ -61,13 +162,165 @@
     }
 
     .page {
-      width: min(1180px, 100% - 48px);
-      margin: 56px 0 80px;
+      width: min(1180px, 100%);
+      margin: 0 auto;
       display: flex;
       flex-direction: column;
       gap: 24px;
       position: relative;
       z-index: 1;
+    }
+
+    .view {
+      display: none;
+    }
+
+    .view.active {
+      display: flex;
+    }
+
+    #monitoringView {
+      gap: 20px;
+    }
+
+    .monitoring-filters {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 16px;
+    }
+
+    .filter-group {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      font-size: 13px;
+    }
+
+    .filter-group label {
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: var(--text-muted);
+    }
+
+    .chip-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+
+    .chip-list label {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 6px 12px;
+      border-radius: 999px;
+      background: rgba(26, 28, 60, 0.8);
+      border: 1px solid rgba(125, 97, 255, 0.25);
+      font-size: 12px;
+      letter-spacing: 0.04em;
+      cursor: pointer;
+    }
+
+    .monitoring-summary {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 12px;
+      margin-bottom: 14px;
+      font-size: 13px;
+    }
+
+    .summary-pill {
+      border-radius: 14px;
+      border: 1px solid rgba(125, 97, 255, 0.25);
+      padding: 12px;
+      background: rgba(20, 22, 52, 0.6);
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+
+    .summary-pill span.label {
+      font-size: 11px;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      color: var(--text-muted);
+    }
+
+    .monitoring-table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+
+    .monitoring-table th,
+    .monitoring-table td {
+      padding: 8px 10px;
+      text-align: left;
+      border-bottom: 1px solid rgba(125, 97, 255, 0.12);
+    }
+
+    .monitoring-table th {
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      font-size: 11px;
+      color: var(--text-muted);
+    }
+
+    .monitoring-table td strong {
+      font-family: 'Rajdhani', 'Inter', sans-serif;
+      letter-spacing: 0.04em;
+    }
+
+    .monitoring-table button {
+      padding: 4px 10px;
+      font-size: 11px;
+      letter-spacing: 0.04em;
+    }
+
+    .monitoring-chart-wrapper {
+      width: 100%;
+      height: 320px;
+    }
+
+    .admin-tools {
+      margin-top: 16px;
+      display: flex;
+      flex-direction: column;
+      gap: 18px;
+    }
+
+    .admin-tools.hidden {
+      display: none;
+    }
+
+    .admin-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      gap: 18px;
+    }
+
+    .blacklist-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+
+    .blacklist-list span {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 6px 10px;
+      border-radius: 12px;
+      background: rgba(255, 107, 154, 0.15);
+      border: 1px solid rgba(255, 107, 154, 0.4);
+      font-size: 12px;
+    }
+
+    .monitoring-actions {
+      display: flex;
+      gap: 10px;
+      flex-wrap: wrap;
+      align-items: center;
     }
 
     h1 {
@@ -1054,7 +1307,26 @@
   <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom@2.0.1/dist/chartjs-plugin-zoom.umd.min.js"></script>
 </head>
 <body>
-  <div class="page">
+  <div class="app-shell" id="appShell">
+    <aside class="sidebar" id="sidebar">
+      <div class="sidebar-header">
+        <div>
+          <strong>ArbiSync</strong>
+          <div class="muted" style="font-size:12px; letter-spacing:0.08em; text-transform:uppercase;">Painel</div>
+        </div>
+        <button class="sidebar-toggle" id="sidebarToggle" type="button">Mostrar/Ocultar</button>
+      </div>
+      <nav class="sidebar-nav">
+        <button class="sidebar-link active" data-view-target="executionView" id="navExecution">Execução</button>
+        <button class="sidebar-link" data-view-target="monitoringView" id="navMonitoring">Monitoramento</button>
+      </nav>
+      <div class="sidebar-footer">
+        <div>Status administrador: <strong id="adminStatusLabel">Visitante</strong></div>
+        <div>Use o login no painel para liberar cadastro de moedas e blacklist.</div>
+      </div>
+    </aside>
+    <main class="app-main">
+      <section class="page view active" id="executionView">
   <h1>Arbitragem <span data-spot-label>Gate.io</span> x MEXC — <span id="titleSymbol">BASE_USDT</span></h1>
 
   <div class="instance-tabs" id="instanceTabs"></div>
@@ -1503,7 +1775,179 @@
     </div>
   </div>
 
-  <script src="scripts.js"></script>
+      </section>
+
+      <section class="page view" id="monitoringView">
+        <h1>Monitoramento inteligente de arbitragem</h1>
+
+        <div class="card" id="monitoringFiltersCard">
+          <h3>Filtros avançados</h3>
+          <div class="card-body monitoring-filters">
+            <div class="filter-group">
+              <label for="filterSearch">Buscar moeda</label>
+              <input type="text" id="filterSearch" placeholder="Ex.: CPOOL" />
+            </div>
+            <div class="filter-group">
+              <label for="filterMinArb">% de Arb mínima</label>
+              <input type="range" id="filterMinArb" min="0" max="10" step="0.5" value="0" />
+              <span id="filterMinArbValue" class="muted">0%</span>
+            </div>
+            <div class="filter-group">
+              <label>Corretoras SPOT</label>
+              <div class="chip-list">
+                <label><input type="checkbox" class="filter-spot" value="Gate.io" checked /> Gate.io</label>
+                <label><input type="checkbox" class="filter-spot" value="Binance" checked /> Binance</label>
+                <label><input type="checkbox" class="filter-spot" value="KuCoin" checked /> KuCoin</label>
+              </div>
+            </div>
+            <div class="filter-group">
+              <label>Corretoras FUTUROS</label>
+              <div class="chip-list">
+                <label><input type="checkbox" class="filter-futures" value="MEXC Futures" checked /> MEXC</label>
+                <label><input type="checkbox" class="filter-futures" value="Gate.io Futures" checked /> Gate.io</label>
+                <label><input type="checkbox" class="filter-futures" value="Bybit" checked /> Bybit</label>
+              </div>
+            </div>
+            <div class="filter-group">
+              <label for="filterVolume">Volume mínimo (24h)</label>
+              <select id="filterVolume">
+                <option value="0">Sem filtro</option>
+                <option value="100000">≥ 100k USDT</option>
+                <option value="500000">≥ 500k USDT</option>
+                <option value="1000000">≥ 1M USDT</option>
+              </select>
+            </div>
+            <div class="filter-group">
+              <label>Perfil de risco</label>
+              <div class="chip-list">
+                <label><input type="checkbox" class="filter-risk" value="Baixo" checked /> Baixo</label>
+                <label><input type="checkbox" class="filter-risk" value="Médio" checked /> Médio</label>
+                <label><input type="checkbox" class="filter-risk" value="Alto" /> Alto</label>
+              </div>
+            </div>
+            <div class="filter-group">
+              <label for="filterStability">Estabilidade mínima</label>
+              <select id="filterStability">
+                <option value="flex">Qualquer</option>
+                <option value="Estável">Estável</option>
+                <option value="Volátil">Volátil apenas</option>
+              </select>
+            </div>
+          </div>
+        </div>
+
+        <div class="card" id="monitoringTableCard">
+          <h3>Oportunidades ativas</h3>
+          <div class="card-body">
+            <div class="monitoring-summary">
+              <div class="summary-pill">
+                <span class="label">Moedas elegíveis</span>
+                <strong id="monitoringResultCount">0</strong>
+              </div>
+              <div class="summary-pill">
+                <span class="label">Melhor arb</span>
+                <strong id="monitoringSummaryBest">-</strong>
+              </div>
+              <div class="summary-pill">
+                <span class="label">Média filtrada</span>
+                <strong id="monitoringSummaryAvg">0%</strong>
+              </div>
+              <div class="summary-pill">
+                <span class="label">Blacklist ativa</span>
+                <strong id="monitoringSummaryBlacklist">0</strong>
+              </div>
+            </div>
+            <div class="table-scroll">
+              <table class="monitoring-table">
+                <thead>
+                  <tr>
+                    <th>Par</th>
+                    <th>% Arb</th>
+                    <th>Corretoras SPOT</th>
+                    <th>Corretoras FUTUROS</th>
+                    <th>Volume 24h</th>
+                    <th>Profundidade</th>
+                    <th>Funding</th>
+                    <th>Risco</th>
+                    <th></th>
+                  </tr>
+                </thead>
+                <tbody id="monitoringTableBody"></tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+
+        <div class="card" id="monitoringChartCard">
+          <h3>Histórico de % de Arb (24h)</h3>
+          <div class="card-body">
+            <div class="monitoring-actions">
+              <label for="monitoringPairSelect">Moeda:</label>
+              <select id="monitoringPairSelect"></select>
+              <button id="refreshMonitoringChart" type="button">Atualizar gráfico</button>
+            </div>
+            <div class="monitoring-chart-wrapper">
+              <canvas id="monitoringChart"></canvas>
+            </div>
+            <p class="muted" style="margin-top:12px;">Linhas de abertura/fechamento e barras de volume SPOT x FUTUROS ajudam a visualizar onde a arbitragem ganha força.</p>
+          </div>
+        </div>
+
+        <div class="card" id="adminCard">
+          <h3>Painel do administrador</h3>
+          <div class="card-body">
+            <form id="adminLoginForm" class="monitoring-actions" autocomplete="off">
+              <label for="adminPassword">Senha de acesso:</label>
+              <input id="adminPassword" type="password" placeholder="Digite a senha" />
+              <button type="submit">Entrar</button>
+              <span id="adminLoginFeedback" class="muted"></span>
+            </form>
+            <div id="adminTools" class="admin-tools hidden">
+              <div class="admin-grid">
+                <form id="adminAddCoinForm">
+                  <label>Moeda
+                    <input type="text" id="adminCoinSymbol" placeholder="FARM_USDT" required />
+                  </label>
+                  <label>Nome amigável
+                    <input type="text" id="adminCoinName" placeholder="Harvest Finance" required />
+                  </label>
+                  <label>Corretoras spot (separadas por vírgula)
+                    <input type="text" id="adminCoinSpot" placeholder="Gate.io, Binance" />
+                  </label>
+                  <label>Corretoras futuros (separadas por vírgula)
+                    <input type="text" id="adminCoinFutures" placeholder="MEXC Futures" />
+                  </label>
+                  <label>Meta de % arb
+                    <input type="number" id="adminCoinArb" min="0" step="0.1" value="1.5" />
+                  </label>
+                  <label>Nível de risco
+                    <select id="adminCoinRisk">
+                      <option value="Baixo">Baixo</option>
+                      <option value="Médio">Médio</option>
+                      <option value="Alto">Alto</option>
+                    </select>
+                  </label>
+                  <button type="submit">Cadastrar moeda</button>
+                </form>
+                <form id="adminRemoveCoinForm">
+                  <label for="adminRemoveCoinSelect">Descadastrar moeda</label>
+                  <select id="adminRemoveCoinSelect"></select>
+                  <button type="submit">Remover</button>
+                </form>
+                <form id="blacklistForm">
+                  <label for="blacklistInput">Adicionar à blacklist</label>
+                  <input type="text" id="blacklistInput" placeholder="Ex.: TOKEN_USDT" />
+                  <button type="submit">Adicionar</button>
+                  <div class="blacklist-list" id="blacklistList"></div>
+                </form>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
   </div>
+
+  <script src="scripts.js"></script>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -2000,6 +2000,7 @@
             <div class="monitoring-refresh-bar">
               <label for="monitoringRefreshInterval">Frequência de atualização</label>
               <select id="monitoringRefreshInterval">
+                <option value="0.5">0.5s</option>
                 <option value="1">1s</option>
                 <option value="2">2s</option>
                 <option value="3" selected>3s</option>
@@ -2137,6 +2138,36 @@
                   <button type="submit">Adicionar</button>
                   <div class="blacklist-list" id="blacklistList"></div>
                 </form>
+                <div class="admin-discovery">
+                  <div class="discovery-header">
+                    <h4>Ativos mais negociados (24h)</h4>
+                    <p class="muted">Escolha as corretoras e busque os pares com maior volume para adicioná-los rapidamente.</p>
+                  </div>
+                  <div class="discovery-controls">
+                    <div class="discovery-exchanges">
+                      <label><input type="checkbox" class="top-exchange" value="gate_spot" checked />Gate.io Spot</label>
+                      <label><input type="checkbox" class="top-exchange" value="mexc_spot" checked />MEXC Spot</label>
+                      <label><input type="checkbox" class="top-exchange" value="bitget_spot" checked />Bitget Spot</label>
+                      <label><input type="checkbox" class="top-exchange" value="kucoin_spot" checked />KuCoin Spot</label>
+                      <label><input type="checkbox" class="top-exchange" value="binance_spot" checked />Binance Spot</label>
+                      <label><input type="checkbox" class="top-exchange" value="bybit_spot" checked />Bybit Spot</label>
+                      <label><input type="checkbox" class="top-exchange" value="gate_futures" checked />Gate.io Futures</label>
+                      <label><input type="checkbox" class="top-exchange" value="mexc_futures" checked />MEXC Futures</label>
+                      <label><input type="checkbox" class="top-exchange" value="bitget_futures" checked />Bitget Futures</label>
+                      <label><input type="checkbox" class="top-exchange" value="kucoin_futures" checked />KuCoin Futures</label>
+                      <label><input type="checkbox" class="top-exchange" value="binance_futures" checked />Binance Futures</label>
+                      <label><input type="checkbox" class="top-exchange" value="bybit_futures" checked />Bybit Futures</label>
+                    </div>
+                    <div class="discovery-actions">
+                      <button type="button" id="discoverTopAssets">Buscar top 24h</button>
+                      <span id="topAssetsStatus" class="muted"></span>
+                    </div>
+                  </div>
+                  <div id="topAssetsResults" class="top-assets-results hidden">
+                    <div class="top-assets-list" id="topAssetsList"></div>
+                    <button type="button" id="addSelectedTopAssets">Adicionar selecionados</button>
+                  </div>
+                </div>
               </div>
             </div>
           </div>

--- a/public/index.html
+++ b/public/index.html
@@ -1789,7 +1789,7 @@
             </div>
             <div class="filter-group">
               <label for="filterMinArb">% de Arb mínima</label>
-              <input type="range" id="filterMinArb" min="0" max="10" step="0.5" value="0" />
+              <input type="range" id="filterMinArb" min="0" max="10" step="0.1" value="0" />
               <span id="filterMinArbValue" class="muted">0%</span>
             </div>
             <div class="filter-group">

--- a/public/index.html
+++ b/public/index.html
@@ -66,8 +66,8 @@
       pointer-events: none;
     }
 
-    .app-shell.sidebar-hidden .sidebar-toggle {
-      left: 8px;
+    .app-shell.sidebar-hidden .sidebar-toggle-floating {
+      box-shadow: 0 10px 30px -16px rgba(0, 0, 0, 0.8);
     }
 
     .sidebar {
@@ -108,6 +108,15 @@
       font-size: 12px;
       letter-spacing: 0.05em;
       cursor: pointer;
+    }
+
+    .sidebar-toggle-floating {
+      position: absolute;
+      top: 18px;
+      left: 14px;
+      z-index: 5;
+      box-shadow: 0 18px 38px -24px var(--card-glow);
+      transform: none;
     }
 
     .sidebar-nav {
@@ -455,6 +464,78 @@
       gap: 10px;
       flex-wrap: wrap;
       align-items: center;
+    }
+
+    .top-assets-results {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .top-assets-card {
+      background: var(--surface);
+      border: 1px solid rgba(125, 97, 255, 0.24);
+      border-radius: 14px;
+      overflow: hidden;
+      box-shadow: 0 18px 40px -28px var(--card-glow);
+    }
+
+    .top-assets-head,
+    .top-assets-row {
+      display: grid;
+      grid-template-columns: 0.7fr 1.4fr 1.1fr 1fr 1.3fr;
+      gap: 12px;
+      padding: 10px 14px;
+      align-items: center;
+    }
+
+    .top-assets-head {
+      background: rgba(18, 22, 54, 0.9);
+      font-size: 12px;
+      letter-spacing: 0.04em;
+      color: var(--text-muted);
+      text-transform: uppercase;
+      border-bottom: 1px solid rgba(125, 97, 255, 0.18);
+    }
+
+    .top-assets-list {
+      max-height: 280px;
+      overflow: auto;
+    }
+
+    .top-assets-row {
+      border-bottom: 1px solid rgba(125, 97, 255, 0.08);
+      font-size: 13px;
+      background: rgba(14, 16, 40, 0.65);
+    }
+
+    .top-assets-row input {
+      width: 16px;
+      height: 16px;
+      accent-color: var(--accent);
+    }
+
+    .top-assets-row:nth-child(even) {
+      background: rgba(14, 16, 40, 0.5);
+    }
+
+    .top-assets-row .asset-volume {
+      font-variant-numeric: tabular-nums;
+    }
+
+    .top-assets-footer {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 10px 14px;
+      background: rgba(18, 22, 54, 0.85);
+      border-top: 1px solid rgba(125, 97, 255, 0.18);
+    }
+
+    .top-assets-pagination {
+      display: flex;
+      align-items: center;
+      gap: 8px;
     }
 
     h1 {
@@ -1442,13 +1523,13 @@
 </head>
 <body>
   <div class="app-shell" id="appShell">
+    <button class="sidebar-toggle sidebar-toggle-floating" id="sidebarToggle" type="button">Mostrar/Ocultar</button>
     <aside class="sidebar" id="sidebar">
       <div class="sidebar-header">
         <div>
           <strong>ArbiSync</strong>
           <div class="muted" style="font-size:12px; letter-spacing:0.08em; text-transform:uppercase;">Painel</div>
         </div>
-        <button class="sidebar-toggle" id="sidebarToggle" type="button">Mostrar/Ocultar</button>
       </div>
       <nav class="sidebar-nav">
         <button class="sidebar-link active" data-view-target="executionView" id="navExecution">Execução</button>
@@ -1923,7 +2004,7 @@
             </div>
             <div class="filter-group">
               <label for="filterMinArb">% de Arb mínima</label>
-              <input type="range" id="filterMinArb" min="0" max="10" step="0.1" value="0" />
+              <input type="range" id="filterMinArb" min="0" max="10" step="0.05" value="0" />
               <span id="filterMinArbValue" class="muted">0%</span>
             </div>
             <div class="filter-group">
@@ -2164,7 +2245,24 @@
                     </div>
                   </div>
                   <div id="topAssetsResults" class="top-assets-results hidden">
-                    <div class="top-assets-list" id="topAssetsList"></div>
+                    <div class="top-assets-card">
+                      <div class="top-assets-head">
+                        <span>Selecionar</span>
+                        <span>Ativo</span>
+                        <span>Símbolo</span>
+                        <span>Volume 24h</span>
+                        <span>Corretoras</span>
+                      </div>
+                      <div class="top-assets-list" id="topAssetsList"></div>
+                      <div class="top-assets-footer">
+                        <span id="topAssetsPaginationInfo" class="muted"></span>
+                        <div class="top-assets-pagination">
+                          <button type="button" id="topAssetsPrev">Anterior</button>
+                          <span id="topAssetsPaginationStatus" class="muted"></span>
+                          <button type="button" id="topAssetsNext">Próxima</button>
+                        </div>
+                      </div>
+                    </div>
                     <button type="button" id="addSelectedTopAssets">Adicionar selecionados</button>
                   </div>
                 </div>

--- a/public/index.html
+++ b/public/index.html
@@ -447,6 +447,16 @@
       color: #3fe7c3;
     }
 
+    .monitoring-extremes .extreme-min {
+      color: #f87171;
+      font-weight: 700;
+    }
+
+    .monitoring-extremes .extreme-max {
+      color: #34d399;
+      font-weight: 700;
+    }
+
     .monitoring-history-source {
       margin-top: 4px;
       font-size: 12px;

--- a/public/index.html
+++ b/public/index.html
@@ -274,6 +274,50 @@
       color: var(--text-muted);
     }
 
+    .monitoring-history-controls {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 12px;
+      margin: 16px 0;
+    }
+
+    .monitoring-history-controls label {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      font-size: 12px;
+      color: var(--text-muted);
+    }
+
+    .monitoring-history-controls select {
+      border-radius: 10px;
+      border: 1px solid rgba(125, 97, 255, 0.4);
+      background: rgba(9, 11, 32, 0.8);
+      color: var(--text);
+      padding: 8px 10px;
+      font-size: 13px;
+    }
+
+    .monitoring-history-source {
+      margin-top: 4px;
+      font-size: 12px;
+      color: var(--text-muted);
+    }
+
+    .monitoring-history-status {
+      margin-top: 6px;
+      font-size: 13px;
+      color: var(--text-muted);
+    }
+
+    .monitoring-history-status.success {
+      color: var(--success);
+    }
+
+    .monitoring-history-status.error {
+      color: var(--danger);
+    }
+
     .monitoring-table {
       width: 100%;
       border-collapse: collapse;
@@ -1919,11 +1963,47 @@
               <select id="monitoringPairSelect"></select>
               <button id="refreshMonitoringChart" type="button">Atualizar gráfico</button>
             </div>
+            <div class="monitoring-history-controls">
+              <label>Intervalo do candle
+                <select id="monitoringHistoryInterval">
+                  <option value="1m">1 min</option>
+                  <option value="5m">5 min</option>
+                  <option value="15m">15 min</option>
+                  <option value="30m">30 min</option>
+                  <option value="1h" selected>1 hora</option>
+                  <option value="4h">4 horas</option>
+                </select>
+              </label>
+              <label>Corretora SPOT
+                <select id="monitoringHistorySpot">
+                  <option value="gate_spot" selected>Gate.io (SPOT)</option>
+                  <option value="mexc_spot">MEXC (SPOT)</option>
+                  <option value="bitget_spot">Bitget (SPOT)</option>
+                  <option value="kucoin_spot">KuCoin (SPOT)</option>
+                  <option value="binance_spot">Binance (SPOT)</option>
+                  <option value="bybit_spot">Bybit (SPOT)</option>
+                </select>
+              </label>
+              <label>Corretora FUTUROS
+                <select id="monitoringHistoryFutures">
+                  <option value="gate_futures" selected>Gate.io Futures</option>
+                  <option value="mexc_futures">MEXC Futures</option>
+                  <option value="bitget_futures">Bitget Futures</option>
+                  <option value="kucoin_futures">KuCoin Futures</option>
+                  <option value="binance_futures">Binance Futures</option>
+                  <option value="bybit_futures">Bybit Futures</option>
+                </select>
+              </label>
+            </div>
+            <p id="monitoringHistorySource" class="monitoring-history-source">
+              Selecione um par, intervalo e corretoras para ver como a % de arbitragem evoluiu nas últimas 24 horas.
+            </p>
+            <p id="monitoringHistoryStatus" class="monitoring-history-status"></p>
             <div class="monitoring-chart-wrapper">
               <canvas id="monitoringChart"></canvas>
             </div>
             <p class="monitoring-history-hint">
-              <strong>Fonte do histórico:</strong> candles de 1h da Gate.io (<code>/spot/candlesticks</code> x <code>/futures/usdt/candlesticks</code>). Para cada hora calculamos a % de arbitragem comparando o preço de fechamento (e abrimos a linha de abertura com o dado de abertura dos mesmos candles) entre o par SPOT e o contrato perp USDT correspondente. Os volumes plotados representam os volumes reportados pela Gate.io para cada candle SPOT e FUTUROS.
+              <strong>Como calculamos:</strong> o endpoint <code>/api/monitoring/history</code> consulta em tempo real os candles oficiais das corretoras selecionadas (Gate.io, MEXC, Bitget, KuCoin, Binance e Bybit — SPOT e perp USDT). Cada candle traz os preços de abertura/fechamento e volumes de SPOT e FUTUROS; combinamos esses valores para gerar as linhas de abertura/fechamento do % de arbitragem e as barras de volume correspondentes para as últimas 24 horas.
             </p>
           </div>
         </div>

--- a/public/index.html
+++ b/public/index.html
@@ -501,11 +501,42 @@
       letter-spacing: 0.04em;
     }
 
-.monitoring-table button {
-  padding: 4px 10px;
-  font-size: 11px;
-  letter-spacing: 0.04em;
-}
+    .col-hidden {
+      display: none;
+    }
+
+    .monitoring-column-controls {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin: 10px 0 6px;
+      font-size: 12px;
+      color: var(--text-muted);
+    }
+
+    .monitoring-column-controls label {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 6px 10px;
+      border: 1px solid rgba(125, 97, 255, 0.25);
+      border-radius: 10px;
+      background: rgba(26, 28, 60, 0.5);
+      color: var(--text-primary);
+      cursor: pointer;
+    }
+
+    .volume-inline {
+      display: inline-flex;
+      gap: 8px;
+      align-items: center;
+    }
+
+    .monitoring-table button {
+      padding: 4px 10px;
+      font-size: 11px;
+      letter-spacing: 0.04em;
+    }
 
 .monitoring-actions-cell {
   display: flex;
@@ -2340,17 +2371,25 @@
               </div>
               <span class="monitoring-refresh-note">Atualiza automaticamente as oportunidades após os filtros ativos. Favoritos permanecem no topo.</span>
             </div>
+            <div class="monitoring-column-controls" id="monitoringColumnControls">
+              <span>Colunas:</span>
+              <label><input type="checkbox" class="monitoring-column-toggle" data-col="spot" checked />Corretoras SPOT</label>
+              <label><input type="checkbox" class="monitoring-column-toggle" data-col="futures" checked />Corretoras FUTUROS</label>
+              <label><input type="checkbox" class="monitoring-column-toggle" data-col="volume" checked />Volume 24h</label>
+              <label><input type="checkbox" class="monitoring-column-toggle" data-col="favorite" checked />Favorito</label>
+              <label><input type="checkbox" class="monitoring-column-toggle" data-col="actions" checked />Ações</label>
+            </div>
             <div class="table-scroll">
               <table class="monitoring-table">
                 <thead>
                   <tr>
-                    <th>Par</th>
-                    <th>% Arb</th>
-                    <th>Corretoras SPOT</th>
-                    <th>Corretoras FUTUROS</th>
-                    <th>Volume 24h</th>
-                    <th>Favorito</th>
-                    <th>Ações</th>
+                    <th class="col-symbol">Par</th>
+                    <th class="col-arb">% Arb</th>
+                    <th class="col-spot">Corretoras SPOT</th>
+                    <th class="col-futures">Corretoras FUTUROS</th>
+                    <th class="col-volume">Volume 24h</th>
+                    <th class="col-favorite">Favorito</th>
+                    <th class="col-actions">Ações</th>
                   </tr>
                 </thead>
                 <tbody id="monitoringTableBody"></tbody>

--- a/public/index.html
+++ b/public/index.html
@@ -256,14 +256,14 @@
       color: var(--text-muted);
     }
 
-    .monitoring-refresh-bar {
-      display: flex;
-      flex-wrap: wrap;
-      align-items: center;
-      gap: 12px;
-      margin-bottom: 16px;
-      font-size: 13px;
-    }
+.monitoring-refresh-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 16px;
+  font-size: 13px;
+}
 
     .monitoring-refresh-bar label {
       font-size: 11px;
@@ -272,19 +272,45 @@
       color: var(--text-muted);
     }
 
-    .monitoring-refresh-bar select {
-      border-radius: 10px;
-      border: 1px solid rgba(125, 97, 255, 0.35);
-      background: rgba(9, 11, 32, 0.85);
+.monitoring-refresh-bar select {
+  border-radius: 10px;
+  border: 1px solid rgba(125, 97, 255, 0.35);
+  background: rgba(9, 11, 32, 0.85);
       color: var(--text);
       padding: 6px 10px;
       font-size: 13px;
     }
 
-    .monitoring-refresh-note {
-      color: var(--text-muted);
-      font-size: 12px;
-    }
+.monitoring-refresh-note {
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.monitoring-refresh-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.monitoring-refresh-toggle {
+  padding: 6px 12px;
+  border: 1px solid #3fe7c3;
+  background: rgba(9, 11, 32, 0.85);
+  color: #3fe7c3;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.monitoring-refresh-toggle.paused {
+  border-color: #f2b760;
+  color: #f2b760;
+}
+
+.monitoring-refresh-toggle:hover {
+  background: rgba(63, 231, 195, 0.08);
+}
 
     .monitoring-pagination {
       margin-top: 12px;
@@ -314,10 +340,32 @@
       cursor: pointer;
     }
 
-    .pagination-controls button:disabled {
-      opacity: 0.45;
-      cursor: not-allowed;
-    }
+.pagination-controls button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.toast {
+  position: fixed;
+  right: 18px;
+  bottom: 18px;
+  background: rgba(9, 11, 32, 0.95);
+  border: 1px solid #3fe7c3;
+  color: var(--text);
+  padding: 12px 14px;
+  border-radius: 12px;
+  box-shadow: 0 10px 32px rgba(0, 0, 0, 0.35);
+  opacity: 0;
+  transform: translateY(10px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  z-index: 9999;
+  pointer-events: none;
+}
+
+.toast.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
 
     .monitoring-sources {
       display: flex;
@@ -414,11 +462,35 @@
       letter-spacing: 0.04em;
     }
 
-    .monitoring-table button {
-      padding: 4px 10px;
-      font-size: 11px;
-      letter-spacing: 0.04em;
-    }
+.monitoring-table button {
+  padding: 4px 10px;
+  font-size: 11px;
+  letter-spacing: 0.04em;
+}
+
+.monitoring-actions-cell {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.monitoring-favorite-btn {
+  border-color: var(--warning);
+  color: var(--warning);
+}
+
+.monitoring-favorite-btn.favorited {
+  background: rgba(242, 183, 96, 0.08);
+  color: #f7d7a2;
+}
+
+.monitoring-favorite-flag {
+  color: var(--warning);
+  font-size: 0.9rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
 
     .monitoring-chart-wrapper {
       width: 100%;
@@ -2110,15 +2182,18 @@
             </div>
             <div class="monitoring-refresh-bar">
               <label for="monitoringRefreshInterval">Frequência de atualização</label>
-              <select id="monitoringRefreshInterval">
-                <option value="0.5">0.5s</option>
-                <option value="1">1s</option>
-                <option value="2">2s</option>
-                <option value="3" selected>3s</option>
-                <option value="4">4s</option>
-                <option value="5">5s</option>
-              </select>
-              <span class="monitoring-refresh-note">Atualiza automaticamente as oportunidades após os filtros ativos.</span>
+              <div class="monitoring-refresh-actions">
+                <select id="monitoringRefreshInterval">
+                  <option value="0.5">0.5s</option>
+                  <option value="1">1s</option>
+                  <option value="2">2s</option>
+                  <option value="3" selected>3s</option>
+                  <option value="4">4s</option>
+                  <option value="5">5s</option>
+                </select>
+                <button type="button" id="monitoringRefreshToggle" class="monitoring-refresh-toggle" aria-pressed="false">⏸ Pausar</button>
+              </div>
+              <span class="monitoring-refresh-note">Atualiza automaticamente as oportunidades após os filtros ativos. Favoritos permanecem no topo.</span>
             </div>
             <div class="table-scroll">
               <table class="monitoring-table">
@@ -2132,7 +2207,8 @@
                     <th>Profundidade</th>
                     <th>Funding</th>
                     <th>Risco</th>
-                    <th></th>
+                    <th>Favorito</th>
+                    <th>Ações</th>
                   </tr>
                 </thead>
                 <tbody id="monitoringTableBody"></tbody>
@@ -2318,6 +2394,8 @@
       </section>
     </main>
   </div>
+
+  <div id="executionToast" class="toast" role="status" aria-live="polite"></div>
 
   <script src="scripts.js"></script>
 </body>

--- a/public/index.html
+++ b/public/index.html
@@ -418,6 +418,35 @@
       font-size: 13px;
     }
 
+    .monitoring-extremes {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 10px;
+      margin: 10px 0 6px;
+    }
+
+    .monitoring-extremes .extreme-block {
+      background: rgba(63, 231, 195, 0.08);
+      border: 1px solid rgba(63, 231, 195, 0.25);
+      border-radius: 10px;
+      padding: 8px 10px;
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+
+    .monitoring-extremes .label {
+      font-size: 11px;
+      color: var(--text-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+
+    .monitoring-extremes strong {
+      font-size: 14px;
+      color: #3fe7c3;
+    }
+
     .monitoring-history-source {
       margin-top: 4px;
       font-size: 12px;
@@ -472,6 +501,64 @@
   display: flex;
   gap: 6px;
   flex-wrap: wrap;
+}
+
+.exchange-header {
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-bottom: 4px;
+}
+
+.quote-chip {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 6px 8px;
+  border-radius: 10px;
+  margin-bottom: 6px;
+  font-size: 12px;
+  gap: 10px;
+  background: rgba(125, 97, 255, 0.08);
+  border: 1px solid rgba(125, 97, 255, 0.25);
+}
+
+.quote-chip.ask {
+  border-color: rgba(63, 231, 195, 0.35);
+  background: rgba(63, 231, 195, 0.06);
+}
+
+.quote-chip.bid {
+  border-color: rgba(242, 183, 96, 0.45);
+  background: rgba(242, 183, 96, 0.06);
+}
+
+.quote-chip span {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.quote-chip strong {
+  color: var(--text);
+  letter-spacing: 0.02em;
+}
+
+.quote-chip em {
+  font-style: normal;
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+.uptime-chip {
+  margin-top: 4px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  border-radius: 10px;
+  background: rgba(63, 231, 195, 0.08);
+  border: 1px solid rgba(63, 231, 195, 0.3);
+  font-size: 11px;
+  color: #3fe7c3;
 }
 
 .monitoring-favorite-btn {
@@ -2304,6 +2391,16 @@
               Selecione um par, intervalo e corretoras para ver como a % de arbitragem evoluiu nas últimas 24 horas.
             </p>
             <p id="monitoringHistoryStatus" class="monitoring-history-status"></p>
+            <div class="monitoring-extremes" id="monitoringHistoryExtremes">
+              <div class="extreme-block">
+                <span class="label">Abertura</span>
+                <strong id="monitoringOpenRange">–</strong>
+              </div>
+              <div class="extreme-block">
+                <span class="label">Fechamento</span>
+                <strong id="monitoringCloseRange">–</strong>
+              </div>
+            </div>
             <div class="monitoring-chart-wrapper">
               <canvas id="monitoringChart"></canvas>
             </div>

--- a/public/index.html
+++ b/public/index.html
@@ -519,6 +519,12 @@
   margin-bottom: 4px;
 }
 
+.quote-chip-container {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
 .quote-chip {
   display: flex;
   justify-content: space-between;
@@ -556,6 +562,10 @@
   font-style: normal;
   color: var(--text-muted);
   font-size: 11px;
+}
+
+.volume-badges.compact {
+  gap: 6px;
 }
 
 .uptime-chip {

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -4134,10 +4134,18 @@ if (positionDismantleBtn) {
 // ======== Shell / Monitoring / Admin UI ========
 const appShellEl = document.getElementById('appShell');
 const sidebarToggleBtn = document.getElementById('sidebarToggle');
+function refreshSidebarToggleLabel() {
+  if (!sidebarToggleBtn || !appShellEl) return;
+  const hidden = appShellEl.classList.contains('sidebar-hidden');
+  sidebarToggleBtn.textContent = hidden ? 'Mostrar menu' : 'Ocultar menu';
+  sidebarToggleBtn.setAttribute('aria-expanded', String(!hidden));
+}
 if (sidebarToggleBtn && appShellEl) {
   sidebarToggleBtn.addEventListener('click', () => {
     appShellEl.classList.toggle('sidebar-hidden');
+    refreshSidebarToggleLabel();
   });
+  refreshSidebarToggleLabel();
 }
 
 const navButtons = Array.from(document.querySelectorAll('.sidebar-link[data-view-target]'));
@@ -4214,12 +4222,19 @@ const addSelectedTopAssetsBtn = document.getElementById('addSelectedTopAssets');
 const topAssetsList = document.getElementById('topAssetsList');
 const topAssetsStatus = document.getElementById('topAssetsStatus');
 const topAssetsResults = document.getElementById('topAssetsResults');
+const topAssetsPaginationInfo = document.getElementById('topAssetsPaginationInfo');
+const topAssetsPaginationStatus = document.getElementById('topAssetsPaginationStatus');
+const topAssetsPrev = document.getElementById('topAssetsPrev');
+const topAssetsNext = document.getElementById('topAssetsNext');
 
 const MONITORING_PAGE_SIZE = 10;
 const monitoringPaginationState = { page: 1, perPage: MONITORING_PAGE_SIZE };
 let monitoringFilteredRows = [];
 const MONITORING_REFRESH_DEFAULT_SECONDS = 3;
 let monitoringAutoRefreshTimer = null;
+const TOP_ASSETS_PAGE_SIZE = 8;
+const topAssetsState = { items: [], page: 1, perPage: TOP_ASSETS_PAGE_SIZE };
+const topAssetsSelection = new Set();
 
 function getCheckedValues(selector) {
   return Array.from(document.querySelectorAll(selector))
@@ -4438,31 +4453,44 @@ async function loadMonitoringData({ focusSymbol = null, silent = false, updateCh
     if (!response.ok) throw new Error(`Falha ao buscar dados (${response.status})`);
     const payload = await safeJson(response);
     const entries = Array.isArray(payload?.symbols) ? payload.symbols : [];
-    monitoringRows = entries.map((entry) => {
+    monitoringRows = entries.flatMap((entry) => {
       const symbol = (entry?.symbol || '').toUpperCase();
-      if (!symbol) return null;
+      if (!symbol) return [];
       const name = getMonitoringName(symbol, entry?.label || symbol);
       const metrics = entry?.metrics || {};
-      const arb = toFiniteNumber(metrics.arbPct);
-      const volume24h = toFiniteNumber(metrics.volume24h);
-      const funding = toFiniteNumber(metrics.fundingRate);
       const volatility = toFiniteNumber(metrics.volatilityPct);
       const metaInfo = monitoringMeta.get(symbol);
       const stability = metrics.stability || metaInfo?.stability || (Number.isFinite(volatility) ? (volatility > 6 ? 'Volátil' : 'Estável') : 'Indefinido');
       const riskLabel = metrics.riskLabel || metaInfo?.risk || 'Indefinido';
-      return {
-        symbol,
-        name,
-        arb,
-        spotExchanges: (entry?.spot || []).filter((ticker) => !ticker.error && ticker.exchange).map((ticker) => ticker.exchange),
-        futuresExchanges: (entry?.futures || []).filter((ticker) => !ticker.error && ticker.exchange).map((ticker) => ticker.exchange),
-        volume24h: Number.isFinite(volume24h) ? volume24h : 0,
-        depth: metrics.depthLabel || 'N/D',
-        funding,
-        risk: riskLabel,
-        stability
-      };
-    }).filter(Boolean);
+      const spotTickers = (entry?.spot || []).filter((ticker) => !ticker.error && Number.isFinite(ticker.ask) && ticker.ask > 0);
+      const futuresTickers = (entry?.futures || []).filter((ticker) => !ticker.error && Number.isFinite(ticker.bid));
+      const combos = [];
+      for (const spot of spotTickers) {
+        for (const futures of futuresTickers) {
+          const arbRaw = Number.isFinite(spot.ask) && spot.ask > 0 && Number.isFinite(futures.bid)
+            ? ((futures.bid - spot.ask) / spot.ask) * 100
+            : null;
+          if (!Number.isFinite(arbRaw)) continue;
+          const arb = Number(arbRaw.toFixed(3));
+          const volumeCandidates = [toFiniteNumber(spot.volume), toFiniteNumber(futures.volume)].filter((v) => Number.isFinite(v));
+          const volume24h = volumeCandidates.length ? Math.min(...volumeCandidates) : 0;
+          combos.push({
+            symbol,
+            name,
+            arb,
+            spotExchanges: [spot.exchange || spot.key || 'SPOT'],
+            futuresExchanges: [futures.exchange || futures.key || 'FUTUROS'],
+            volume24h,
+            depth: metrics.depthLabel || 'N/D',
+            funding: toFiniteNumber(futures.fundingRate),
+            risk: riskLabel,
+            stability,
+            combination: `${spot.exchange || spot.key || 'SPOT'} → ${futures.exchange || futures.key || 'FUTUROS'}`
+          });
+        }
+      }
+      return combos;
+    });
     resetMonitoringHistory();
     renderMonitoringTable();
     updateMonitoringSelectors();
@@ -4511,7 +4539,8 @@ function renderMonitoringSummary(filtered) {
 function renderMonitoringTable() {
   if (!monitoringTableBody) return;
   const searchTerm = (filterSearchEl?.value || '').trim().toUpperCase();
-  const minArb = Number(filterMinArbEl?.value) || 0;
+  const minArbRaw = Number(filterMinArbEl?.value);
+  const minArb = Number.isFinite(minArbRaw) ? Math.max(0, minArbRaw) : 0;
   const minVolume = Number(filterVolumeEl?.value) || 0;
   const selectedSpot = getCheckedValues('.filter-spot');
   const selectedFutures = getCheckedValues('.filter-futures');
@@ -4523,7 +4552,6 @@ function renderMonitoringTable() {
     .filter((coin) => !blacklist.has(coin.symbol))
     .filter((coin) => (searchTerm ? coin.symbol.includes(searchTerm) || coin.name?.toUpperCase().includes(searchTerm) : true))
     .filter((coin) => {
-      if (!minArb) return true;
       if (!Number.isFinite(coin.arb)) return false;
       return coin.arb >= minArb;
     })
@@ -4754,7 +4782,10 @@ filterInputs.forEach((input) => {
 
 if (filterMinArbEl) {
   filterMinArbEl.addEventListener('input', () => {
-    if (filterMinArbValueEl) filterMinArbValueEl.textContent = `${filterMinArbEl.value}%`;
+    if (filterMinArbValueEl) {
+      const value = Number(filterMinArbEl.value) || 0;
+      filterMinArbValueEl.textContent = `${value.toFixed(2)}%`;
+    }
     resetMonitoringPagination();
     renderMonitoringTable();
   });
@@ -4866,25 +4897,57 @@ function getSelectedTopExchanges() {
     .map((el) => el.value);
 }
 
-function renderTopAssetsList(assets) {
+function updateTopAssetsPagination(total) {
+  const totalPages = total ? Math.max(1, Math.ceil(total / topAssetsState.perPage)) : 1;
+  if (topAssetsState.page < 1) topAssetsState.page = 1;
+  if (topAssetsState.page > totalPages) topAssetsState.page = totalPages;
+  const start = total ? (topAssetsState.page - 1) * topAssetsState.perPage + 1 : 0;
+  const end = total ? Math.min(start + topAssetsState.perPage - 1, total) : 0;
+  if (topAssetsPaginationInfo) {
+    topAssetsPaginationInfo.textContent = total
+      ? `Mostrando ${start}–${end} de ${total} ativos`
+      : 'Nenhum ativo carregado';
+  }
+  if (topAssetsPaginationStatus) {
+    topAssetsPaginationStatus.textContent = total ? `Página ${topAssetsState.page} de ${totalPages}` : 'Página 0 de 0';
+  }
+  if (topAssetsPrev) topAssetsPrev.disabled = topAssetsState.page <= 1 || !total;
+  if (topAssetsNext) topAssetsNext.disabled = topAssetsState.page >= totalPages || !total;
+}
+
+function renderTopAssetsList() {
   if (!topAssetsList) return;
-  if (!assets.length) {
-    topAssetsList.innerHTML = '<p class="muted">Nenhum ativo retornado para as corretoras selecionadas.</p>';
+  const assets = topAssetsState.items || [];
+  const total = assets.length;
+  if (!total) {
+    topAssetsList.innerHTML = '<p class="muted" style="padding:12px;">Nenhum ativo retornado para as corretoras selecionadas.</p>';
+    updateTopAssetsPagination(0);
     return;
   }
-  topAssetsList.innerHTML = assets
+  const startIndex = (topAssetsState.page - 1) * topAssetsState.perPage;
+  const visible = assets.slice(startIndex, startIndex + topAssetsState.perPage);
+  topAssetsList.innerHTML = visible
     .map((asset) => {
       const bestVolume = Number.isFinite(asset.bestVolume) ? formatVolume(asset.bestVolume) : 'N/D';
       const exchanges = Array.isArray(asset.exchanges) && asset.exchanges.length ? asset.exchanges.join(', ') : '—';
-      return `<label class="top-asset-row">
-        <input type="checkbox" class="top-asset-option" value="${asset.symbol}" data-label="${asset.label || asset.symbol}">
+      const checked = topAssetsSelection.has(asset.symbol) ? 'checked' : '';
+      return `<label class="top-assets-row">
+        <span><input type="checkbox" class="top-asset-option" value="${asset.symbol}" data-label="${asset.label || asset.symbol}" ${checked}></span>
         <span class="asset-name">${asset.label || asset.symbol}</span>
         <span class="asset-symbol">${asset.symbol}</span>
-        <span class="asset-volume">Vol 24h: ${bestVolume}</span>
+        <span class="asset-volume">${bestVolume}</span>
         <span class="asset-exchanges">${exchanges}</span>
       </label>`;
     })
     .join('');
+  topAssetsList.querySelectorAll('.top-asset-option').forEach((input) => {
+    input.addEventListener('change', () => {
+      const symbol = input.value;
+      if (!symbol) return;
+      if (input.checked) topAssetsSelection.add(symbol); else topAssetsSelection.delete(symbol);
+    });
+  });
+  updateTopAssetsPagination(total);
 }
 
 function normalizeMonitoringSymbolInput(value) {
@@ -4913,7 +4976,10 @@ async function discoverTopAssets() {
     if (!response.ok) throw new Error(`Falha ao buscar top 24h (${response.status})`);
     const payload = await safeJson(response);
     const assets = Array.isArray(payload?.assets) ? payload.assets : [];
-    renderTopAssetsList(assets);
+    topAssetsState.items = assets;
+    topAssetsState.page = 1;
+    topAssetsSelection.clear();
+    renderTopAssetsList();
     if (topAssetsResults) topAssetsResults.classList.toggle('hidden', !assets.length);
     if (topAssetsStatus) {
       const errors = Array.isArray(payload?.errors) && payload.errors.length
@@ -4934,9 +5000,9 @@ async function discoverTopAssets() {
 }
 
 function getSelectedDiscoveredAssets() {
-  return Array.from(document.querySelectorAll('.top-asset-option'))
-    .filter((el) => el.checked)
-    .map((el) => ({ symbol: el.value, label: el.dataset.label || el.value }));
+  return topAssetsState.items
+    .filter((asset) => topAssetsSelection.has(asset.symbol))
+    .map((asset) => ({ symbol: asset.symbol, label: asset.label || asset.symbol }));
 }
 
 if (adminAddCoinForm) {
@@ -5023,6 +5089,26 @@ if (discoverTopAssetsBtn) {
   discoverTopAssetsBtn.addEventListener('click', discoverTopAssets);
 }
 
+if (topAssetsPrev) {
+  topAssetsPrev.addEventListener('click', () => {
+    if (topAssetsState.page > 1) {
+      topAssetsState.page -= 1;
+      renderTopAssetsList();
+    }
+  });
+}
+
+if (topAssetsNext) {
+  topAssetsNext.addEventListener('click', () => {
+    const total = topAssetsState.items.length;
+    const totalPages = total ? Math.max(1, Math.ceil(total / topAssetsState.perPage)) : 1;
+    if (topAssetsState.page < totalPages) {
+      topAssetsState.page += 1;
+      renderTopAssetsList();
+    }
+  });
+}
+
 if (addSelectedTopAssetsBtn) {
   addSelectedTopAssetsBtn.addEventListener('click', () => {
     if (!requireAdmin()) return;
@@ -5063,7 +5149,10 @@ if (addSelectedTopAssetsBtn) {
 function bootstrapMonitoring() {
   updateMonitoringSelectors();
   renderMonitoringTable();
-  if (filterMinArbValueEl && filterMinArbEl) filterMinArbValueEl.textContent = `${filterMinArbEl.value}%`;
+  if (filterMinArbValueEl && filterMinArbEl) {
+    const value = Number(filterMinArbEl.value) || 0;
+    filterMinArbValueEl.textContent = `${value.toFixed(2)}%`;
+  }
   renderBlacklist();
   loadMonitoringData();
   scheduleMonitoringAutoRefresh();

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -4685,10 +4685,14 @@ async function loadMonitoringData({ focusSymbol = null, silent = false, updateCh
             futuresVolume,
             spotAsk: toFiniteNumber(spot.ask),
             spotBid: toFiniteNumber(spot.bid),
+            spotAskSize: toFiniteNumber(spot.askSize),
+            spotBidSize: toFiniteNumber(spot.bidSize),
             spotAskNotional: toFiniteNumber(spot.askNotional ?? computeNotionalLocal(spot.ask, spot.askSize)),
             spotBidNotional: toFiniteNumber(spot.bidNotional ?? computeNotionalLocal(spot.bid, spot.bidSize)),
             futuresAsk: toFiniteNumber(futures.ask),
             futuresBid: toFiniteNumber(futures.bid),
+            futuresAskSize: toFiniteNumber(futures.askSize),
+            futuresBidSize: toFiniteNumber(futures.bidSize),
             futuresAskNotional: toFiniteNumber(futures.askNotional ?? computeNotionalLocal(futures.ask, futures.askSize)),
             futuresBidNotional: toFiniteNumber(futures.bidNotional ?? computeNotionalLocal(futures.bid, futures.bidSize)),
             depth: metrics.depthLabel || 'N/D',
@@ -4729,7 +4733,9 @@ function formatVolume(value) {
   if (!Number.isFinite(value)) return '-';
   if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
   if (value >= 1_000) return `${(value / 1_000).toFixed(1)}k`;
-  return value.toFixed(0);
+  if (value >= 10) return value.toFixed(1);
+  if (value >= 1) return value.toFixed(2);
+  return value.toExponential(2);
 }
 
 function formatPriceCompact(value) {
@@ -4746,6 +4752,7 @@ function formatPriceCompact(value) {
 function formatUptime(ms) {
   if (!Number.isFinite(ms) || ms <= 0) return '—';
   const totalMinutes = Math.floor(ms / 60000);
+  const seconds = Math.floor((ms % 60000) / 1000);
   const days = Math.floor(totalMinutes / (60 * 24));
   const hours = Math.floor((totalMinutes % (60 * 24)) / 60);
   const minutes = totalMinutes % 60;
@@ -4753,6 +4760,7 @@ function formatUptime(ms) {
   if (days) parts.push(`${days}d`);
   if (hours || days) parts.push(`${hours}h`);
   parts.push(`${minutes}min`);
+  parts.push(`${seconds}s`);
   return parts.join(' ');
 }
 
@@ -4777,8 +4785,13 @@ function updateArbUptime(key, arb) {
   return entry.start ? formatUptime(now - entry.start) : '—';
 }
 
-function renderLegDetails(price, notional, side) {
-  const volLabel = Number.isFinite(notional) ? `${formatVolume(notional)} USDT` : 's/ dado';
+function renderLegDetails(price, notional, side, fallbackVolume, fallbackSize) {
+  const computedNotional = Number.isFinite(notional)
+    ? notional
+    : computeNotionalLocal(price, fallbackSize);
+  const fallback = Number.isFinite(fallbackVolume) ? fallbackVolume : null;
+  const volValue = Number.isFinite(computedNotional) && computedNotional > 0 ? computedNotional : fallback;
+  const volLabel = Number.isFinite(volValue) ? `${formatVolume(volValue)} USDT` : 's/ dado';
   const sideLabel = side === 'bid' ? 'Bid' : 'Ask';
   const chipClass = side === 'bid' ? 'bid' : 'ask';
   return `<div class="quote-chip ${chipClass}"><strong>${sideLabel} ${formatPriceCompact(price)}</strong><em>Vol: ${volLabel}</em></div>`;
@@ -4858,8 +4871,8 @@ function renderMonitoringTable() {
       : metaInfo?.futuresHint?.length
         ? `${metaInfo.futuresHint.join(', ')} (config)`
         : 'Sem dados';
-    const spotDetail = renderLegDetails(coin.spotAsk, coin.spotAskNotional, 'ask');
-    const futuresDetail = renderLegDetails(coin.futuresBid, coin.futuresBidNotional, 'bid');
+    const spotDetail = renderLegDetails(coin.spotAsk, coin.spotAskNotional, 'ask', coin.spotVolume, coin.spotAskSize);
+    const futuresDetail = renderLegDetails(coin.futuresBid, coin.futuresBidNotional, 'bid', coin.futuresVolume, coin.futuresBidSize);
     const spotVolumeLabel = Number.isFinite(coin.spotVolume) ? `${formatVolume(coin.spotVolume)} USDT` : 's/ dado';
     const futuresVolumeLabel = Number.isFinite(coin.futuresVolume) ? `${formatVolume(coin.futuresVolume)} USDT` : 's/ dado';
     return `

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -4130,3 +4130,472 @@ if (positionDismantleBtn) {
   persistInstances();
 
 })();
+
+// ======== Shell / Monitoring / Admin UI ========
+const appShellEl = document.getElementById('appShell');
+const sidebarToggleBtn = document.getElementById('sidebarToggle');
+if (sidebarToggleBtn && appShellEl) {
+  sidebarToggleBtn.addEventListener('click', () => {
+    appShellEl.classList.toggle('sidebar-hidden');
+  });
+}
+
+const navButtons = Array.from(document.querySelectorAll('.sidebar-link[data-view-target]'));
+function activateView(targetId) {
+  navButtons.forEach((btn) => {
+    const isActive = btn.dataset.viewTarget === targetId;
+    if (isActive) btn.classList.add('active'); else btn.classList.remove('active');
+  });
+  document.querySelectorAll('.view').forEach((view) => {
+    if (view.id === targetId) {
+      view.classList.add('active');
+    } else {
+      view.classList.remove('active');
+    }
+  });
+}
+
+navButtons.forEach((btn) => {
+  btn.addEventListener('click', () => activateView(btn.dataset.viewTarget));
+});
+
+const monitoringCoins = [
+  {
+    symbol: 'CPOOL_USDT',
+    name: 'Clearpool',
+    arb: 2.6,
+    spotExchanges: ['Gate.io', 'Binance'],
+    futuresExchanges: ['MEXC Futures', 'Gate.io Futures'],
+    volume24h: 680000,
+    depth: 'Alta',
+    funding: 0.018,
+    risk: 'Baixo',
+    stability: 'Estável'
+  },
+  {
+    symbol: 'MAT_USDT',
+    name: 'Mycelium',
+    arb: 1.4,
+    spotExchanges: ['Gate.io', 'KuCoin'],
+    futuresExchanges: ['Bybit', 'MEXC Futures'],
+    volume24h: 320000,
+    depth: 'Média',
+    funding: 0.011,
+    risk: 'Médio',
+    stability: 'Estável'
+  },
+  {
+    symbol: 'FARM_USDT',
+    name: 'Harvest Finance',
+    arb: 3.1,
+    spotExchanges: ['Gate.io', 'Binance'],
+    futuresExchanges: ['MEXC Futures'],
+    volume24h: 1500000,
+    depth: 'Alta',
+    funding: 0.024,
+    risk: 'Baixo',
+    stability: 'Volátil'
+  }
+];
+
+const monitoringHistory = {};
+function generateHistory(symbol, baseArb) {
+  const points = [];
+  const now = Date.now();
+  let last = baseArb;
+  for (let i = 24; i >= 0; i -= 1) {
+    const ts = now - i * 60 * 60 * 1000;
+    const open = Number((last + (Math.random() - 0.5) * 0.6).toFixed(2));
+    const close = Number((open + (Math.random() - 0.5) * 0.5).toFixed(2));
+    const arb = Number((close + (Math.random() - 0.5) * 0.4).toFixed(2));
+    const spotVol = Math.round((0.8 + Math.random() * 0.5) * 100000);
+    const futuresVol = Math.round((0.6 + Math.random() * 0.6) * 90000);
+    points.push({
+      label: new Date(ts).toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' }),
+      open,
+      close,
+      arb,
+      spotVol,
+      futuresVol
+    });
+    last = arb;
+  }
+  return points;
+}
+
+monitoringCoins.forEach((coin) => {
+  monitoringHistory[coin.symbol] = generateHistory(coin.symbol, coin.arb);
+});
+
+const blacklist = new Set();
+const ADMIN_PASSWORD = 'arbisync@2024';
+let isAdmin = false;
+
+const monitoringTableBody = document.getElementById('monitoringTableBody');
+const filterSearchEl = document.getElementById('filterSearch');
+const filterMinArbEl = document.getElementById('filterMinArb');
+const filterMinArbValueEl = document.getElementById('filterMinArbValue');
+const filterVolumeEl = document.getElementById('filterVolume');
+const filterStabilityEl = document.getElementById('filterStability');
+const monitoringSummaryBestEl = document.getElementById('monitoringSummaryBest');
+const monitoringSummaryAvgEl = document.getElementById('monitoringSummaryAvg');
+const monitoringSummaryCountEl = document.getElementById('monitoringResultCount');
+const monitoringSummaryBlacklistEl = document.getElementById('monitoringSummaryBlacklist');
+const monitoringPairSelect = document.getElementById('monitoringPairSelect');
+const adminStatusLabel = document.getElementById('adminStatusLabel');
+const adminLoginFeedback = document.getElementById('adminLoginFeedback');
+const adminTools = document.getElementById('adminTools');
+const adminLoginForm = document.getElementById('adminLoginForm');
+const adminPasswordInput = document.getElementById('adminPassword');
+const adminAddCoinForm = document.getElementById('adminAddCoinForm');
+const adminRemoveCoinForm = document.getElementById('adminRemoveCoinForm');
+const adminRemoveCoinSelect = document.getElementById('adminRemoveCoinSelect');
+const blacklistForm = document.getElementById('blacklistForm');
+const blacklistInput = document.getElementById('blacklistInput');
+const blacklistList = document.getElementById('blacklistList');
+
+function getCheckedValues(selector) {
+  return Array.from(document.querySelectorAll(selector))
+    .filter((el) => el.checked)
+    .map((el) => el.value);
+}
+
+function formatVolume(value) {
+  if (!Number.isFinite(value)) return '-';
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}k`;
+  return value.toFixed(0);
+}
+
+function renderMonitoringSummary(filtered) {
+  if (monitoringSummaryCountEl) monitoringSummaryCountEl.textContent = filtered.length;
+  if (monitoringSummaryBlacklistEl) monitoringSummaryBlacklistEl.textContent = blacklist.size;
+  if (monitoringSummaryBestEl) {
+    const best = filtered.reduce((acc, coin) => (coin.arb > (acc?.arb || 0) ? coin : acc), null);
+    monitoringSummaryBestEl.textContent = best ? `${best.symbol} • ${best.arb.toFixed(2)}%` : '-';
+  }
+  if (monitoringSummaryAvgEl) {
+    const avg = filtered.length
+      ? (filtered.reduce((acc, coin) => acc + coin.arb, 0) / filtered.length).toFixed(2)
+      : '0.00';
+    monitoringSummaryAvgEl.textContent = `${avg}%`;
+  }
+}
+
+function renderMonitoringTable() {
+  if (!monitoringTableBody) return;
+  const searchTerm = (filterSearchEl?.value || '').trim().toUpperCase();
+  const minArb = Number(filterMinArbEl?.value) || 0;
+  const minVolume = Number(filterVolumeEl?.value) || 0;
+  const selectedSpot = getCheckedValues('.filter-spot');
+  const selectedFutures = getCheckedValues('.filter-futures');
+  const selectedRisks = getCheckedValues('.filter-risk');
+  const stabilityFilter = filterStabilityEl?.value || 'flex';
+
+  const filtered = monitoringCoins
+    .filter((coin) => !blacklist.has(coin.symbol))
+    .filter((coin) => (searchTerm ? coin.symbol.includes(searchTerm) || coin.name.toUpperCase().includes(searchTerm) : true))
+    .filter((coin) => coin.arb >= minArb)
+    .filter((coin) => coin.volume24h >= minVolume)
+    .filter((coin) => !selectedSpot.length || coin.spotExchanges.some((ex) => selectedSpot.includes(ex)))
+    .filter((coin) => !selectedFutures.length || coin.futuresExchanges.some((ex) => selectedFutures.includes(ex)))
+    .filter((coin) => !selectedRisks.length || selectedRisks.includes(coin.risk))
+    .filter((coin) => stabilityFilter === 'flex' || coin.stability === stabilityFilter);
+
+  filtered.sort((a, b) => b.arb - a.arb);
+
+  monitoringTableBody.innerHTML = filtered.map((coin) => `
+      <tr>
+        <td><strong>${coin.symbol}</strong><br/><span class="muted">${coin.name}</span></td>
+        <td>${coin.arb.toFixed(2)}%</td>
+        <td>${coin.spotExchanges.join(', ')}</td>
+        <td>${coin.futuresExchanges.join(', ')}</td>
+        <td>${formatVolume(coin.volume24h)} USDT</td>
+        <td>${coin.depth}</td>
+        <td>${(coin.funding * 100).toFixed(2)}%</td>
+        <td>${coin.risk}</td>
+        <td><button type="button" class="monitoring-view-chart" data-symbol="${coin.symbol}">Ver gráfico</button></td>
+      </tr>
+    `).join('');
+
+  renderMonitoringSummary(filtered);
+
+  if (filtered.length && monitoringPairSelect && !monitoringPairSelect.value) {
+    monitoringPairSelect.value = filtered[0].symbol;
+    updateMonitoringChart(filtered[0].symbol);
+  }
+}
+
+function renderBlacklist() {
+  if (!blacklistList) return;
+  const entries = Array.from(blacklist).sort();
+  blacklistList.innerHTML = entries.length
+    ? entries.map((symbol) => `<span>${symbol} <button type="button" data-remove-symbol="${symbol}">×</button></span>`).join('')
+    : '<span class="muted">Nenhuma moeda bloqueada.</span>';
+}
+
+function updateMonitoringSelectors() {
+  const previousSymbol = monitoringPairSelect?.value;
+  if (monitoringPairSelect) {
+    monitoringPairSelect.innerHTML = monitoringCoins.map((coin) => `<option value="${coin.symbol}">${coin.symbol} — ${coin.name}</option>`).join('');
+    if (previousSymbol && monitoringCoins.some((coin) => coin.symbol === previousSymbol)) {
+      monitoringPairSelect.value = previousSymbol;
+    }
+  }
+  if (adminRemoveCoinSelect) {
+    adminRemoveCoinSelect.innerHTML = monitoringCoins.map((coin) => `<option value="${coin.symbol}">${coin.symbol}</option>`).join('');
+  }
+}
+
+let monitoringChart = null;
+function ensureMonitoringChart() {
+  if (monitoringChart) return monitoringChart;
+  const ctx = document.getElementById('monitoringChart');
+  if (!ctx) return null;
+  monitoringChart = new Chart(ctx, {
+    type: 'line',
+    data: { labels: [], datasets: [] },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      interaction: { intersect: false, mode: 'index' },
+      scales: {
+        y: { ticks: { callback: (value) => `${value}%` } },
+        yVolume: { position: 'right', grid: { drawOnChartArea: false }, ticks: { callback: (value) => `${formatVolume(value)} USDT` } }
+      }
+    }
+  });
+  return monitoringChart;
+}
+
+function updateMonitoringChart(symbol) {
+  const chart = ensureMonitoringChart();
+  if (!chart) return;
+  const history = monitoringHistory[symbol] || [];
+  chart.data.labels = history.map((p) => p.label);
+  chart.data.datasets = [
+    {
+      type: 'line',
+      label: '% Arb médio',
+      data: history.map((p) => p.arb),
+      borderColor: '#8d6cff',
+      backgroundColor: 'rgba(141, 108, 255, 0.2)',
+      tension: 0.35,
+      yAxisID: 'y',
+      fill: false,
+      borderWidth: 2
+    },
+    {
+      type: 'line',
+      label: 'Linha de abertura',
+      data: history.map((p) => p.open),
+      borderColor: '#3fe7c3',
+      borderDash: [6, 6],
+      tension: 0.3,
+      yAxisID: 'y',
+      fill: false,
+      borderWidth: 1.5
+    },
+    {
+      type: 'line',
+      label: 'Linha de fechamento',
+      data: history.map((p) => p.close),
+      borderColor: '#f2b760',
+      borderDash: [6, 6],
+      tension: 0.3,
+      yAxisID: 'y',
+      fill: false,
+      borderWidth: 1.5
+    },
+    {
+      type: 'bar',
+      label: 'Volume Spot',
+      data: history.map((p) => p.spotVol),
+      backgroundColor: 'rgba(141, 108, 255, 0.35)',
+      borderRadius: 4,
+      yAxisID: 'yVolume'
+    },
+    {
+      type: 'bar',
+      label: 'Volume Futuros',
+      data: history.map((p) => p.futuresVol),
+      backgroundColor: 'rgba(63, 231, 195, 0.35)',
+      borderRadius: 4,
+      yAxisID: 'yVolume'
+    }
+  ];
+  chart.update();
+}
+
+const filterInputs = [filterSearchEl, filterVolumeEl, filterStabilityEl];
+filterInputs.forEach((input) => {
+  if (!input) return;
+  input.addEventListener('input', () => renderMonitoringTable());
+});
+
+if (filterMinArbEl) {
+  filterMinArbEl.addEventListener('input', () => {
+    if (filterMinArbValueEl) filterMinArbValueEl.textContent = `${filterMinArbEl.value}%`;
+    renderMonitoringTable();
+  });
+}
+
+['.filter-spot', '.filter-futures', '.filter-risk'].forEach((selector) => {
+  document.querySelectorAll(selector).forEach((input) => {
+    input.addEventListener('change', () => renderMonitoringTable());
+  });
+});
+
+if (monitoringTableBody) {
+  monitoringTableBody.addEventListener('click', (event) => {
+    const button = event.target.closest('.monitoring-view-chart');
+    if (!button) return;
+    const { symbol } = button.dataset;
+    if (!symbol) return;
+    if (monitoringPairSelect) monitoringPairSelect.value = symbol;
+    updateMonitoringChart(symbol);
+    activateView('monitoringView');
+  });
+}
+
+if (monitoringPairSelect) {
+  monitoringPairSelect.addEventListener('change', () => updateMonitoringChart(monitoringPairSelect.value));
+}
+
+const refreshMonitoringChartBtn = document.getElementById('refreshMonitoringChart');
+if (refreshMonitoringChartBtn) {
+  refreshMonitoringChartBtn.addEventListener('click', () => {
+    const symbol = monitoringPairSelect?.value || monitoringCoins[0]?.symbol;
+    if (symbol) updateMonitoringChart(symbol);
+  });
+}
+
+if (adminLoginForm) {
+  adminLoginForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const password = adminPasswordInput?.value || '';
+    if (password === ADMIN_PASSWORD) {
+      isAdmin = true;
+      adminLoginFeedback.textContent = 'Acesso liberado';
+      adminLoginFeedback.classList.remove('muted');
+      adminLoginFeedback.style.color = '#3fe7c3';
+      adminStatusLabel.textContent = 'Conectado';
+      if (adminTools) adminTools.classList.remove('hidden');
+    } else {
+      isAdmin = false;
+      adminLoginFeedback.textContent = 'Senha incorreta';
+      adminLoginFeedback.classList.add('muted');
+      adminStatusLabel.textContent = 'Visitante';
+      if (adminTools) adminTools.classList.add('hidden');
+    }
+    if (adminPasswordInput) adminPasswordInput.value = '';
+  });
+}
+
+function requireAdmin() {
+  if (isAdmin) return true;
+  if (adminLoginFeedback) {
+    adminLoginFeedback.textContent = 'Faça login como administrador para continuar.';
+    adminLoginFeedback.classList.remove('muted');
+    adminLoginFeedback.style.color = '#ff6b9a';
+  }
+  return false;
+}
+
+if (adminAddCoinForm) {
+  adminAddCoinForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+    if (!requireAdmin()) return;
+    const symbolInput = document.getElementById('adminCoinSymbol');
+    const nameInput = document.getElementById('adminCoinName');
+    const spotInput = document.getElementById('adminCoinSpot');
+    const futuresInput = document.getElementById('adminCoinFutures');
+    const arbInput = document.getElementById('adminCoinArb');
+    const riskInput = document.getElementById('adminCoinRisk');
+    if (!symbolInput || !nameInput) return;
+    const symbol = symbolInput.value.trim().toUpperCase();
+    const name = nameInput.value.trim() || symbol;
+    if (!symbol) return;
+    const existing = monitoringCoins.find((coin) => coin.symbol === symbol);
+    const newCoin = {
+      symbol,
+      name,
+      arb: Number(arbInput?.value) || 1,
+      spotExchanges: (spotInput?.value || 'Gate.io').split(',').map((s) => s.trim()).filter(Boolean),
+      futuresExchanges: (futuresInput?.value || 'MEXC Futures').split(',').map((s) => s.trim()).filter(Boolean),
+      volume24h: Math.round(200000 + Math.random() * 900000),
+      depth: 'Custom',
+      funding: 0.01,
+      risk: riskInput?.value || 'Médio',
+      stability: 'Estável'
+    };
+    if (existing) {
+      Object.assign(existing, newCoin);
+    } else {
+      monitoringCoins.push(newCoin);
+    }
+    monitoringHistory[symbol] = generateHistory(symbol, newCoin.arb);
+    symbolInput.value = '';
+    nameInput.value = '';
+    if (spotInput) spotInput.value = '';
+    if (futuresInput) futuresInput.value = '';
+    if (arbInput) arbInput.value = '1.5';
+    renderMonitoringTable();
+    updateMonitoringSelectors();
+    renderBlacklist();
+  });
+}
+
+if (adminRemoveCoinForm) {
+  adminRemoveCoinForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+    if (!requireAdmin()) return;
+    const symbol = adminRemoveCoinSelect?.value;
+    if (!symbol) return;
+    const idx = monitoringCoins.findIndex((coin) => coin.symbol === symbol);
+    if (idx >= 0) {
+      monitoringCoins.splice(idx, 1);
+      blacklist.delete(symbol);
+      delete monitoringHistory[symbol];
+    }
+    updateMonitoringSelectors();
+    renderMonitoringTable();
+    renderBlacklist();
+  });
+}
+
+if (blacklistForm) {
+  blacklistForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+    if (!requireAdmin()) return;
+    const symbol = (blacklistInput?.value || '').trim().toUpperCase();
+    if (!symbol) return;
+    blacklist.add(symbol);
+    if (blacklistInput) blacklistInput.value = '';
+    renderBlacklist();
+    renderMonitoringTable();
+  });
+}
+
+if (blacklistList) {
+  blacklistList.addEventListener('click', (event) => {
+    const button = event.target.closest('button[data-remove-symbol]');
+    if (!button) return;
+    if (!requireAdmin()) return;
+    const symbol = button.dataset.removeSymbol;
+    blacklist.delete(symbol);
+    renderBlacklist();
+    renderMonitoringTable();
+  });
+}
+
+function bootstrapMonitoring() {
+  updateMonitoringSelectors();
+  renderMonitoringTable();
+  const initialSymbol = monitoringPairSelect?.value || monitoringCoins[0]?.symbol;
+  if (initialSymbol) updateMonitoringChart(initialSymbol);
+  if (filterMinArbValueEl && filterMinArbEl) filterMinArbValueEl.textContent = `${filterMinArbEl.value}%`;
+  renderBlacklist();
+}
+
+bootstrapMonitoring();

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -4218,6 +4218,8 @@ const monitoringHistorySpotSelect = document.getElementById('monitoringHistorySp
 const monitoringHistoryFuturesSelect = document.getElementById('monitoringHistoryFutures');
 const monitoringHistorySourceEl = document.getElementById('monitoringHistorySource');
 const monitoringHistoryStatusEl = document.getElementById('monitoringHistoryStatus');
+const monitoringOpenRangeEl = document.getElementById('monitoringOpenRange');
+const monitoringCloseRangeEl = document.getElementById('monitoringCloseRange');
 const monitoringRefreshIntervalSelect = document.getElementById('monitoringRefreshInterval');
 const monitoringRefreshToggleBtn = document.getElementById('monitoringRefreshToggle');
 const monitoringPaginationInfo = document.getElementById('monitoringPaginationInfo');
@@ -4260,6 +4262,7 @@ const TOP_ASSETS_LIMIT_DEFAULT = 60;
 const topAssetsState = { items: [], page: 1, perPage: TOP_ASSETS_PAGE_SIZE, limit: TOP_ASSETS_LIMIT_DEFAULT };
 const topAssetsSelection = new Set();
 const monitoringFavorites = new Set();
+const monitoringArbTimers = new Map();
 let executionToastTimer = null;
 
 const EXECUTION_SPOT_PROVIDERS = ['Gate.io', 'Bitget'];
@@ -4274,6 +4277,14 @@ function getCheckedValues(selector) {
 function toFiniteNumber(value) {
   const num = Number(value);
   return Number.isFinite(num) ? num : null;
+}
+
+function computeNotionalLocal(price, size) {
+  const p = toFiniteNumber(price);
+  const s = toFiniteNumber(size);
+  if (!Number.isFinite(p) || !Number.isFinite(s)) return null;
+  const notional = p * s;
+  return Number.isFinite(notional) ? notional : null;
 }
 
 function getMonitoringName(symbol, fallbackLabel = null) {
@@ -4548,6 +4559,22 @@ function updateMonitoringHistorySource(entry) {
   monitoringHistorySourceEl.textContent = parts.length ? parts.join(' — ') : '';
 }
 
+function updateMonitoringHistoryExtremes(entry) {
+  const openLabel = monitoringOpenRangeEl;
+  const closeLabel = monitoringCloseRangeEl;
+  if (!openLabel || !closeLabel) return;
+  const openStats = entry?.stats?.open;
+  const closeStats = entry?.stats?.close;
+  const formatRange = (stats) => {
+    if (!stats || !Number.isFinite(stats.min) || !Number.isFinite(stats.max)) return '–';
+    const minStr = stats.min.toFixed(3).replace(/\.0+$/, '').replace(/(\.\d*[1-9])0+$/, '$1');
+    const maxStr = stats.max.toFixed(3).replace(/\.0+$/, '').replace(/(\.\d*[1-9])0+$/, '$1');
+    return `${minStr}% a ${maxStr}%`;
+  };
+  openLabel.textContent = formatRange(openStats);
+  closeLabel.textContent = formatRange(closeStats);
+}
+
 async function fetchMonitoringHistorySeries(symbol, intervalKey, spotKey, futuresKey) {
   const params = new URLSearchParams({ symbol, interval: intervalKey, spot: spotKey, futures: futuresKey });
   const response = await fetch(`/api/monitoring/history?${params.toString()}`);
@@ -4590,6 +4617,7 @@ async function fetchMonitoringHistorySeries(symbol, intervalKey, spotKey, future
   return {
     fetchedAt: Date.now(),
     points,
+    stats: data?.stats || null,
     meta: {
       interval: data?.interval || null,
       spot: data?.spot || null,
@@ -4651,6 +4679,14 @@ async function loadMonitoringData({ focusSymbol = null, silent = false, updateCh
             spotExchanges: [spot.exchange || spot.key || 'SPOT'],
             futuresExchanges: [futures.exchange || futures.key || 'FUTUROS'],
             volume24h,
+            spotAsk: toFiniteNumber(spot.ask),
+            spotBid: toFiniteNumber(spot.bid),
+            spotAskNotional: toFiniteNumber(spot.askNotional ?? computeNotionalLocal(spot.ask, spot.askSize)),
+            spotBidNotional: toFiniteNumber(spot.bidNotional ?? computeNotionalLocal(spot.bid, spot.bidSize)),
+            futuresAsk: toFiniteNumber(futures.ask),
+            futuresBid: toFiniteNumber(futures.bid),
+            futuresAskNotional: toFiniteNumber(futures.askNotional ?? computeNotionalLocal(futures.ask, futures.askSize)),
+            futuresBidNotional: toFiniteNumber(futures.bidNotional ?? computeNotionalLocal(futures.bid, futures.bidSize)),
             depth: metrics.depthLabel || 'N/D',
             funding: toFiniteNumber(futures.fundingRate),
             risk: riskLabel,
@@ -4692,6 +4728,25 @@ function formatVolume(value) {
   return value.toFixed(0);
 }
 
+function formatPriceCompact(value) {
+  if (!Number.isFinite(value)) return '—';
+  if (value >= 1) return value.toFixed(4).replace(/\.0+$/, '').replace(/(\.\d*[1-9])0+$/, '$1');
+  return value.toFixed(6).replace(/0+$/, '').replace(/\.$/, '');
+}
+
+function formatUptime(ms) {
+  if (!Number.isFinite(ms) || ms <= 0) return '—';
+  const totalMinutes = Math.floor(ms / 60000);
+  const days = Math.floor(totalMinutes / (60 * 24));
+  const hours = Math.floor((totalMinutes % (60 * 24)) / 60);
+  const minutes = totalMinutes % 60;
+  const parts = [];
+  if (days) parts.push(`${days}d`);
+  if (hours || days) parts.push(`${hours}h`);
+  parts.push(`${minutes}min`);
+  return parts.join(' ');
+}
+
 function renderMonitoringSummary(filtered) {
   if (monitoringSummaryCountEl) monitoringSummaryCountEl.textContent = filtered.length;
   if (monitoringSummaryBlacklistEl) monitoringSummaryBlacklistEl.textContent = blacklist.size;
@@ -4699,6 +4754,27 @@ function renderMonitoringSummary(filtered) {
     const best = filtered.reduce((acc, coin) => (Number.isFinite(coin.arb) && coin.arb > (acc?.arb ?? -Infinity) ? coin : acc), null);
     monitoringSummaryBestEl.textContent = best ? `${best.symbol} • ${best.arb.toFixed(2)}%` : (monitoringLastFetchError ? 'Erro' : '-');
   }
+}
+
+function updateArbUptime(key, arb) {
+  const entry = monitoringArbTimers.get(key) || { start: null };
+  const now = Date.now();
+  if (Number.isFinite(arb) && arb > 0) {
+    if (!entry.start) entry.start = now;
+  } else {
+    entry.start = null;
+  }
+  monitoringArbTimers.set(key, entry);
+  return entry.start ? formatUptime(now - entry.start) : '—';
+}
+
+function renderLegDetails(label, ask, bid, askNotional, bidNotional) {
+  const lines = [];
+  const askVolLabel = Number.isFinite(askNotional) ? `${formatVolume(askNotional)} USDT` : 's/ dado';
+  const bidVolLabel = Number.isFinite(bidNotional) ? `${formatVolume(bidNotional)} USDT` : 's/ dado';
+  lines.push(`<div class="quote-chip ask"><span>${label}</span><strong>Ask ${formatPriceCompact(ask)}</strong><em>Vol: ${askVolLabel}</em></div>`);
+  lines.push(`<div class="quote-chip bid"><span>${label}</span><strong>Bid ${formatPriceCompact(bid)}</strong><em>Vol: ${bidVolLabel}</em></div>`);
+  return lines.join('');
 }
 
 function renderMonitoringTable() {
@@ -4762,7 +4838,8 @@ function renderMonitoringTable() {
     const metaInfo = monitoringMeta.get(coin.symbol);
     const favKey = buildOpportunityKey(coin);
     const isFavorite = monitoringFavorites.has(favKey);
-    const arbLabel = Number.isFinite(coin.arb) ? `${coin.arb.toFixed(2)}%` : '—';
+    const arbLabel = Number.isFinite(coin.arb) ? `${coin.arb.toFixed(3)}%` : '—';
+    const uptime = updateArbUptime(favKey, coin.arb);
     const spotList = coin.spotExchanges.length
       ? coin.spotExchanges.join(', ')
       : metaInfo?.spotHint?.length
@@ -4773,12 +4850,14 @@ function renderMonitoringTable() {
       : metaInfo?.futuresHint?.length
         ? `${metaInfo.futuresHint.join(', ')} (config)`
         : 'Sem dados';
+    const spotDetail = renderLegDetails(coin.spotExchanges[0] || 'SPOT', coin.spotAsk, coin.spotBid, coin.spotAskNotional, coin.spotBidNotional);
+    const futuresDetail = renderLegDetails(coin.futuresExchanges[0] || 'FUTUROS', coin.futuresAsk, coin.futuresBid, coin.futuresAskNotional, coin.futuresBidNotional);
     return `
       <tr>
         <td><strong>${coin.symbol}</strong><br/><span class="muted">${coin.name}</span></td>
-        <td>${arbLabel}</td>
-        <td>${spotList}</td>
-        <td>${futuresList}</td>
+        <td>${arbLabel}<div class="uptime-chip">⬆︎ acima de 0% por ${uptime}</div></td>
+        <td><div class="exchange-header">${spotList}</div>${spotDetail}</td>
+        <td><div class="exchange-header">${futuresList}</div>${futuresDetail}</td>
         <td>${formatVolume(coin.volume24h)} USDT</td>
         <td>${isFavorite ? '<span class="monitoring-favorite-flag">★ Favorito</span>' : '—'}</td>
         <td class="monitoring-actions-cell">
@@ -4933,6 +5012,7 @@ async function updateMonitoringChart(symbolInput) {
       monitoringHistoryCache.set(cacheKey, entry);
     } catch (err) {
       updateMonitoringHistorySource(null);
+      updateMonitoringHistoryExtremes(null);
       chart.data.labels = [];
       chart.data.datasets = [];
       chart.update();
@@ -4997,6 +5077,7 @@ async function updateMonitoringChart(symbolInput) {
   chart.update();
   syncMonitoringChartVisibilityFromChart(chart);
   updateMonitoringHistorySource(entry);
+  updateMonitoringHistoryExtremes(entry);
   if (!points.length) {
     const warning = entry.errors?.spot || entry.errors?.futures;
     if (warning) {

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -4159,73 +4159,17 @@ navButtons.forEach((btn) => {
   btn.addEventListener('click', () => activateView(btn.dataset.viewTarget));
 });
 
-const monitoringCoins = [
-  {
-    symbol: 'CPOOL_USDT',
-    name: 'Clearpool',
-    arb: 2.6,
-    spotExchanges: ['Gate.io', 'Binance'],
-    futuresExchanges: ['MEXC Futures', 'Gate.io Futures'],
-    volume24h: 680000,
-    depth: 'Alta',
-    funding: 0.018,
-    risk: 'Baixo',
-    stability: 'Estável'
-  },
-  {
-    symbol: 'MAT_USDT',
-    name: 'Mycelium',
-    arb: 1.4,
-    spotExchanges: ['Gate.io', 'KuCoin'],
-    futuresExchanges: ['Bybit', 'MEXC Futures'],
-    volume24h: 320000,
-    depth: 'Média',
-    funding: 0.011,
-    risk: 'Médio',
-    stability: 'Estável'
-  },
-  {
-    symbol: 'FARM_USDT',
-    name: 'Harvest Finance',
-    arb: 3.1,
-    spotExchanges: ['Gate.io', 'Binance'],
-    futuresExchanges: ['MEXC Futures'],
-    volume24h: 1500000,
-    depth: 'Alta',
-    funding: 0.024,
-    risk: 'Baixo',
-    stability: 'Volátil'
-  }
-];
+const monitoringMeta = new Map([
+  ['CPOOL_USDT', { name: 'Clearpool', risk: 'Baixo', spotHint: ['Gate.io', 'Binance'], futuresHint: ['MEXC Futures', 'Gate.io Futures'] }],
+  ['MAT_USDT', { name: 'Mycelium', risk: 'Médio', spotHint: ['Gate.io', 'KuCoin'], futuresHint: ['Bybit', 'MEXC Futures'] }],
+  ['FARM_USDT', { name: 'Harvest Finance', risk: 'Baixo', spotHint: ['Gate.io', 'Binance'], futuresHint: ['MEXC Futures'] }]
+]);
 
+let trackedMonitoringSymbols = Array.from(monitoringMeta.keys());
+let monitoringRows = [];
 const monitoringHistory = {};
-function generateHistory(symbol, baseArb) {
-  const points = [];
-  const now = Date.now();
-  let last = baseArb;
-  for (let i = 24; i >= 0; i -= 1) {
-    const ts = now - i * 60 * 60 * 1000;
-    const open = Number((last + (Math.random() - 0.5) * 0.6).toFixed(2));
-    const close = Number((open + (Math.random() - 0.5) * 0.5).toFixed(2));
-    const arb = Number((close + (Math.random() - 0.5) * 0.4).toFixed(2));
-    const spotVol = Math.round((0.8 + Math.random() * 0.5) * 100000);
-    const futuresVol = Math.round((0.6 + Math.random() * 0.6) * 90000);
-    points.push({
-      label: new Date(ts).toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' }),
-      open,
-      close,
-      arb,
-      spotVol,
-      futuresVol
-    });
-    last = arb;
-  }
-  return points;
-}
-
-monitoringCoins.forEach((coin) => {
-  monitoringHistory[coin.symbol] = generateHistory(coin.symbol, coin.arb);
-});
+let monitoringLoading = true;
+let monitoringLastFetchError = null;
 
 const blacklist = new Set();
 const ADMIN_PASSWORD = 'arbisync@2024';
@@ -4260,6 +4204,111 @@ function getCheckedValues(selector) {
     .map((el) => el.value);
 }
 
+function toFiniteNumber(value) {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+}
+
+function getMonitoringName(symbol, fallbackLabel = null) {
+  if (!symbol) return fallbackLabel || '';
+  const normalized = symbol.toUpperCase();
+  const meta = monitoringMeta.get(normalized);
+  return meta?.name || fallbackLabel || normalized;
+}
+
+function resetMonitoringHistory() {
+  Object.keys(monitoringHistory).forEach((key) => delete monitoringHistory[key]);
+}
+
+async function loadMonitoringData({ focusSymbol = null, silent = false } = {}) {
+  if (!trackedMonitoringSymbols.length) {
+    monitoringRows = [];
+    resetMonitoringHistory();
+    renderMonitoringTable();
+    updateMonitoringSelectors();
+    monitoringLoading = false;
+    return;
+  }
+  try {
+    monitoringLoading = true;
+    monitoringLastFetchError = null;
+    if (!silent && monitoringTableBody) {
+      monitoringTableBody.innerHTML = '<tr><td colspan="9">Carregando dados de arbitragem em tempo real...</td></tr>';
+    }
+    const params = new URLSearchParams();
+    params.set('symbols', trackedMonitoringSymbols.join(','));
+    const response = await fetch(`/api/monitoring/markets?${params.toString()}`);
+    if (!response.ok) throw new Error(`Falha ao buscar dados (${response.status})`);
+    const payload = await safeJson(response);
+    const entries = Array.isArray(payload?.symbols) ? payload.symbols : [];
+    monitoringRows = entries.map((entry) => {
+      const symbol = (entry?.symbol || '').toUpperCase();
+      if (!symbol) return null;
+      const name = getMonitoringName(symbol, entry?.label || symbol);
+      const metrics = entry?.metrics || {};
+      const arb = toFiniteNumber(metrics.arbPct);
+      const volume24h = toFiniteNumber(metrics.volume24h);
+      const funding = toFiniteNumber(metrics.fundingRate);
+      const volatility = toFiniteNumber(metrics.volatilityPct);
+      const metaInfo = monitoringMeta.get(symbol);
+      const stability = metrics.stability || metaInfo?.stability || (Number.isFinite(volatility) ? (volatility > 6 ? 'Volátil' : 'Estável') : 'Indefinido');
+      const riskLabel = metrics.riskLabel || metaInfo?.risk || 'Indefinido';
+      return {
+        symbol,
+        name,
+        arb,
+        spotExchanges: (entry?.spot || []).filter((ticker) => !ticker.error && ticker.exchange).map((ticker) => ticker.exchange),
+        futuresExchanges: (entry?.futures || []).filter((ticker) => !ticker.error && ticker.exchange).map((ticker) => ticker.exchange),
+        volume24h: Number.isFinite(volume24h) ? volume24h : 0,
+        depth: metrics.depthLabel || 'N/D',
+        funding,
+        risk: riskLabel,
+        stability
+      };
+    }).filter(Boolean);
+    resetMonitoringHistory();
+    entries.forEach((entry) => {
+      const symbol = (entry?.symbol || '').toUpperCase();
+      if (!symbol) return;
+      const points = Array.isArray(entry?.history?.points) ? entry.history.points : [];
+      monitoringHistory[symbol] = points.map((point) => {
+        const ts = toFiniteNumber(point.timestamp);
+        const label = ts
+          ? new Date(ts).toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' })
+          : '';
+        const open = toFiniteNumber(point.openArbPct ?? point.arbPct);
+        const close = toFiniteNumber(point.arbPct ?? point.openArbPct);
+        return {
+          label,
+          open: open ?? close ?? 0,
+          close: close ?? open ?? 0,
+          arb: close ?? open ?? 0,
+          spotVol: toFiniteNumber(point.spotVolume) ?? 0,
+          futuresVol: toFiniteNumber(point.futuresVolume) ?? 0
+        };
+      });
+    });
+    renderMonitoringTable();
+    updateMonitoringSelectors();
+    const preferredSymbol = focusSymbol && monitoringHistory[focusSymbol]
+      ? focusSymbol
+      : (monitoringPairSelect?.value || monitoringRows[0]?.symbol || null);
+    if (preferredSymbol && monitoringPairSelect) {
+      monitoringPairSelect.value = preferredSymbol;
+    }
+    if (preferredSymbol) updateMonitoringChart(preferredSymbol);
+  } catch (err) {
+    monitoringLastFetchError = err;
+    console.error('[monitoring] erro ao carregar dados', err);
+    if (monitoringTableBody) {
+      monitoringTableBody.innerHTML = `<tr><td colspan="9">Erro ao carregar dados de arbitragem: ${err.message || err}</td></tr>`;
+    }
+    renderMonitoringSummary([]);
+  } finally {
+    monitoringLoading = false;
+  }
+}
+
 function formatVolume(value) {
   if (!Number.isFinite(value)) return '-';
   if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
@@ -4271,13 +4320,12 @@ function renderMonitoringSummary(filtered) {
   if (monitoringSummaryCountEl) monitoringSummaryCountEl.textContent = filtered.length;
   if (monitoringSummaryBlacklistEl) monitoringSummaryBlacklistEl.textContent = blacklist.size;
   if (monitoringSummaryBestEl) {
-    const best = filtered.reduce((acc, coin) => (coin.arb > (acc?.arb || 0) ? coin : acc), null);
-    monitoringSummaryBestEl.textContent = best ? `${best.symbol} • ${best.arb.toFixed(2)}%` : '-';
+    const best = filtered.reduce((acc, coin) => (Number.isFinite(coin.arb) && coin.arb > (acc?.arb ?? -Infinity) ? coin : acc), null);
+    monitoringSummaryBestEl.textContent = best ? `${best.symbol} • ${best.arb.toFixed(2)}%` : (monitoringLastFetchError ? 'Erro' : '-');
   }
   if (monitoringSummaryAvgEl) {
-    const avg = filtered.length
-      ? (filtered.reduce((acc, coin) => acc + coin.arb, 0) / filtered.length).toFixed(2)
-      : '0.00';
+    const arbs = filtered.map((coin) => coin.arb).filter((value) => Number.isFinite(value));
+    const avg = arbs.length ? (arbs.reduce((acc, value) => acc + value, 0) / arbs.length).toFixed(2) : '0.00';
     monitoringSummaryAvgEl.textContent = `${avg}%`;
   }
 }
@@ -4292,31 +4340,65 @@ function renderMonitoringTable() {
   const selectedRisks = getCheckedValues('.filter-risk');
   const stabilityFilter = filterStabilityEl?.value || 'flex';
 
-  const filtered = monitoringCoins
+  const filtered = monitoringRows
+    .filter((coin) => trackedMonitoringSymbols.includes(coin.symbol))
     .filter((coin) => !blacklist.has(coin.symbol))
-    .filter((coin) => (searchTerm ? coin.symbol.includes(searchTerm) || coin.name.toUpperCase().includes(searchTerm) : true))
-    .filter((coin) => coin.arb >= minArb)
+    .filter((coin) => (searchTerm ? coin.symbol.includes(searchTerm) || coin.name?.toUpperCase().includes(searchTerm) : true))
+    .filter((coin) => {
+      if (!minArb) return true;
+      if (!Number.isFinite(coin.arb)) return false;
+      return coin.arb >= minArb;
+    })
     .filter((coin) => coin.volume24h >= minVolume)
     .filter((coin) => !selectedSpot.length || coin.spotExchanges.some((ex) => selectedSpot.includes(ex)))
     .filter((coin) => !selectedFutures.length || coin.futuresExchanges.some((ex) => selectedFutures.includes(ex)))
     .filter((coin) => !selectedRisks.length || selectedRisks.includes(coin.risk))
     .filter((coin) => stabilityFilter === 'flex' || coin.stability === stabilityFilter);
 
-  filtered.sort((a, b) => b.arb - a.arb);
+  filtered.sort((a, b) => {
+    const aArb = Number.isFinite(a.arb) ? a.arb : -Infinity;
+    const bArb = Number.isFinite(b.arb) ? b.arb : -Infinity;
+    return bArb - aArb;
+  });
 
-  monitoringTableBody.innerHTML = filtered.map((coin) => `
+  if (!filtered.length) {
+    const emptyMessage = monitoringLoading
+      ? 'Atualizando dados de arbitragem...'
+      : monitoringLastFetchError
+        ? `Última tentativa falhou: ${monitoringLastFetchError.message || monitoringLastFetchError}`
+        : 'Nenhuma moeda atende aos filtros ativos.';
+    monitoringTableBody.innerHTML = `<tr><td colspan="9">${emptyMessage}</td></tr>`;
+    renderMonitoringSummary(filtered);
+    return;
+  }
+
+  monitoringTableBody.innerHTML = filtered.map((coin) => {
+    const metaInfo = monitoringMeta.get(coin.symbol);
+    const arbLabel = Number.isFinite(coin.arb) ? `${coin.arb.toFixed(2)}%` : '—';
+    const fundingLabel = Number.isFinite(coin.funding) ? `${(coin.funding * 100).toFixed(3)}%` : '—';
+    const spotList = coin.spotExchanges.length
+      ? coin.spotExchanges.join(', ')
+      : metaInfo?.spotHint?.length
+        ? `${metaInfo.spotHint.join(', ')} (config)`
+        : 'Sem dados';
+    const futuresList = coin.futuresExchanges.length
+      ? coin.futuresExchanges.join(', ')
+      : metaInfo?.futuresHint?.length
+        ? `${metaInfo.futuresHint.join(', ')} (config)`
+        : 'Sem dados';
+    return `
       <tr>
         <td><strong>${coin.symbol}</strong><br/><span class="muted">${coin.name}</span></td>
-        <td>${coin.arb.toFixed(2)}%</td>
-        <td>${coin.spotExchanges.join(', ')}</td>
-        <td>${coin.futuresExchanges.join(', ')}</td>
+        <td>${arbLabel}</td>
+        <td>${spotList}</td>
+        <td>${futuresList}</td>
         <td>${formatVolume(coin.volume24h)} USDT</td>
         <td>${coin.depth}</td>
-        <td>${(coin.funding * 100).toFixed(2)}%</td>
+        <td>${fundingLabel}</td>
         <td>${coin.risk}</td>
         <td><button type="button" class="monitoring-view-chart" data-symbol="${coin.symbol}">Ver gráfico</button></td>
-      </tr>
-    `).join('');
+      </tr>`;
+  }).join('');
 
   renderMonitoringSummary(filtered);
 
@@ -4337,13 +4419,21 @@ function renderBlacklist() {
 function updateMonitoringSelectors() {
   const previousSymbol = monitoringPairSelect?.value;
   if (monitoringPairSelect) {
-    monitoringPairSelect.innerHTML = monitoringCoins.map((coin) => `<option value="${coin.symbol}">${coin.symbol} — ${coin.name}</option>`).join('');
-    if (previousSymbol && monitoringCoins.some((coin) => coin.symbol === previousSymbol)) {
+    monitoringPairSelect.innerHTML = trackedMonitoringSymbols
+      .map((symbol) => {
+        const row = monitoringRows.find((coin) => coin.symbol === symbol);
+        const label = getMonitoringName(symbol, row?.name || symbol);
+        return `<option value="${symbol}">${symbol} — ${label}</option>`;
+      })
+      .join('');
+    if (previousSymbol && trackedMonitoringSymbols.includes(previousSymbol)) {
       monitoringPairSelect.value = previousSymbol;
     }
   }
   if (adminRemoveCoinSelect) {
-    adminRemoveCoinSelect.innerHTML = monitoringCoins.map((coin) => `<option value="${coin.symbol}">${coin.symbol}</option>`).join('');
+    adminRemoveCoinSelect.innerHTML = trackedMonitoringSymbols
+      .map((symbol) => `<option value="${symbol}">${symbol}</option>`)
+      .join('');
   }
 }
 
@@ -4465,8 +4555,10 @@ if (monitoringPairSelect) {
 const refreshMonitoringChartBtn = document.getElementById('refreshMonitoringChart');
 if (refreshMonitoringChartBtn) {
   refreshMonitoringChartBtn.addEventListener('click', () => {
-    const symbol = monitoringPairSelect?.value || monitoringCoins[0]?.symbol;
-    if (symbol) updateMonitoringChart(symbol);
+    const symbol = monitoringPairSelect?.value || monitoringRows[0]?.symbol || trackedMonitoringSymbols[0];
+    if (symbol) {
+      loadMonitoringData({ focusSymbol: symbol, silent: true });
+    }
   });
 }
 
@@ -4508,39 +4600,32 @@ if (adminAddCoinForm) {
     if (!requireAdmin()) return;
     const symbolInput = document.getElementById('adminCoinSymbol');
     const nameInput = document.getElementById('adminCoinName');
+    const riskInput = document.getElementById('adminCoinRisk');
     const spotInput = document.getElementById('adminCoinSpot');
     const futuresInput = document.getElementById('adminCoinFutures');
-    const arbInput = document.getElementById('adminCoinArb');
-    const riskInput = document.getElementById('adminCoinRisk');
     if (!symbolInput || !nameInput) return;
     const symbol = symbolInput.value.trim().toUpperCase();
     const name = nameInput.value.trim() || symbol;
     if (!symbol) return;
-    const existing = monitoringCoins.find((coin) => coin.symbol === symbol);
-    const newCoin = {
-      symbol,
-      name,
-      arb: Number(arbInput?.value) || 1,
-      spotExchanges: (spotInput?.value || 'Gate.io').split(',').map((s) => s.trim()).filter(Boolean),
-      futuresExchanges: (futuresInput?.value || 'MEXC Futures').split(',').map((s) => s.trim()).filter(Boolean),
-      volume24h: Math.round(200000 + Math.random() * 900000),
-      depth: 'Custom',
-      funding: 0.01,
-      risk: riskInput?.value || 'Médio',
-      stability: 'Estável'
-    };
-    if (existing) {
-      Object.assign(existing, newCoin);
-    } else {
-      monitoringCoins.push(newCoin);
+    const risk = riskInput?.value || 'Médio';
+    const spotHint = (spotInput?.value || '')
+      .split(',')
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+    const futuresHint = (futuresInput?.value || '')
+      .split(',')
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+    monitoringMeta.set(symbol, { name, risk, spotHint, futuresHint });
+    if (!trackedMonitoringSymbols.includes(symbol)) {
+      trackedMonitoringSymbols.push(symbol);
     }
-    monitoringHistory[symbol] = generateHistory(symbol, newCoin.arb);
     symbolInput.value = '';
     nameInput.value = '';
+    if (riskInput) riskInput.value = 'Médio';
     if (spotInput) spotInput.value = '';
     if (futuresInput) futuresInput.value = '';
-    if (arbInput) arbInput.value = '1.5';
-    renderMonitoringTable();
+    loadMonitoringData({ focusSymbol: symbol, silent: true });
     updateMonitoringSelectors();
     renderBlacklist();
   });
@@ -4552,12 +4637,12 @@ if (adminRemoveCoinForm) {
     if (!requireAdmin()) return;
     const symbol = adminRemoveCoinSelect?.value;
     if (!symbol) return;
-    const idx = monitoringCoins.findIndex((coin) => coin.symbol === symbol);
-    if (idx >= 0) {
-      monitoringCoins.splice(idx, 1);
-      blacklist.delete(symbol);
-      delete monitoringHistory[symbol];
-    }
+    const idx = trackedMonitoringSymbols.indexOf(symbol);
+    if (idx >= 0) trackedMonitoringSymbols.splice(idx, 1);
+    monitoringMeta.delete(symbol);
+    blacklist.delete(symbol);
+    delete monitoringHistory[symbol];
+    monitoringRows = monitoringRows.filter((coin) => coin.symbol !== symbol);
     updateMonitoringSelectors();
     renderMonitoringTable();
     renderBlacklist();
@@ -4592,10 +4677,9 @@ if (blacklistList) {
 function bootstrapMonitoring() {
   updateMonitoringSelectors();
   renderMonitoringTable();
-  const initialSymbol = monitoringPairSelect?.value || monitoringCoins[0]?.symbol;
-  if (initialSymbol) updateMonitoringChart(initialSymbol);
   if (filterMinArbValueEl && filterMinArbEl) filterMinArbValueEl.textContent = `${filterMinArbEl.value}%`;
   renderBlacklist();
+  loadMonitoringData();
 }
 
 bootstrapMonitoring();

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -4216,6 +4216,8 @@ function persistMonitoringVisibility(map) {
   } catch {}
 }
 
+const MONITORING_DEFAULT_COLUMNS = { spot: true, futures: true, volume: true, favorite: true, actions: true };
+
 let monitoringColumnVisibility = loadMonitoringColumns();
 let monitoringDatasetVisibility = loadMonitoringVisibility();
 monitoringColumnVisibility = { ...MONITORING_DEFAULT_COLUMNS, ...monitoringColumnVisibility };
@@ -4278,7 +4280,6 @@ let monitoringFilteredRows = [];
 const MONITORING_REFRESH_DEFAULT_SECONDS = 3;
 let monitoringAutoRefreshTimer = null;
 let monitoringAutoRefreshPaused = false;
-const MONITORING_DEFAULT_COLUMNS = { spot: true, futures: true, volume: true, favorite: true, actions: true };
 const TOP_ASSETS_PAGE_SIZE = 8;
 const TOP_ASSETS_LIMIT_DEFAULT = 60;
 const topAssetsState = { items: [], page: 1, perPage: TOP_ASSETS_PAGE_SIZE, limit: TOP_ASSETS_LIMIT_DEFAULT };

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -4262,6 +4262,9 @@ const topAssetsSelection = new Set();
 const monitoringFavorites = new Set();
 let executionToastTimer = null;
 
+const EXECUTION_SPOT_PROVIDERS = ['Gate.io', 'Bitget'];
+const EXECUTION_FUTURES_PROVIDERS = ['MEXC Futures'];
+
 function getCheckedValues(selector) {
   return Array.from(document.querySelectorAll(selector))
     .filter((el) => el.checked)
@@ -4366,6 +4369,18 @@ function toggleFavorite(key) {
   setFavorite(normalized, nowFav);
   renderMonitoringTable();
   return nowFav;
+}
+
+function getMissingExecutionExchanges(coin) {
+  if (!coin) return [];
+  const missing = [];
+  const spotList = Array.isArray(coin.spotExchanges) ? coin.spotExchanges : [];
+  const futuresList = Array.isArray(coin.futuresExchanges) ? coin.futuresExchanges : [];
+  const unsupportedSpot = spotList.filter((ex) => !EXECUTION_SPOT_PROVIDERS.includes(ex));
+  const unsupportedFutures = futuresList.filter((ex) => !EXECUTION_FUTURES_PROVIDERS.includes(ex));
+  if (unsupportedSpot.length) missing.push(`SPOT: ${unsupportedSpot.join(', ')}`);
+  if (unsupportedFutures.length) missing.push(`FUTUROS: ${unsupportedFutures.join(', ')}`);
+  return missing;
 }
 
 function resolveSpotKeyFromLabel(labelList) {
@@ -5065,6 +5080,11 @@ if (monitoringPaginationNext) {
       const key = execBtn.dataset.favoriteKey;
       const coin = findOpportunityByKey(key);
       if (!coin) return;
+      const missing = getMissingExecutionExchanges(coin);
+      if (missing.length) {
+        showExecutionToast(`Ainda não há API de execução para ${missing.join(' | ')}`);
+        return;
+      }
       setFavorite(key, true);
       renderMonitoringTable();
       addExecutionTabFromOpportunity(coin, execBtn.dataset.spot);

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -4782,7 +4782,13 @@ function renderMonitoringTable() {
         <td>${formatVolume(coin.volume24h)} USDT</td>
         <td>${isFavorite ? '<span class="monitoring-favorite-flag">★ Favorito</span>' : '—'}</td>
         <td class="monitoring-actions-cell">
-          <button type="button" class="monitoring-view-chart" data-symbol="${coin.symbol}">Ver gráfico</button>
+          <button
+            type="button"
+            class="monitoring-view-chart"
+            data-symbol="${coin.symbol}"
+            data-spot="${coin.spotExchanges.join('|')}"
+            data-futures="${coin.futuresExchanges.join('|')}"
+          >Ver gráfico</button>
           <button
             type="button"
             class="monitoring-favorite-btn ${isFavorite ? 'favorited' : ''}"
@@ -4896,7 +4902,8 @@ function ensureMonitoringChart() {
             callback: (value) => {
               const num = Number(value);
               if (!Number.isFinite(num)) return `${value}%`;
-              return `${num.toFixed(3)}%`;
+              const formatted = num.toFixed(3).replace(/\.0+$/, '').replace(/(\.\d*[1-9])0+$/, '$1');
+              return `${formatted}%`;
             }
           }
         },

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -4167,7 +4167,9 @@ const monitoringMeta = new Map([
 
 let trackedMonitoringSymbols = Array.from(monitoringMeta.keys());
 let monitoringRows = [];
-const monitoringHistory = {};
+const monitoringHistoryCache = new Map();
+const MONITORING_HISTORY_DEFAULTS = { interval: '1h', spot: 'gate_spot', futures: 'gate_futures' };
+const MONITORING_HISTORY_CACHE_TTL = 60 * 1000;
 let monitoringLoading = true;
 let monitoringLastFetchError = null;
 
@@ -4186,6 +4188,11 @@ const monitoringSummaryAvgEl = document.getElementById('monitoringSummaryAvg');
 const monitoringSummaryCountEl = document.getElementById('monitoringResultCount');
 const monitoringSummaryBlacklistEl = document.getElementById('monitoringSummaryBlacklist');
 const monitoringPairSelect = document.getElementById('monitoringPairSelect');
+const monitoringHistoryIntervalSelect = document.getElementById('monitoringHistoryInterval');
+const monitoringHistorySpotSelect = document.getElementById('monitoringHistorySpot');
+const monitoringHistoryFuturesSelect = document.getElementById('monitoringHistoryFutures');
+const monitoringHistorySourceEl = document.getElementById('monitoringHistorySource');
+const monitoringHistoryStatusEl = document.getElementById('monitoringHistoryStatus');
 const adminStatusLabel = document.getElementById('adminStatusLabel');
 const adminLoginFeedback = document.getElementById('adminLoginFeedback');
 const adminTools = document.getElementById('adminTools');
@@ -4217,7 +4224,105 @@ function getMonitoringName(symbol, fallbackLabel = null) {
 }
 
 function resetMonitoringHistory() {
-  Object.keys(monitoringHistory).forEach((key) => delete monitoringHistory[key]);
+  monitoringHistoryCache.clear();
+}
+
+function buildMonitoringHistoryCacheKey(symbol, intervalKey, spotKey, futuresKey) {
+  const base = String(symbol || '').toUpperCase();
+  return `${base}:${intervalKey}:${spotKey}:${futuresKey}`;
+}
+
+function purgeMonitoringHistoryCache(symbol) {
+  if (!symbol) return;
+  const prefix = `${String(symbol).toUpperCase()}:`;
+  Array.from(monitoringHistoryCache.keys()).forEach((key) => {
+    if (key.startsWith(prefix)) {
+      monitoringHistoryCache.delete(key);
+    }
+  });
+}
+
+function getCachedMonitoringHistory(cacheKey) {
+  const cached = monitoringHistoryCache.get(cacheKey);
+  if (!cached) return null;
+  if (Date.now() - cached.fetchedAt > MONITORING_HISTORY_CACHE_TTL) {
+    monitoringHistoryCache.delete(cacheKey);
+    return null;
+  }
+  return cached;
+}
+
+function formatHistoryLabel(timestamp) {
+  try {
+    return new Date(timestamp).toLocaleString('pt-BR', {
+      day: '2-digit',
+      month: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false
+    });
+  } catch {
+    return '';
+  }
+}
+
+function setMonitoringHistoryStatus(message, tone = 'muted') {
+  if (!monitoringHistoryStatusEl) return;
+  monitoringHistoryStatusEl.textContent = message || '';
+  monitoringHistoryStatusEl.classList.remove('error', 'success');
+  if (tone === 'error') {
+    monitoringHistoryStatusEl.classList.add('error');
+  } else if (tone === 'success') {
+    monitoringHistoryStatusEl.classList.add('success');
+  }
+}
+
+function updateMonitoringHistorySource(entry) {
+  if (!monitoringHistorySourceEl) return;
+  const parts = [];
+  if (entry?.meta?.spot?.label && entry?.meta?.futures?.label) {
+    parts.push(`${entry.meta.spot.label} (SPOT) × ${entry.meta.futures.label} (Futuros)`);
+  }
+  if (entry?.meta?.interval?.label) {
+    parts.push(`${entry.meta.interval.label} • ${entry.points?.length || 0} candles`);
+  }
+  monitoringHistorySourceEl.textContent = parts.length ? parts.join(' — ') : '';
+}
+
+async function fetchMonitoringHistorySeries(symbol, intervalKey, spotKey, futuresKey) {
+  const params = new URLSearchParams({ symbol, interval: intervalKey, spot: spotKey, futures: futuresKey });
+  const response = await fetch(`/api/monitoring/history?${params.toString()}`);
+  const data = await safeJson(response);
+  if (!response.ok) {
+    throw new Error(data?.error || 'Erro ao buscar histórico');
+  }
+  const points = (Array.isArray(data?.points) ? data.points : [])
+    .map((point) => {
+      const ts = toFiniteNumber(point.timestamp);
+      const close = toFiniteNumber(point.closeArbPct ?? point.arbPct ?? point.closeArb);
+      const open = toFiniteNumber(point.openArbPct ?? point.arbPct ?? point.openArb);
+      if (!Number.isFinite(ts) || (!Number.isFinite(close) && !Number.isFinite(open))) return null;
+      return {
+        timestamp: ts,
+        label: formatHistoryLabel(ts),
+        arb: Number.isFinite(close) ? close : open || 0,
+        open: Number.isFinite(open) ? open : close || 0,
+        close: Number.isFinite(close) ? close : open || 0,
+        spotVol: toFiniteNumber(point.spotVolume) ?? 0,
+        futuresVol: toFiniteNumber(point.futuresVolume) ?? 0
+      };
+    })
+    .filter(Boolean);
+  return {
+    fetchedAt: Date.now(),
+    points,
+    meta: {
+      interval: data?.interval || null,
+      spot: data?.spot || null,
+      futures: data?.futures || null
+    },
+    errors: { spot: data?.spotError || null, futures: data?.futuresError || null }
+  };
 }
 
 async function loadMonitoringData({ focusSymbol = null, silent = false } = {}) {
@@ -4267,32 +4372,9 @@ async function loadMonitoringData({ focusSymbol = null, silent = false } = {}) {
       };
     }).filter(Boolean);
     resetMonitoringHistory();
-    entries.forEach((entry) => {
-      const symbol = (entry?.symbol || '').toUpperCase();
-      if (!symbol) return;
-      const points = Array.isArray(entry?.history?.points) ? entry.history.points : [];
-      monitoringHistory[symbol] = points.map((point) => {
-        const ts = toFiniteNumber(point.timestamp);
-        const label = ts
-          ? new Date(ts).toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' })
-          : '';
-        const open = toFiniteNumber(point.openArbPct ?? point.arbPct);
-        const close = toFiniteNumber(point.arbPct ?? point.openArbPct);
-        return {
-          label,
-          open: open ?? close ?? 0,
-          close: close ?? open ?? 0,
-          arb: close ?? open ?? 0,
-          spotVol: toFiniteNumber(point.spotVolume) ?? 0,
-          futuresVol: toFiniteNumber(point.futuresVolume) ?? 0
-        };
-      });
-    });
     renderMonitoringTable();
     updateMonitoringSelectors();
-    const preferredSymbol = focusSymbol && monitoringHistory[focusSymbol]
-      ? focusSymbol
-      : (monitoringPairSelect?.value || monitoringRows[0]?.symbol || null);
+    const preferredSymbol = focusSymbol || monitoringPairSelect?.value || monitoringRows[0]?.symbol || null;
     if (preferredSymbol && monitoringPairSelect) {
       monitoringPairSelect.value = preferredSymbol;
     }
@@ -4458,16 +4540,38 @@ function ensureMonitoringChart() {
   return monitoringChart;
 }
 
-function updateMonitoringChart(symbol) {
+async function updateMonitoringChart(symbolInput) {
   const chart = ensureMonitoringChart();
   if (!chart) return;
-  const history = monitoringHistory[symbol] || [];
-  chart.data.labels = history.map((p) => p.label);
+  const fallbackSymbol = monitoringPairSelect?.value || monitoringRows[0]?.symbol || trackedMonitoringSymbols[0];
+  const symbol = String(symbolInput || fallbackSymbol || '').toUpperCase();
+  if (!symbol) return;
+  const intervalKey = monitoringHistoryIntervalSelect?.value || MONITORING_HISTORY_DEFAULTS.interval;
+  const spotKey = monitoringHistorySpotSelect?.value || MONITORING_HISTORY_DEFAULTS.spot;
+  const futuresKey = monitoringHistoryFuturesSelect?.value || MONITORING_HISTORY_DEFAULTS.futures;
+  const cacheKey = buildMonitoringHistoryCacheKey(symbol, intervalKey, spotKey, futuresKey);
+  let entry = getCachedMonitoringHistory(cacheKey);
+  if (!entry) {
+    setMonitoringHistoryStatus('Carregando histórico em tempo real...');
+    try {
+      entry = await fetchMonitoringHistorySeries(symbol, intervalKey, spotKey, futuresKey);
+      monitoringHistoryCache.set(cacheKey, entry);
+    } catch (err) {
+      updateMonitoringHistorySource(null);
+      chart.data.labels = [];
+      chart.data.datasets = [];
+      chart.update();
+      setMonitoringHistoryStatus(`Erro ao carregar histórico: ${err.message || err}`, 'error');
+      return;
+    }
+  }
+  const points = entry.points || [];
+  chart.data.labels = points.map((p) => p.label);
   chart.data.datasets = [
     {
       type: 'line',
       label: '% Arb médio',
-      data: history.map((p) => p.arb),
+      data: points.map((p) => p.arb),
       borderColor: '#8d6cff',
       backgroundColor: 'rgba(141, 108, 255, 0.2)',
       tension: 0.35,
@@ -4478,7 +4582,7 @@ function updateMonitoringChart(symbol) {
     {
       type: 'line',
       label: 'Linha de abertura',
-      data: history.map((p) => p.open),
+      data: points.map((p) => p.open),
       borderColor: '#3fe7c3',
       borderDash: [6, 6],
       tension: 0.3,
@@ -4489,7 +4593,7 @@ function updateMonitoringChart(symbol) {
     {
       type: 'line',
       label: 'Linha de fechamento',
-      data: history.map((p) => p.close),
+      data: points.map((p) => p.close),
       borderColor: '#f2b760',
       borderDash: [6, 6],
       tension: 0.3,
@@ -4500,7 +4604,7 @@ function updateMonitoringChart(symbol) {
     {
       type: 'bar',
       label: 'Volume Spot',
-      data: history.map((p) => p.spotVol),
+      data: points.map((p) => p.spotVol),
       backgroundColor: 'rgba(141, 108, 255, 0.35)',
       borderRadius: 4,
       yAxisID: 'yVolume'
@@ -4508,13 +4612,32 @@ function updateMonitoringChart(symbol) {
     {
       type: 'bar',
       label: 'Volume Futuros',
-      data: history.map((p) => p.futuresVol),
+      data: points.map((p) => p.futuresVol),
       backgroundColor: 'rgba(63, 231, 195, 0.35)',
       borderRadius: 4,
       yAxisID: 'yVolume'
     }
   ];
   chart.update();
+  updateMonitoringHistorySource(entry);
+  if (!points.length) {
+    const warning = entry.errors?.spot || entry.errors?.futures;
+    if (warning) {
+      setMonitoringHistoryStatus(`Sem candles para esta combinação (${warning})`, 'error');
+    } else {
+      setMonitoringHistoryStatus('Nenhum candle disponível nas últimas 24h para esta combinação.');
+    }
+    return;
+  }
+  const updatedAt = new Date(entry.fetchedAt || Date.now()).toLocaleTimeString('pt-BR', { hour12: false });
+  const errorParts = [];
+  if (entry.errors?.spot) errorParts.push(`SPOT: ${entry.errors.spot}`);
+  if (entry.errors?.futures) errorParts.push(`FUTUROS: ${entry.errors.futures}`);
+  if (errorParts.length) {
+    setMonitoringHistoryStatus(`Dados parciais — ${errorParts.join(' | ')}`, 'error');
+  } else {
+    setMonitoringHistoryStatus(`Atualizado às ${updatedAt}`, 'success');
+  }
 }
 
 const filterInputs = [filterSearchEl, filterVolumeEl, filterStabilityEl];
@@ -4552,13 +4675,25 @@ if (monitoringPairSelect) {
   monitoringPairSelect.addEventListener('change', () => updateMonitoringChart(monitoringPairSelect.value));
 }
 
+[monitoringHistoryIntervalSelect, monitoringHistorySpotSelect, monitoringHistoryFuturesSelect].forEach((select) => {
+  if (!select) return;
+  select.addEventListener('change', () => {
+    const symbol = monitoringPairSelect?.value || monitoringRows[0]?.symbol || trackedMonitoringSymbols[0];
+    if (symbol) updateMonitoringChart(symbol);
+  });
+});
+
 const refreshMonitoringChartBtn = document.getElementById('refreshMonitoringChart');
 if (refreshMonitoringChartBtn) {
   refreshMonitoringChartBtn.addEventListener('click', () => {
     const symbol = monitoringPairSelect?.value || monitoringRows[0]?.symbol || trackedMonitoringSymbols[0];
-    if (symbol) {
-      loadMonitoringData({ focusSymbol: symbol, silent: true });
-    }
+    if (!symbol) return;
+    const intervalKey = monitoringHistoryIntervalSelect?.value || MONITORING_HISTORY_DEFAULTS.interval;
+    const spotKey = monitoringHistorySpotSelect?.value || MONITORING_HISTORY_DEFAULTS.spot;
+    const futuresKey = monitoringHistoryFuturesSelect?.value || MONITORING_HISTORY_DEFAULTS.futures;
+    const cacheKey = buildMonitoringHistoryCacheKey(symbol, intervalKey, spotKey, futuresKey);
+    monitoringHistoryCache.delete(cacheKey);
+    updateMonitoringChart(symbol);
   });
 }
 
@@ -4641,7 +4776,7 @@ if (adminRemoveCoinForm) {
     if (idx >= 0) trackedMonitoringSymbols.splice(idx, 1);
     monitoringMeta.delete(symbol);
     blacklist.delete(symbol);
-    delete monitoringHistory[symbol];
+    purgeMonitoringHistoryCache(symbol);
     monitoringRows = monitoringRows.filter((coin) => coin.symbol !== symbol);
     updateMonitoringSelectors();
     renderMonitoringTable();

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -4209,6 +4209,11 @@ const adminRemoveCoinSelect = document.getElementById('adminRemoveCoinSelect');
 const blacklistForm = document.getElementById('blacklistForm');
 const blacklistInput = document.getElementById('blacklistInput');
 const blacklistList = document.getElementById('blacklistList');
+const discoverTopAssetsBtn = document.getElementById('discoverTopAssets');
+const addSelectedTopAssetsBtn = document.getElementById('addSelectedTopAssets');
+const topAssetsList = document.getElementById('topAssetsList');
+const topAssetsStatus = document.getElementById('topAssetsStatus');
+const topAssetsResults = document.getElementById('topAssetsResults');
 
 const MONITORING_PAGE_SIZE = 10;
 const monitoringPaginationState = { page: 1, perPage: MONITORING_PAGE_SIZE };
@@ -4277,7 +4282,7 @@ function changeMonitoringPage(delta) {
 function getMonitoringRefreshSeconds() {
   const seconds = Number(monitoringRefreshIntervalSelect?.value);
   if (!Number.isFinite(seconds)) return MONITORING_REFRESH_DEFAULT_SECONDS;
-  return Math.min(Math.max(seconds, 1), 5);
+  return Math.min(Math.max(seconds, 0.5), 5);
 }
 
 function scheduleMonitoringAutoRefresh() {
@@ -4288,7 +4293,7 @@ function scheduleMonitoringAutoRefresh() {
   const intervalMs = getMonitoringRefreshSeconds() * 1000;
   monitoringAutoRefreshTimer = setInterval(() => {
     if (document.hidden) return;
-    loadMonitoringData({ silent: true });
+    loadMonitoringData({ silent: true, updateChart: false });
   }, intervalMs);
 }
 
@@ -4409,7 +4414,7 @@ async function fetchMonitoringHistorySeries(symbol, intervalKey, spotKey, future
   };
 }
 
-async function loadMonitoringData({ focusSymbol = null, silent = false } = {}) {
+async function loadMonitoringData({ focusSymbol = null, silent = false, updateChart = true } = {}) {
   if (!trackedMonitoringSymbols.length) {
     monitoringRows = [];
     resetMonitoringHistory();
@@ -4461,11 +4466,13 @@ async function loadMonitoringData({ focusSymbol = null, silent = false } = {}) {
     resetMonitoringHistory();
     renderMonitoringTable();
     updateMonitoringSelectors();
-    const preferredSymbol = focusSymbol || monitoringPairSelect?.value || monitoringRows[0]?.symbol || null;
-    if (preferredSymbol && monitoringPairSelect) {
-      monitoringPairSelect.value = preferredSymbol;
+    if (updateChart) {
+      const preferredSymbol = focusSymbol || monitoringPairSelect?.value || monitoringRows[0]?.symbol || null;
+      if (preferredSymbol && monitoringPairSelect) {
+        monitoringPairSelect.value = preferredSymbol;
+      }
+      if (preferredSymbol) updateMonitoringChart(preferredSymbol);
     }
-    if (preferredSymbol) updateMonitoringChart(preferredSymbol);
   } catch (err) {
     monitoringLastFetchError = err;
     console.error('[monitoring] erro ao carregar dados', err);
@@ -4811,13 +4818,13 @@ if (refreshMonitoringChartBtn) {
 if (monitoringRefreshIntervalSelect) {
   monitoringRefreshIntervalSelect.addEventListener('change', () => {
     scheduleMonitoringAutoRefresh();
-    loadMonitoringData({ silent: true });
+    loadMonitoringData({ silent: true, updateChart: false });
   });
 }
 
 document.addEventListener('visibilitychange', () => {
   if (!document.hidden) {
-    loadMonitoringData({ silent: true });
+    loadMonitoringData({ silent: true, updateChart: false });
   }
 });
 
@@ -4851,6 +4858,85 @@ function requireAdmin() {
     adminLoginFeedback.style.color = '#ff6b9a';
   }
   return false;
+}
+
+function getSelectedTopExchanges() {
+  return Array.from(document.querySelectorAll('.top-exchange'))
+    .filter((el) => el.checked)
+    .map((el) => el.value);
+}
+
+function renderTopAssetsList(assets) {
+  if (!topAssetsList) return;
+  if (!assets.length) {
+    topAssetsList.innerHTML = '<p class="muted">Nenhum ativo retornado para as corretoras selecionadas.</p>';
+    return;
+  }
+  topAssetsList.innerHTML = assets
+    .map((asset) => {
+      const bestVolume = Number.isFinite(asset.bestVolume) ? formatVolume(asset.bestVolume) : 'N/D';
+      const exchanges = Array.isArray(asset.exchanges) && asset.exchanges.length ? asset.exchanges.join(', ') : '—';
+      return `<label class="top-asset-row">
+        <input type="checkbox" class="top-asset-option" value="${asset.symbol}" data-label="${asset.label || asset.symbol}">
+        <span class="asset-name">${asset.label || asset.symbol}</span>
+        <span class="asset-symbol">${asset.symbol}</span>
+        <span class="asset-volume">Vol 24h: ${bestVolume}</span>
+        <span class="asset-exchanges">${exchanges}</span>
+      </label>`;
+    })
+    .join('');
+}
+
+function normalizeMonitoringSymbolInput(value) {
+  const str = String(value || '').trim().toUpperCase();
+  if (!str) return null;
+  if (str.includes('-')) return str.replace(/-/g, '_');
+  if (str.includes('_')) return str;
+  if (str.endsWith('USDT')) {
+    const base = str.slice(0, -4);
+    return base ? `${base}_USDT` : null;
+  }
+  return str;
+}
+
+async function discoverTopAssets() {
+  if (!requireAdmin()) return;
+  const selected = getSelectedTopExchanges();
+  if (topAssetsStatus) {
+    topAssetsStatus.textContent = 'Buscando ativos com maior volume...';
+    topAssetsStatus.classList.remove('error');
+  }
+  const params = new URLSearchParams();
+  if (selected.length) params.set('exchanges', selected.join(','));
+  try {
+    const response = await fetch(`/api/monitoring/top-assets?${params.toString()}`);
+    if (!response.ok) throw new Error(`Falha ao buscar top 24h (${response.status})`);
+    const payload = await safeJson(response);
+    const assets = Array.isArray(payload?.assets) ? payload.assets : [];
+    renderTopAssetsList(assets);
+    if (topAssetsResults) topAssetsResults.classList.toggle('hidden', !assets.length);
+    if (topAssetsStatus) {
+      const errors = Array.isArray(payload?.errors) && payload.errors.length
+        ? ` — ${payload.errors.length} fontes indisponíveis`
+        : '';
+      topAssetsStatus.textContent = assets.length
+        ? `Encontrados ${assets.length} ativos elegíveis${errors}`
+        : `Nenhum ativo retornado${errors}`;
+      topAssetsStatus.classList.remove('error');
+    }
+  } catch (err) {
+    if (topAssetsStatus) {
+      topAssetsStatus.textContent = err.message || 'Erro ao buscar ativos';
+      topAssetsStatus.classList.add('error');
+    }
+    if (topAssetsResults) topAssetsResults.classList.add('hidden');
+  }
+}
+
+function getSelectedDiscoveredAssets() {
+  return Array.from(document.querySelectorAll('.top-asset-option'))
+    .filter((el) => el.checked)
+    .map((el) => ({ symbol: el.value, label: el.dataset.label || el.value }));
 }
 
 if (adminAddCoinForm) {
@@ -4930,6 +5016,47 @@ if (blacklistList) {
     blacklist.delete(symbol);
     renderBlacklist();
     renderMonitoringTable();
+  });
+}
+
+if (discoverTopAssetsBtn) {
+  discoverTopAssetsBtn.addEventListener('click', discoverTopAssets);
+}
+
+if (addSelectedTopAssetsBtn) {
+  addSelectedTopAssetsBtn.addEventListener('click', () => {
+    if (!requireAdmin()) return;
+    const selected = getSelectedDiscoveredAssets();
+    if (!selected.length) {
+      if (topAssetsStatus) {
+        topAssetsStatus.textContent = 'Selecione ao menos um ativo da lista retornada.';
+        topAssetsStatus.classList.add('error');
+      }
+      return;
+    }
+    const added = [];
+    selected.forEach(({ symbol, label }) => {
+      const normalized = normalizeMonitoringSymbolInput(symbol);
+      if (!normalized) return;
+      if (!monitoringMeta.has(normalized)) {
+        monitoringMeta.set(normalized, { name: label || normalized, risk: 'Médio' });
+      }
+      if (!trackedMonitoringSymbols.includes(normalized)) {
+        trackedMonitoringSymbols.push(normalized);
+        added.push(normalized);
+      }
+      blacklist.delete(normalized);
+    });
+    updateMonitoringSelectors();
+    renderBlacklist();
+    renderMonitoringTable();
+    if (added.length) {
+      loadMonitoringData({ focusSymbol: added[0], silent: true });
+      if (topAssetsStatus) {
+        topAssetsStatus.textContent = `Adicionados ${added.length} ativo(s) ao monitoramento.`;
+        topAssetsStatus.classList.remove('error');
+      }
+    }
   });
 }
 

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -4181,6 +4181,25 @@ const MONITORING_HISTORY_CACHE_TTL = 60 * 1000;
 let monitoringLoading = true;
 let monitoringLastFetchError = null;
 
+const MONITORING_VISIBILITY_STORAGE_KEY = 'monitoringChartVisibility';
+function loadMonitoringVisibility() {
+  try {
+    const raw = localStorage.getItem(MONITORING_VISIBILITY_STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object') return parsed;
+  } catch {}
+  return {};
+}
+
+function persistMonitoringVisibility(map) {
+  try {
+    localStorage.setItem(MONITORING_VISIBILITY_STORAGE_KEY, JSON.stringify(map || {}));
+  } catch {}
+}
+
+let monitoringDatasetVisibility = loadMonitoringVisibility();
+
 const blacklist = new Set();
 const ADMIN_PASSWORD = 'arbisync@2024';
 let isAdmin = false;
@@ -4782,6 +4801,29 @@ function updateMonitoringSelectors() {
 }
 
 let monitoringChart = null;
+function syncMonitoringChartVisibilityFromChart(chart) {
+  if (!chart || !chart.data?.datasets) return;
+  const next = { ...monitoringDatasetVisibility };
+  chart.data.datasets.forEach((dataset, idx) => {
+    const meta = chart.getDatasetMeta(idx);
+    next[dataset.label] = meta?.hidden !== true;
+  });
+  monitoringDatasetVisibility = next;
+  persistMonitoringVisibility(next);
+}
+
+function applyMonitoringChartVisibility(chart) {
+  if (!chart || !chart.data?.datasets) return;
+  chart.data.datasets.forEach((dataset, idx) => {
+    const visible = monitoringDatasetVisibility[dataset.label];
+    if (typeof visible === 'boolean') {
+      dataset.hidden = !visible;
+      const meta = chart.getDatasetMeta(idx);
+      if (meta) meta.hidden = visible ? null : true;
+    }
+  });
+}
+
 function ensureMonitoringChart() {
   if (monitoringChart) return monitoringChart;
   const ctx = document.getElementById('monitoringChart');
@@ -4793,6 +4835,17 @@ function ensureMonitoringChart() {
       responsive: true,
       maintainAspectRatio: false,
       interaction: { intersect: false, mode: 'index' },
+      plugins: {
+        legend: {
+          onClick(event, legendItem, legend) {
+            const defaultHandler = (Chart.overrides?.line?.plugins?.legend?.onClick) || (Chart.defaults?.plugins?.legend?.onClick);
+            if (typeof defaultHandler === 'function') {
+              defaultHandler.call(this, event, legendItem, legend);
+            }
+            syncMonitoringChartVisibilityFromChart(legend?.chart);
+          }
+        }
+      },
       scales: {
         y: { ticks: { callback: (value) => `${value}%` } },
         yVolume: { position: 'right', grid: { drawOnChartArea: false }, ticks: { callback: (value) => `${formatVolume(value)} USDT` } }
@@ -4805,13 +4858,7 @@ function ensureMonitoringChart() {
 async function updateMonitoringChart(symbolInput) {
   const chart = ensureMonitoringChart();
   if (!chart) return;
-  const previousVisibility = new Map();
-  if (chart.data?.datasets?.length) {
-    chart.data.datasets.forEach((ds, idx) => {
-      const meta = chart.getDatasetMeta(idx);
-      previousVisibility.set(ds.label, meta?.hidden === true);
-    });
-  }
+  syncMonitoringChartVisibilityFromChart(chart);
   const fallbackSymbol = monitoringPairSelect?.value || monitoringRows[0]?.symbol || trackedMonitoringSymbols[0];
   const symbol = String(symbolInput || fallbackSymbol || '').toUpperCase();
   if (!symbol) return;
@@ -4887,12 +4934,9 @@ async function updateMonitoringChart(symbolInput) {
       yAxisID: 'yVolume'
     }
   ];
-  chart.data.datasets.forEach((dataset) => {
-    if (previousVisibility.has(dataset.label)) {
-      dataset.hidden = previousVisibility.get(dataset.label);
-    }
-  });
+  applyMonitoringChartVisibility(chart);
   chart.update();
+  syncMonitoringChartVisibilityFromChart(chart);
   updateMonitoringHistorySource(entry);
   if (!points.length) {
     const warning = entry.errors?.spot || entry.errors?.futures;

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -4670,7 +4670,9 @@ async function loadMonitoringData({ focusSymbol = null, silent = false, updateCh
             : null;
           if (!Number.isFinite(arbRaw)) continue;
           const arb = Number(arbRaw.toFixed(3));
-          const volumeCandidates = [toFiniteNumber(spot.volume), toFiniteNumber(futures.volume)].filter((v) => Number.isFinite(v));
+          const spotVolume = toFiniteNumber(spot.volume);
+          const futuresVolume = toFiniteNumber(futures.volume);
+          const volumeCandidates = [spotVolume, futuresVolume].filter((v) => Number.isFinite(v));
           const volume24h = volumeCandidates.length ? Math.min(...volumeCandidates) : 0;
           combos.push({
             symbol,
@@ -4679,6 +4681,8 @@ async function loadMonitoringData({ focusSymbol = null, silent = false, updateCh
             spotExchanges: [spot.exchange || spot.key || 'SPOT'],
             futuresExchanges: [futures.exchange || futures.key || 'FUTUROS'],
             volume24h,
+            spotVolume,
+            futuresVolume,
             spotAsk: toFiniteNumber(spot.ask),
             spotBid: toFiniteNumber(spot.bid),
             spotAskNotional: toFiniteNumber(spot.askNotional ?? computeNotionalLocal(spot.ask, spot.askSize)),
@@ -4773,11 +4777,11 @@ function updateArbUptime(key, arb) {
   return entry.start ? formatUptime(now - entry.start) : '—';
 }
 
-function renderLegDetails(label, price, notional, side) {
+function renderLegDetails(price, notional, side) {
   const volLabel = Number.isFinite(notional) ? `${formatVolume(notional)} USDT` : 's/ dado';
   const sideLabel = side === 'bid' ? 'Bid' : 'Ask';
   const chipClass = side === 'bid' ? 'bid' : 'ask';
-  return `<div class="quote-chip ${chipClass}"><span>${label}</span><strong>${sideLabel} ${formatPriceCompact(price)}</strong><em>Vol: ${volLabel}</em></div>`;
+  return `<div class="quote-chip ${chipClass}"><strong>${sideLabel} ${formatPriceCompact(price)}</strong><em>Vol: ${volLabel}</em></div>`;
 }
 
 function renderMonitoringTable() {
@@ -4842,7 +4846,8 @@ function renderMonitoringTable() {
     const favKey = buildOpportunityKey(coin);
     const isFavorite = monitoringFavorites.has(favKey);
     const arbLabel = Number.isFinite(coin.arb) ? `${coin.arb.toFixed(3)}%` : '—';
-    const uptime = updateArbUptime(favKey, coin.arb);
+    const uptimeValue = updateArbUptime(favKey, coin.arb);
+    const uptime = Number.isFinite(coin.arb) && coin.arb > 0 ? uptimeValue : '';
     const spotList = coin.spotExchanges.length
       ? coin.spotExchanges.join(', ')
       : metaInfo?.spotHint?.length
@@ -4853,15 +4858,22 @@ function renderMonitoringTable() {
       : metaInfo?.futuresHint?.length
         ? `${metaInfo.futuresHint.join(', ')} (config)`
         : 'Sem dados';
-    const spotDetail = renderLegDetails(coin.spotExchanges[0] || 'SPOT', coin.spotAsk, coin.spotAskNotional, 'ask');
-    const futuresDetail = renderLegDetails(coin.futuresExchanges[0] || 'FUTUROS', coin.futuresBid, coin.futuresBidNotional, 'bid');
+    const spotDetail = renderLegDetails(coin.spotAsk, coin.spotAskNotional, 'ask');
+    const futuresDetail = renderLegDetails(coin.futuresBid, coin.futuresBidNotional, 'bid');
+    const spotVolumeLabel = Number.isFinite(coin.spotVolume) ? `${formatVolume(coin.spotVolume)} USDT` : 's/ dado';
+    const futuresVolumeLabel = Number.isFinite(coin.futuresVolume) ? `${formatVolume(coin.futuresVolume)} USDT` : 's/ dado';
     return `
       <tr>
         <td><strong>${coin.symbol}</strong><br/><span class="muted">${coin.name}</span></td>
-        <td>${arbLabel}<div class="uptime-chip">${uptime}</div></td>
-        <td><div class="exchange-header">${spotList}</div>${spotDetail}</td>
-        <td><div class="exchange-header">${futuresList}</div>${futuresDetail}</td>
-        <td>${formatVolume(coin.volume24h)} USDT</td>
+        <td>${arbLabel}${uptime ? `<div class="uptime-chip">${uptime}</div>` : ''}</td>
+        <td><div class="exchange-header">${spotList}</div><div class="quote-chip-container">${spotDetail}</div></td>
+        <td><div class="exchange-header">${futuresList}</div><div class="quote-chip-container">${futuresDetail}</div></td>
+        <td>
+          <div class="volume-badges compact">
+            <span class="volume-badge"><strong>${coin.spotExchanges[0] || 'SPOT'}</strong><span class="asset-volume">${spotVolumeLabel}</span></span>
+            <span class="volume-badge"><strong>${coin.futuresExchanges[0] || 'FUTUROS'}</strong><span class="asset-volume">${futuresVolumeLabel}</span></span>
+          </div>
+        </td>
         <td>${isFavorite ? '<span class="monitoring-favorite-flag">★ Favorito</span>' : '—'}</td>
         <td class="monitoring-actions-cell">
           <button

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -4209,9 +4209,7 @@ const filterSearchEl = document.getElementById('filterSearch');
 const filterMinArbEl = document.getElementById('filterMinArb');
 const filterMinArbValueEl = document.getElementById('filterMinArbValue');
 const filterVolumeEl = document.getElementById('filterVolume');
-const filterStabilityEl = document.getElementById('filterStability');
 const monitoringSummaryBestEl = document.getElementById('monitoringSummaryBest');
-const monitoringSummaryAvgEl = document.getElementById('monitoringSummaryAvg');
 const monitoringSummaryCountEl = document.getElementById('monitoringResultCount');
 const monitoringSummaryBlacklistEl = document.getElementById('monitoringSummaryBlacklist');
 const monitoringPairSelect = document.getElementById('monitoringPairSelect');
@@ -4572,7 +4570,7 @@ async function loadMonitoringData({ focusSymbol = null, silent = false, updateCh
     monitoringLoading = true;
     monitoringLastFetchError = null;
     if (!silent && monitoringTableBody) {
-      monitoringTableBody.innerHTML = '<tr><td colspan="10">Carregando dados de arbitragem em tempo real...</td></tr>';
+      monitoringTableBody.innerHTML = '<tr><td colspan="7">Carregando dados de arbitragem em tempo real...</td></tr>';
     }
     const params = new URLSearchParams();
     params.set('symbols', trackedMonitoringSymbols.join(','));
@@ -4632,7 +4630,7 @@ async function loadMonitoringData({ focusSymbol = null, silent = false, updateCh
     monitoringLastFetchError = err;
     console.error('[monitoring] erro ao carregar dados', err);
     if (monitoringTableBody) {
-      monitoringTableBody.innerHTML = `<tr><td colspan="10">Erro ao carregar dados de arbitragem: ${err.message || err}</td></tr>`;
+    monitoringTableBody.innerHTML = `<tr><td colspan="7">Erro ao carregar dados de arbitragem: ${err.message || err}</td></tr>`;
     }
     monitoringFilteredRows = [];
     updateMonitoringPaginationUI(0);
@@ -4656,11 +4654,6 @@ function renderMonitoringSummary(filtered) {
     const best = filtered.reduce((acc, coin) => (Number.isFinite(coin.arb) && coin.arb > (acc?.arb ?? -Infinity) ? coin : acc), null);
     monitoringSummaryBestEl.textContent = best ? `${best.symbol} • ${best.arb.toFixed(2)}%` : (monitoringLastFetchError ? 'Erro' : '-');
   }
-  if (monitoringSummaryAvgEl) {
-    const arbs = filtered.map((coin) => coin.arb).filter((value) => Number.isFinite(value));
-    const avg = arbs.length ? (arbs.reduce((acc, value) => acc + value, 0) / arbs.length).toFixed(2) : '0.00';
-    monitoringSummaryAvgEl.textContent = `${avg}%`;
-  }
 }
 
 function renderMonitoringTable() {
@@ -4671,55 +4664,60 @@ function renderMonitoringTable() {
   const minVolume = Number(filterVolumeEl?.value) || 0;
   const selectedSpot = getCheckedValues('.filter-spot');
   const selectedFutures = getCheckedValues('.filter-futures');
-  const selectedRisks = getCheckedValues('.filter-risk');
-  const stabilityFilter = filterStabilityEl?.value || 'flex';
-
-  const filtered = monitoringRows
+  const favoritesSet = new Set(Array.from(monitoringFavorites));
+  const baseRows = monitoringRows
     .filter((coin) => trackedMonitoringSymbols.includes(coin.symbol))
-    .filter((coin) => !blacklist.has(coin.symbol))
+    .filter((coin) => !blacklist.has(coin.symbol));
+
+  const favoriteRows = baseRows.filter((coin) => favoritesSet.has(buildOpportunityKey(coin)));
+
+  const filteredNonFavorites = baseRows
+    .filter((coin) => !favoritesSet.has(buildOpportunityKey(coin)))
     .filter((coin) => (searchTerm ? coin.symbol.includes(searchTerm) || coin.name?.toUpperCase().includes(searchTerm) : true))
-    .filter((coin) => {
-      if (!Number.isFinite(coin.arb)) return false;
-      return coin.arb >= minArb;
-    })
+    .filter((coin) => Number.isFinite(coin.arb) && coin.arb >= minArb)
     .filter((coin) => coin.volume24h >= minVolume)
     .filter((coin) => !selectedSpot.length || coin.spotExchanges.some((ex) => selectedSpot.includes(ex)))
-    .filter((coin) => !selectedFutures.length || coin.futuresExchanges.some((ex) => selectedFutures.includes(ex)))
-    .filter((coin) => !selectedRisks.length || selectedRisks.includes(coin.risk))
-    .filter((coin) => stabilityFilter === 'flex' || coin.stability === stabilityFilter);
+    .filter((coin) => !selectedFutures.length || coin.futuresExchanges.some((ex) => selectedFutures.includes(ex)));
 
-  filtered.sort((a, b) => {
-    const favA = monitoringFavorites.has(buildOpportunityKey(a));
-    const favB = monitoringFavorites.has(buildOpportunityKey(b));
+  const seen = new Set();
+  const merged = [...favoriteRows, ...filteredNonFavorites].filter((coin) => {
+    const key = buildOpportunityKey(coin);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+
+  merged.sort((a, b) => {
+    const favA = favoritesSet.has(buildOpportunityKey(a));
+    const favB = favoritesSet.has(buildOpportunityKey(b));
     if (favA !== favB) return favA ? -1 : 1;
     const aArb = Number.isFinite(a.arb) ? a.arb : -Infinity;
     const bArb = Number.isFinite(b.arb) ? b.arb : -Infinity;
     return bArb - aArb;
   });
 
-  monitoringFilteredRows = filtered;
-  updateMonitoringPaginationUI(filtered.length);
+  monitoringFilteredRows = merged;
+  updateMonitoringPaginationUI(merged.length);
 
-  if (!filtered.length) {
+  if (!merged.length) {
     const emptyMessage = monitoringLoading
       ? 'Atualizando dados de arbitragem...'
       : monitoringLastFetchError
         ? `Última tentativa falhou: ${monitoringLastFetchError.message || monitoringLastFetchError}`
         : 'Nenhuma moeda atende aos filtros ativos.';
-    monitoringTableBody.innerHTML = `<tr><td colspan="10">${emptyMessage}</td></tr>`;
-    renderMonitoringSummary(filtered);
+    monitoringTableBody.innerHTML = `<tr><td colspan="7">${emptyMessage}</td></tr>`;
+    renderMonitoringSummary(merged);
     return;
   }
 
   const startIndex = (monitoringPaginationState.page - 1) * monitoringPaginationState.perPage;
-  const visibleCoins = filtered.slice(startIndex, startIndex + monitoringPaginationState.perPage);
+  const visibleCoins = merged.slice(startIndex, startIndex + monitoringPaginationState.perPage);
 
   monitoringTableBody.innerHTML = visibleCoins.map((coin) => {
     const metaInfo = monitoringMeta.get(coin.symbol);
     const favKey = buildOpportunityKey(coin);
     const isFavorite = monitoringFavorites.has(favKey);
     const arbLabel = Number.isFinite(coin.arb) ? `${coin.arb.toFixed(2)}%` : '—';
-    const fundingLabel = Number.isFinite(coin.funding) ? `${(coin.funding * 100).toFixed(3)}%` : '—';
     const spotList = coin.spotExchanges.length
       ? coin.spotExchanges.join(', ')
       : metaInfo?.spotHint?.length
@@ -4737,9 +4735,6 @@ function renderMonitoringTable() {
         <td>${spotList}</td>
         <td>${futuresList}</td>
         <td>${formatVolume(coin.volume24h)} USDT</td>
-        <td>${coin.depth}</td>
-        <td>${fundingLabel}</td>
-        <td>${coin.risk}</td>
         <td>${isFavorite ? '<span class="monitoring-favorite-flag">★ Favorito</span>' : '—'}</td>
         <td class="monitoring-actions-cell">
           <button type="button" class="monitoring-view-chart" data-symbol="${coin.symbol}">Ver gráfico</button>
@@ -4758,16 +4753,16 @@ function renderMonitoringTable() {
             data-symbol="${coin.symbol}"
             data-spot="${coin.spotExchanges.join('|')}"
             data-futures="${coin.futuresExchanges.join('|')}"
-          >Favoritar + Executar</button>
+          >Executar</button>
         </td>
       </tr>`;
   }).join('');
 
-  renderMonitoringSummary(filtered);
+  renderMonitoringSummary(merged);
 
-  if (filtered.length && monitoringPairSelect && !monitoringPairSelect.value) {
-    monitoringPairSelect.value = filtered[0].symbol;
-    updateMonitoringChart(filtered[0].symbol);
+  if (merged.length && monitoringPairSelect && !monitoringPairSelect.value) {
+    monitoringPairSelect.value = merged[0].symbol;
+    updateMonitoringChart(merged[0].symbol);
   }
 }
 
@@ -4794,9 +4789,13 @@ function updateMonitoringSelectors() {
     }
   }
   if (adminRemoveCoinSelect) {
+    const previousRemoval = adminRemoveCoinSelect.value;
     adminRemoveCoinSelect.innerHTML = trackedMonitoringSymbols
       .map((symbol) => `<option value="${symbol}">${symbol}</option>`)
       .join('');
+    if (previousRemoval && trackedMonitoringSymbols.includes(previousRemoval)) {
+      adminRemoveCoinSelect.value = previousRemoval;
+    }
   }
 }
 
@@ -4958,7 +4957,7 @@ async function updateMonitoringChart(symbolInput) {
   }
 }
 
-const filterInputs = [filterSearchEl, filterVolumeEl, filterStabilityEl];
+const filterInputs = [filterSearchEl, filterVolumeEl];
 filterInputs.forEach((input) => {
   if (!input) return;
   const eventName = input.tagName === 'SELECT' ? 'change' : 'input';
@@ -4979,7 +4978,7 @@ if (filterMinArbEl) {
   });
 }
 
-['.filter-spot', '.filter-futures', '.filter-risk'].forEach((selector) => {
+['.filter-spot', '.filter-futures'].forEach((selector) => {
   document.querySelectorAll(selector).forEach((input) => {
     input.addEventListener('change', () => {
       resetMonitoringPagination();
@@ -5297,31 +5296,24 @@ if (adminAddCoinForm) {
     event.preventDefault();
     if (!requireAdmin()) return;
     const symbolInput = document.getElementById('adminCoinSymbol');
-    const nameInput = document.getElementById('adminCoinName');
-    const riskInput = document.getElementById('adminCoinRisk');
     const spotInput = document.getElementById('adminCoinSpot');
     const futuresInput = document.getElementById('adminCoinFutures');
-    if (!symbolInput || !nameInput) return;
+    if (!symbolInput) return;
     const symbol = normalizeMonitoringSymbolInput(symbolInput.value);
-    const name = nameInput.value.trim() || symbol;
+    const name = symbol;
     if (!symbol) return;
-    const risk = riskInput?.value || 'Médio';
-    const spotHint = (spotInput?.value || '')
-      .split(',')
-      .map((entry) => entry.trim())
-      .filter(Boolean);
-    const futuresHint = (futuresInput?.value || '')
-      .split(',')
-      .map((entry) => entry.trim())
-      .filter(Boolean);
+    const spotHint = Array.from(spotInput?.selectedOptions || []).map((opt) => opt.value).filter(Boolean);
+    const futuresHint = Array.from(futuresInput?.selectedOptions || []).map((opt) => opt.value).filter(Boolean);
     try {
-      await persistMonitoringSymbol(symbol, { name, risk, spotHint, futuresHint });
+      await persistMonitoringSymbol(symbol, { name, risk: 'Médio', spotHint, futuresHint });
       blacklist.delete(symbol);
       symbolInput.value = '';
-      nameInput.value = '';
-      if (riskInput) riskInput.value = 'Médio';
-      if (spotInput) spotInput.value = '';
-      if (futuresInput) futuresInput.value = '';
+      if (spotInput) {
+        Array.from(spotInput.options).forEach((opt) => { opt.selected = opt.value === 'Gate.io'; });
+      }
+      if (futuresInput) {
+        Array.from(futuresInput.options).forEach((opt) => { opt.selected = opt.value === 'Gate.io Futures'; });
+      }
       loadMonitoringData({ focusSymbol: symbol, silent: true });
       renderBlacklist();
     } catch (e) {

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -4301,13 +4301,28 @@ async function fetchMonitoringHistorySeries(symbol, intervalKey, spotKey, future
       const ts = toFiniteNumber(point.timestamp);
       const close = toFiniteNumber(point.closeArbPct ?? point.arbPct ?? point.closeArb);
       const open = toFiniteNumber(point.openArbPct ?? point.arbPct ?? point.openArb);
-      if (!Number.isFinite(ts) || (!Number.isFinite(close) && !Number.isFinite(open))) return null;
+      const mid = toFiniteNumber(point.midArbPct ?? point.midArb ?? point.arbPct);
+      if (!Number.isFinite(ts) || (!Number.isFinite(close) && !Number.isFinite(open) && !Number.isFinite(mid))) {
+        return null;
+      }
+      let avg = mid;
+      if (!Number.isFinite(avg)) {
+        if (Number.isFinite(open) && Number.isFinite(close)) {
+          avg = Number(((open + close) / 2).toFixed(4));
+        } else if (Number.isFinite(open)) {
+          avg = open;
+        } else if (Number.isFinite(close)) {
+          avg = close;
+        } else {
+          avg = 0;
+        }
+      }
       return {
         timestamp: ts,
         label: formatHistoryLabel(ts),
-        arb: Number.isFinite(close) ? close : open || 0,
-        open: Number.isFinite(open) ? open : close || 0,
-        close: Number.isFinite(close) ? close : open || 0,
+        arb: avg,
+        open: Number.isFinite(open) ? open : Number.isFinite(close) ? close : avg,
+        close: Number.isFinite(close) ? close : Number.isFinite(open) ? open : avg,
         spotVol: toFiniteNumber(point.spotVolume) ?? 0,
         futuresVol: toFiniteNumber(point.futuresVolume) ?? 0
       };

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -87,6 +87,7 @@ const DEFAULT_ALERT_CONFIG = {
   max: null,
   soundEnabled: false,
   telegramEnabled: false,
+  telegramMinUsdt: null,
   telegramVolumeGuard: false,
   telegramIncludeSymbol: true,
   telegramIncludeDiff: true,
@@ -155,6 +156,10 @@ function createDefaultAlertConfig(overrides) {
   if (has(overrides, 'max')) {
     const num = Number(overrides.max);
     config.max = Number.isFinite(num) ? num : null;
+  }
+  if (has(overrides, 'telegramMinUsdt')) {
+    const num = Number(overrides.telegramMinUsdt);
+    config.telegramMinUsdt = Number.isFinite(num) && num >= 0 ? num : null;
   }
   if (has(overrides, 'soundEnabled')) config.soundEnabled = !!overrides.soundEnabled;
   if (has(overrides, 'telegramEnabled')) config.telegramEnabled = !!overrides.telegramEnabled;
@@ -256,6 +261,7 @@ function getAlertElements() {
     max: document.getElementById('alertMax'),
     sound: document.getElementById('soundToggle'),
     telegram: document.getElementById('telegramToggle'),
+    telegramMinVolume: document.getElementById('telegramMinVolume'),
     volumeGuard: document.getElementById('telegramVolumeGuard'),
     includeSymbol: document.getElementById('telegramIncludeSymbol'),
     includeDiff: document.getElementById('telegramIncludeDiff'),
@@ -265,7 +271,7 @@ function getAlertElements() {
 
 function applyAlertConfigToUI(config) {
   const cfg = createDefaultAlertConfig(config);
-  const { min, max, sound, telegram, volumeGuard, includeSymbol, includeDiff, includeVolumes } = getAlertElements();
+  const { min, max, sound, telegram, telegramMinVolume, volumeGuard, includeSymbol, includeDiff, includeVolumes } = getAlertElements();
   if (min) {
     if (Number.isFinite(cfg.min)) {
       min.value = cfg.min;
@@ -280,6 +286,13 @@ function applyAlertConfigToUI(config) {
       max.value = '';
     }
   }
+  if (telegramMinVolume) {
+    if (Number.isFinite(cfg.telegramMinUsdt)) {
+      telegramMinVolume.value = cfg.telegramMinUsdt;
+    } else {
+      telegramMinVolume.value = '';
+    }
+  }
   if (sound) sound.checked = !!cfg.soundEnabled;
   if (telegram) telegram.checked = !!cfg.telegramEnabled;
   if (volumeGuard) volumeGuard.checked = !!cfg.telegramVolumeGuard;
@@ -292,7 +305,7 @@ function captureAlertControlsToState(inst) {
   if (!inst) return;
   const state = ensureInstanceState(inst);
   const cfg = createDefaultAlertConfig(state.alertConfig);
-  const { min, max, sound, telegram, volumeGuard, includeSymbol, includeDiff, includeVolumes } = getAlertElements();
+  const { min, max, sound, telegram, telegramMinVolume, volumeGuard, includeSymbol, includeDiff, includeVolumes } = getAlertElements();
   if (min) {
     const num = Number(min.value);
     cfg.min = Number.isFinite(num) ? num : null;
@@ -300,6 +313,10 @@ function captureAlertControlsToState(inst) {
   if (max) {
     const num = Number(max.value);
     cfg.max = Number.isFinite(num) ? num : null;
+  }
+  if (telegramMinVolume) {
+    const num = Number(telegramMinVolume.value);
+    cfg.telegramMinUsdt = Number.isFinite(num) && num >= 0 ? num : null;
   }
   if (sound) cfg.soundEnabled = sound.checked;
   if (telegram) cfg.telegramEnabled = telegram.checked;
@@ -1799,6 +1816,14 @@ async function notifyTelegram(diff, { quotesData = lastQuotes, meta = currentMet
     }
   }
 
+  if (Number.isFinite(cfg.telegramMinUsdt) && cfg.telegramMinUsdt > 0) {
+    const effectiveQuote = Math.min(
+      Number.isFinite(stats.gateQuote) ? stats.gateQuote : 0,
+      Number.isFinite(stats.mexcQuote) ? stats.mexcQuote : 0
+    );
+    if (!Number.isFinite(effectiveQuote) || effectiveQuote < cfg.telegramMinUsdt) return;
+  }
+
   run.lastTgSent = now;
   const sanitizeLevel = (entry) => {
     const level = Number(entry?.level);
@@ -1879,7 +1904,7 @@ function handleAlertsForInstance(inst, state, quotesData) {
   }
 }
 
-const { min: alertMinInput, max: alertMaxInput, sound: soundToggleEl, telegram: telegramToggleEl, volumeGuard: telegramVolumeGuardEl, includeSymbol: telegramIncludeSymbolEl, includeDiff: telegramIncludeDiffEl, includeVolumes: telegramIncludeVolumesEl } = getAlertElements();
+const { min: alertMinInput, max: alertMaxInput, sound: soundToggleEl, telegram: telegramToggleEl, telegramMinVolume: telegramMinVolumeEl, volumeGuard: telegramVolumeGuardEl, includeSymbol: telegramIncludeSymbolEl, includeDiff: telegramIncludeDiffEl, includeVolumes: telegramIncludeVolumesEl } = getAlertElements();
 
 alertMinInput?.addEventListener('change', (e) => {
   const num = Number(e.target.value);
@@ -1915,6 +1940,14 @@ telegramToggleEl?.addEventListener('change', (e) => {
     if (!checked && state?.alertRuntime) {
       state.alertRuntime.lastTgSent = 0;
     }
+  });
+  refreshAlertUIFromActiveInstance();
+});
+
+telegramMinVolumeEl?.addEventListener('change', (e) => {
+  const num = Number(e.target.value);
+  mutateActiveAlertConfig((cfg) => {
+    cfg.telegramMinUsdt = Number.isFinite(num) && num >= 0 ? num : null;
   });
   refreshAlertUIFromActiveInstance();
 });

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -4202,6 +4202,7 @@ const monitoringHistoryFuturesSelect = document.getElementById('monitoringHistor
 const monitoringHistorySourceEl = document.getElementById('monitoringHistorySource');
 const monitoringHistoryStatusEl = document.getElementById('monitoringHistoryStatus');
 const monitoringRefreshIntervalSelect = document.getElementById('monitoringRefreshInterval');
+const monitoringRefreshToggleBtn = document.getElementById('monitoringRefreshToggle');
 const monitoringPaginationInfo = document.getElementById('monitoringPaginationInfo');
 const monitoringPaginationStatus = document.getElementById('monitoringPaginationStatus');
 const monitoringPaginationPrev = document.getElementById('monitoringPaginationPrev');
@@ -4234,9 +4235,12 @@ const monitoringPaginationState = { page: 1, perPage: MONITORING_PAGE_SIZE };
 let monitoringFilteredRows = [];
 const MONITORING_REFRESH_DEFAULT_SECONDS = 3;
 let monitoringAutoRefreshTimer = null;
+let monitoringAutoRefreshPaused = false;
 const TOP_ASSETS_PAGE_SIZE = 8;
 const topAssetsState = { items: [], page: 1, perPage: TOP_ASSETS_PAGE_SIZE };
 const topAssetsSelection = new Set();
+const monitoringFavorites = new Set();
+let executionToastTimer = null;
 
 function getCheckedValues(selector) {
   return Array.from(document.querySelectorAll(selector))
@@ -4254,6 +4258,100 @@ function getMonitoringName(symbol, fallbackLabel = null) {
   const normalized = symbol.toUpperCase();
   const meta = monitoringMeta.get(normalized);
   return meta?.name || fallbackLabel || normalized;
+}
+
+function buildOpportunityKey(coin) {
+  if (!coin) return '';
+  const spot = Array.isArray(coin.spotExchanges) ? coin.spotExchanges.join('+') : String(coin.spotExchanges || 'SPOT');
+  const futures = Array.isArray(coin.futuresExchanges)
+    ? coin.futuresExchanges.join('+')
+    : String(coin.futuresExchanges || 'FUT');
+  return `${coin.symbol || ''}::${spot}::${futures}`.toUpperCase();
+}
+
+function loadMonitoringFavorites() {
+  try {
+    const raw = localStorage.getItem('monitoring_favorites');
+    if (!raw) return;
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      monitoringFavorites.clear();
+      parsed.forEach((item) => {
+        if (typeof item === 'string') monitoringFavorites.add(item);
+      });
+    }
+  } catch (e) {
+    console.warn('Falha ao ler favoritos de monitoring:', e);
+  }
+}
+
+function persistMonitoringFavorites() {
+  try {
+    localStorage.setItem('monitoring_favorites', JSON.stringify(Array.from(monitoringFavorites)));
+  } catch (e) {
+    console.warn('Falha ao salvar favoritos de monitoring:', e);
+  }
+}
+
+loadMonitoringFavorites();
+
+function findOpportunityByKey(key) {
+  if (!key) return null;
+  const normalized = String(key).toUpperCase();
+  return monitoringRows.find((coin) => buildOpportunityKey(coin) === normalized) || null;
+}
+
+function setFavorite(key, enabled) {
+  if (!key) return;
+  const normalized = String(key).toUpperCase();
+  if (enabled) {
+    monitoringFavorites.add(normalized);
+  } else {
+    monitoringFavorites.delete(normalized);
+  }
+  persistMonitoringFavorites();
+}
+
+function toggleFavorite(key) {
+  if (!key) return;
+  const normalized = String(key).toUpperCase();
+  const nowFav = !monitoringFavorites.has(normalized);
+  setFavorite(normalized, nowFav);
+  renderMonitoringTable();
+  return nowFav;
+}
+
+function resolveSpotKeyFromLabel(labelList) {
+  const normalized = String(labelList || '').toLowerCase();
+  const entries = normalized.split('|');
+  for (const entry of entries) {
+    if (entry.includes('bitget')) return 'bitget';
+    if (entry.includes('gate')) return 'gate';
+    if (entry.includes('bybit')) return 'bitget';
+  }
+  return 'gate';
+}
+
+function showExecutionToast(message) {
+  const toast = document.getElementById('executionToast');
+  if (!toast) return;
+  toast.textContent = message;
+  toast.classList.add('visible');
+  if (executionToastTimer) clearTimeout(executionToastTimer);
+  executionToastTimer = setTimeout(() => {
+    toast.classList.remove('visible');
+  }, 2800);
+}
+
+function addExecutionTabFromOpportunity(coin, spotLabel) {
+  if (!coin) return null;
+  const spotKey = resolveSpotKeyFromLabel(spotLabel || coin.spotExchanges?.join('|'));
+  const inst = addInstance({ symbol: coin.symbol, spotExchange: spotKey, label: `${coin.symbol} (${spotKey})` }, { switchTo: true });
+  if (inst) {
+    activateView('executionView');
+    showExecutionToast(`${coin.symbol} adicionado ao menu de execução.`);
+  }
+  return inst;
 }
 
 function resetMonitoringPagination() {
@@ -4307,11 +4405,19 @@ function scheduleMonitoringAutoRefresh() {
     clearInterval(monitoringAutoRefreshTimer);
     monitoringAutoRefreshTimer = null;
   }
+  if (monitoringAutoRefreshPaused) return;
   const intervalMs = getMonitoringRefreshSeconds() * 1000;
   monitoringAutoRefreshTimer = setInterval(() => {
     if (document.hidden) return;
     loadMonitoringData({ silent: true, updateChart: false });
   }, intervalMs);
+}
+
+function updateMonitoringRefreshToggleUI() {
+  if (!monitoringRefreshToggleBtn) return;
+  monitoringRefreshToggleBtn.textContent = monitoringAutoRefreshPaused ? '▶ Retomar' : '⏸ Pausar';
+  monitoringRefreshToggleBtn.classList.toggle('paused', monitoringAutoRefreshPaused);
+  monitoringRefreshToggleBtn.setAttribute('aria-pressed', String(!monitoringAutoRefreshPaused));
 }
 
 function resetMonitoringHistory() {
@@ -4447,7 +4553,7 @@ async function loadMonitoringData({ focusSymbol = null, silent = false, updateCh
     monitoringLoading = true;
     monitoringLastFetchError = null;
     if (!silent && monitoringTableBody) {
-      monitoringTableBody.innerHTML = '<tr><td colspan="9">Carregando dados de arbitragem em tempo real...</td></tr>';
+      monitoringTableBody.innerHTML = '<tr><td colspan="10">Carregando dados de arbitragem em tempo real...</td></tr>';
     }
     const params = new URLSearchParams();
     params.set('symbols', trackedMonitoringSymbols.join(','));
@@ -4507,7 +4613,7 @@ async function loadMonitoringData({ focusSymbol = null, silent = false, updateCh
     monitoringLastFetchError = err;
     console.error('[monitoring] erro ao carregar dados', err);
     if (monitoringTableBody) {
-      monitoringTableBody.innerHTML = `<tr><td colspan="9">Erro ao carregar dados de arbitragem: ${err.message || err}</td></tr>`;
+      monitoringTableBody.innerHTML = `<tr><td colspan="10">Erro ao carregar dados de arbitragem: ${err.message || err}</td></tr>`;
     }
     monitoringFilteredRows = [];
     updateMonitoringPaginationUI(0);
@@ -4564,6 +4670,9 @@ function renderMonitoringTable() {
     .filter((coin) => stabilityFilter === 'flex' || coin.stability === stabilityFilter);
 
   filtered.sort((a, b) => {
+    const favA = monitoringFavorites.has(buildOpportunityKey(a));
+    const favB = monitoringFavorites.has(buildOpportunityKey(b));
+    if (favA !== favB) return favA ? -1 : 1;
     const aArb = Number.isFinite(a.arb) ? a.arb : -Infinity;
     const bArb = Number.isFinite(b.arb) ? b.arb : -Infinity;
     return bArb - aArb;
@@ -4578,7 +4687,7 @@ function renderMonitoringTable() {
       : monitoringLastFetchError
         ? `Última tentativa falhou: ${monitoringLastFetchError.message || monitoringLastFetchError}`
         : 'Nenhuma moeda atende aos filtros ativos.';
-    monitoringTableBody.innerHTML = `<tr><td colspan="9">${emptyMessage}</td></tr>`;
+    monitoringTableBody.innerHTML = `<tr><td colspan="10">${emptyMessage}</td></tr>`;
     renderMonitoringSummary(filtered);
     return;
   }
@@ -4588,6 +4697,8 @@ function renderMonitoringTable() {
 
   monitoringTableBody.innerHTML = visibleCoins.map((coin) => {
     const metaInfo = monitoringMeta.get(coin.symbol);
+    const favKey = buildOpportunityKey(coin);
+    const isFavorite = monitoringFavorites.has(favKey);
     const arbLabel = Number.isFinite(coin.arb) ? `${coin.arb.toFixed(2)}%` : '—';
     const fundingLabel = Number.isFinite(coin.funding) ? `${(coin.funding * 100).toFixed(3)}%` : '—';
     const spotList = coin.spotExchanges.length
@@ -4610,7 +4721,26 @@ function renderMonitoringTable() {
         <td>${coin.depth}</td>
         <td>${fundingLabel}</td>
         <td>${coin.risk}</td>
-        <td><button type="button" class="monitoring-view-chart" data-symbol="${coin.symbol}">Ver gráfico</button></td>
+        <td>${isFavorite ? '<span class="monitoring-favorite-flag">★ Favorito</span>' : '—'}</td>
+        <td class="monitoring-actions-cell">
+          <button type="button" class="monitoring-view-chart" data-symbol="${coin.symbol}">Ver gráfico</button>
+          <button
+            type="button"
+            class="monitoring-favorite-btn ${isFavorite ? 'favorited' : ''}"
+            data-favorite-key="${favKey}"
+            data-symbol="${coin.symbol}"
+            data-spot="${coin.spotExchanges.join('|')}"
+            data-futures="${coin.futuresExchanges.join('|')}"
+          >${isFavorite ? 'Desfavoritar' : 'Favoritar'}</button>
+          <button
+            type="button"
+            class="monitoring-exec-btn"
+            data-favorite-key="${favKey}"
+            data-symbol="${coin.symbol}"
+            data-spot="${coin.spotExchanges.join('|')}"
+            data-futures="${coin.futuresExchanges.join('|')}"
+          >Favoritar + Executar</button>
+        </td>
       </tr>`;
   }).join('');
 
@@ -4675,6 +4805,13 @@ function ensureMonitoringChart() {
 async function updateMonitoringChart(symbolInput) {
   const chart = ensureMonitoringChart();
   if (!chart) return;
+  const previousVisibility = new Map();
+  if (chart.data?.datasets?.length) {
+    chart.data.datasets.forEach((ds, idx) => {
+      const meta = chart.getDatasetMeta(idx);
+      previousVisibility.set(ds.label, meta?.hidden === true);
+    });
+  }
   const fallbackSymbol = monitoringPairSelect?.value || monitoringRows[0]?.symbol || trackedMonitoringSymbols[0];
   const symbol = String(symbolInput || fallbackSymbol || '').toUpperCase();
   if (!symbol) return;
@@ -4750,6 +4887,11 @@ async function updateMonitoringChart(symbolInput) {
       yAxisID: 'yVolume'
     }
   ];
+  chart.data.datasets.forEach((dataset) => {
+    if (previousVisibility.has(dataset.label)) {
+      dataset.hidden = previousVisibility.get(dataset.label);
+    }
+  });
   chart.update();
   updateMonitoringHistorySource(entry);
   if (!points.length) {
@@ -4812,13 +4954,34 @@ if (monitoringPaginationNext) {
 
 if (monitoringTableBody) {
   monitoringTableBody.addEventListener('click', (event) => {
-    const button = event.target.closest('.monitoring-view-chart');
-    if (!button) return;
-    const { symbol } = button.dataset;
-    if (!symbol) return;
-    if (monitoringPairSelect) monitoringPairSelect.value = symbol;
-    updateMonitoringChart(symbol);
-    activateView('monitoringView');
+    const chartBtn = event.target.closest('.monitoring-view-chart');
+    if (chartBtn) {
+      const { symbol } = chartBtn.dataset;
+      if (!symbol) return;
+      if (monitoringPairSelect) monitoringPairSelect.value = symbol;
+      updateMonitoringChart(symbol);
+      activateView('monitoringView');
+      return;
+    }
+
+    const favBtn = event.target.closest('.monitoring-favorite-btn');
+    if (favBtn) {
+      const key = favBtn.dataset.favoriteKey;
+      if (!key) return;
+      toggleFavorite(key);
+      return;
+    }
+
+    const execBtn = event.target.closest('.monitoring-exec-btn');
+    if (execBtn) {
+      const key = execBtn.dataset.favoriteKey;
+      const coin = findOpportunityByKey(key);
+      if (!coin) return;
+      setFavorite(key, true);
+      renderMonitoringTable();
+      addExecutionTabFromOpportunity(coin, execBtn.dataset.spot);
+      return;
+    }
   });
 }
 
@@ -4848,15 +5011,31 @@ if (refreshMonitoringChartBtn) {
   });
 }
 
+if (monitoringRefreshToggleBtn) {
+  monitoringRefreshToggleBtn.addEventListener('click', () => {
+    monitoringAutoRefreshPaused = !monitoringAutoRefreshPaused;
+    updateMonitoringRefreshToggleUI();
+    if (monitoringAutoRefreshPaused) {
+      scheduleMonitoringAutoRefresh();
+    } else {
+      loadMonitoringData({ silent: true, updateChart: false });
+      scheduleMonitoringAutoRefresh();
+    }
+  });
+  updateMonitoringRefreshToggleUI();
+}
+
 if (monitoringRefreshIntervalSelect) {
   monitoringRefreshIntervalSelect.addEventListener('change', () => {
     scheduleMonitoringAutoRefresh();
-    loadMonitoringData({ silent: true, updateChart: false });
+    if (!monitoringAutoRefreshPaused) {
+      loadMonitoringData({ silent: true, updateChart: false });
+    }
   });
 }
 
 document.addEventListener('visibilitychange', () => {
-  if (!document.hidden) {
+  if (!document.hidden && !monitoringAutoRefreshPaused) {
     loadMonitoringData({ silent: true, updateChart: false });
   }
 });

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -4808,15 +4808,20 @@ function updateArbUptime(key, arb) {
   return entry.start ? formatUptime(now - entry.start) : '—';
 }
 
-function renderLegDetails(price, notional, side, fallbackVolume, fallbackSize) {
+function renderLegDetails(price, notional, side, fallbackSize) {
+  const priceLabel = Number.isFinite(price) ? formatPriceCompact(price) : 's/ dado';
   const computedNotional = Number.isFinite(notional)
     ? notional
     : computeNotionalLocal(price, fallbackSize);
-  const fallback = Number.isFinite(fallbackVolume) ? fallbackVolume : null;
-  const volValue = Number.isFinite(computedNotional) && computedNotional > 0 ? computedNotional : fallback;
-  const volLabel = Number.isFinite(volValue) ? `${formatVolume(volValue)} USDT` : 's/ dado';
-  const chipClass = side === 'bid' ? 'bid' : 'ask';
-  return `<div class="quote-chip ${chipClass}"><strong>${formatPriceCompact(price)}</strong><em>Vol: ${volLabel}</em></div>`;
+  const volLabel = Number.isFinite(computedNotional) && computedNotional > 0
+    ? `${formatVolume(computedNotional)} USDT`
+    : 's/ dado';
+  const chipClass = side === 'bid' ? 'volume-chip volume-futures' : 'volume-chip volume-spot';
+  const sideLabel = side === 'bid' ? 'Bid' : 'Ask';
+  return `
+    <div class="quote-price">${sideLabel}: ${priceLabel}</div>
+    <div class="${chipClass}">${volLabel}</div>
+  `;
 }
 
 function applyMonitoringColumnVisibility() {
@@ -4903,8 +4908,8 @@ function renderMonitoringTable() {
       : metaInfo?.futuresHint?.length
         ? `${metaInfo.futuresHint.join(', ')} (config)`
         : 'Sem dados';
-    const spotDetail = renderLegDetails(coin.spotAsk, coin.spotAskNotional, 'ask', coin.spotVolume, coin.spotAskSize);
-    const futuresDetail = renderLegDetails(coin.futuresBid, coin.futuresBidNotional, 'bid', coin.futuresVolume, coin.futuresBidSize);
+    const spotDetail = renderLegDetails(coin.spotAsk, coin.spotAskNotional, 'ask', coin.spotAskSize);
+    const futuresDetail = renderLegDetails(coin.futuresBid, coin.futuresBidNotional, 'bid', coin.futuresBidSize);
     const spotVolumeLabel = Number.isFinite(coin.spotVolume) ? `${formatVolume(coin.spotVolume)} USDT` : 's/ dado';
     const futuresVolumeLabel = Number.isFinite(coin.futuresVolume) ? `${formatVolume(coin.futuresVolume)} USDT` : 's/ dado';
     const volume24hCell = `<div class="volume-inline"><span>${spotVolumeLabel}</span><span>|</span><span>${futuresVolumeLabel}</span></div>`;

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -4246,6 +4246,8 @@ const topAssetsPaginationInfo = document.getElementById('topAssetsPaginationInfo
 const topAssetsPaginationStatus = document.getElementById('topAssetsPaginationStatus');
 const topAssetsPrev = document.getElementById('topAssetsPrev');
 const topAssetsNext = document.getElementById('topAssetsNext');
+const topAssetsPageSizeSelect = document.getElementById('topAssetsPageSize');
+const topAssetsLimitSelect = document.getElementById('topAssetsLimit');
 
 const MONITORING_PAGE_SIZE = 10;
 const monitoringPaginationState = { page: 1, perPage: MONITORING_PAGE_SIZE };
@@ -4254,7 +4256,8 @@ const MONITORING_REFRESH_DEFAULT_SECONDS = 3;
 let monitoringAutoRefreshTimer = null;
 let monitoringAutoRefreshPaused = false;
 const TOP_ASSETS_PAGE_SIZE = 8;
-const topAssetsState = { items: [], page: 1, perPage: TOP_ASSETS_PAGE_SIZE };
+const TOP_ASSETS_LIMIT_DEFAULT = 60;
+const topAssetsState = { items: [], page: 1, perPage: TOP_ASSETS_PAGE_SIZE, limit: TOP_ASSETS_LIMIT_DEFAULT };
 const topAssetsSelection = new Set();
 const monitoringFavorites = new Set();
 let executionToastTimer = null;
@@ -4275,6 +4278,33 @@ function getMonitoringName(symbol, fallbackLabel = null) {
   const normalized = symbol.toUpperCase();
   const meta = monitoringMeta.get(normalized);
   return meta?.name || fallbackLabel || normalized;
+}
+
+const SPOT_LABEL_TO_KEY = {
+  'gate.io': 'gate_spot',
+  'gate.io spot': 'gate_spot',
+  'mexc': 'mexc_spot',
+  'bitget': 'bitget_spot',
+  'kucoin': 'kucoin_spot',
+  'binance': 'binance_spot',
+  'bybit': 'bybit_spot'
+};
+
+const FUTURES_LABEL_TO_KEY = {
+  'gate.io futures': 'gate_futures',
+  'mexc futures': 'mexc_futures',
+  'bitget futures': 'bitget_futures',
+  'kucoin futures': 'kucoin_futures',
+  'binance futures': 'binance_futures',
+  'bybit futures': 'bybit_futures'
+};
+
+function resolveHistoryExchangeKey(label, type) {
+  const normalized = String(label || '').trim().toLowerCase();
+  if (!normalized) return null;
+  if (type === 'spot') return SPOT_LABEL_TO_KEY[normalized] || null;
+  if (type === 'futures') return FUTURES_LABEL_TO_KEY[normalized] || null;
+  return null;
 }
 
 function buildOpportunityKey(coin) {
@@ -4846,7 +4876,15 @@ function ensureMonitoringChart() {
         }
       },
       scales: {
-        y: { ticks: { callback: (value) => `${value}%` } },
+        y: {
+          ticks: {
+            callback: (value) => {
+              const num = Number(value);
+              if (!Number.isFinite(num)) return `${value}%`;
+              return `${num.toFixed(3)}%`;
+            }
+          }
+        },
         yVolume: { position: 'right', grid: { drawOnChartArea: false }, ticks: { callback: (value) => `${formatVolume(value)} USDT` } }
       }
     }
@@ -4995,17 +5033,24 @@ if (monitoringPaginationNext) {
   monitoringPaginationNext.addEventListener('click', () => changeMonitoringPage(1));
 }
 
-if (monitoringTableBody) {
-  monitoringTableBody.addEventListener('click', (event) => {
-    const chartBtn = event.target.closest('.monitoring-view-chart');
-    if (chartBtn) {
-      const { symbol } = chartBtn.dataset;
-      if (!symbol) return;
-      if (monitoringPairSelect) monitoringPairSelect.value = symbol;
-      updateMonitoringChart(symbol);
-      activateView('monitoringView');
-      return;
-    }
+  if (monitoringTableBody) {
+    monitoringTableBody.addEventListener('click', (event) => {
+      const chartBtn = event.target.closest('.monitoring-view-chart');
+      if (chartBtn) {
+        const { symbol } = chartBtn.dataset;
+        if (!symbol) return;
+        const spotLabel = (chartBtn.dataset.spot || '').split('|')[0];
+        const futuresLabel = (chartBtn.dataset.futures || '').split('|')[0];
+        const spotKey = resolveHistoryExchangeKey(spotLabel, 'spot');
+        const futuresKey = resolveHistoryExchangeKey(futuresLabel, 'futures');
+        if (monitoringPairSelect) monitoringPairSelect.value = symbol;
+        if (monitoringHistorySpotSelect && spotKey) monitoringHistorySpotSelect.value = spotKey;
+        if (monitoringHistoryFuturesSelect && futuresKey) monitoringHistoryFuturesSelect.value = futuresKey;
+        if (monitoringHistoryIntervalSelect) monitoringHistoryIntervalSelect.value = '30m';
+        updateMonitoringChart(symbol);
+        activateView('monitoringView');
+        return;
+      }
 
     const favBtn = event.target.closest('.monitoring-favorite-btn');
     if (favBtn) {
@@ -5156,15 +5201,17 @@ function renderTopAssetsList() {
   const visible = assets.slice(startIndex, startIndex + topAssetsState.perPage);
   topAssetsList.innerHTML = visible
     .map((asset) => {
-      const bestVolume = Number.isFinite(asset.bestVolume) ? formatVolume(asset.bestVolume) : 'N/D';
-      const exchanges = Array.isArray(asset.exchanges) && asset.exchanges.length ? asset.exchanges.join(', ') : '—';
+      const bestVolume = Number.isFinite(asset.bestVolume) ? `${formatVolume(asset.bestVolume)} USDT` : 'N/D';
       const checked = topAssetsSelection.has(asset.symbol) ? 'checked' : '';
+      const volumes = Array.isArray(asset.volumes) ? asset.volumes : [];
+      const volumeBadges = volumes.length
+        ? volumes.map((item) => `<span class="volume-badge"><strong>${item.exchange}</strong><span class="asset-volume">${formatVolume(item.volume)} USDT</span></span>`).join('')
+        : '<span class="muted">Sem volumes reportados</span>';
       return `<label class="top-assets-row">
         <span><input type="checkbox" class="top-asset-option" value="${asset.symbol}" data-label="${asset.label || asset.symbol}" ${checked}></span>
         <span class="asset-name">${asset.label || asset.symbol}</span>
-        <span class="asset-symbol">${asset.symbol}</span>
+        <span><div class="volume-badges">${volumeBadges}</div></span>
         <span class="asset-volume">${bestVolume}</span>
-        <span class="asset-exchanges">${exchanges}</span>
       </label>`;
     })
     .join('');
@@ -5251,12 +5298,17 @@ async function removeMonitoringSymbol(symbol) {
 async function discoverTopAssets() {
   if (!requireAdmin()) return;
   const selected = getSelectedTopExchanges();
+  const limitSelected = Number(topAssetsLimitSelect?.value);
+  if (Number.isFinite(limitSelected) && limitSelected > 0) {
+    topAssetsState.limit = limitSelected;
+  }
   if (topAssetsStatus) {
     topAssetsStatus.textContent = 'Buscando ativos com maior volume...';
     topAssetsStatus.classList.remove('error');
   }
   const params = new URLSearchParams();
   if (selected.length) params.set('exchanges', selected.join(','));
+  if (topAssetsState.limit) params.set('limit', topAssetsState.limit);
   try {
     const response = await fetch(`/api/monitoring/top-assets?${params.toString()}`);
     if (!response.ok) throw new Error(`Falha ao buscar top 24h (${response.status})`);
@@ -5264,6 +5316,9 @@ async function discoverTopAssets() {
     const assets = Array.isArray(payload?.assets) ? payload.assets : [];
     topAssetsState.items = assets;
     topAssetsState.page = 1;
+    if (Number.isFinite(payload?.limit)) {
+      topAssetsState.limit = Number(payload.limit);
+    }
     topAssetsSelection.clear();
     renderTopAssetsList();
     if (topAssetsResults) topAssetsResults.classList.toggle('hidden', !assets.length);
@@ -5272,7 +5327,7 @@ async function discoverTopAssets() {
         ? ` — ${payload.errors.length} fontes indisponíveis`
         : '';
       topAssetsStatus.textContent = assets.length
-        ? `Encontrados ${assets.length} ativos elegíveis${errors}`
+        ? `Encontrados ${assets.length} ativos elegíveis (limite ${topAssetsState.limit})${errors}`
         : `Nenhum ativo retornado${errors}`;
       topAssetsStatus.classList.remove('error');
     }
@@ -5296,24 +5351,22 @@ if (adminAddCoinForm) {
     event.preventDefault();
     if (!requireAdmin()) return;
     const symbolInput = document.getElementById('adminCoinSymbol');
-    const spotInput = document.getElementById('adminCoinSpot');
-    const futuresInput = document.getElementById('adminCoinFutures');
     if (!symbolInput) return;
     const symbol = normalizeMonitoringSymbolInput(symbolInput.value);
     const name = symbol;
     if (!symbol) return;
-    const spotHint = Array.from(spotInput?.selectedOptions || []).map((opt) => opt.value).filter(Boolean);
-    const futuresHint = Array.from(futuresInput?.selectedOptions || []).map((opt) => opt.value).filter(Boolean);
+    const spotHint = getCheckedValues('.admin-spot-option');
+    const futuresHint = getCheckedValues('.admin-futures-option');
     try {
       await persistMonitoringSymbol(symbol, { name, risk: 'Médio', spotHint, futuresHint });
       blacklist.delete(symbol);
       symbolInput.value = '';
-      if (spotInput) {
-        Array.from(spotInput.options).forEach((opt) => { opt.selected = opt.value === 'Gate.io'; });
-      }
-      if (futuresInput) {
-        Array.from(futuresInput.options).forEach((opt) => { opt.selected = opt.value === 'Gate.io Futures'; });
-      }
+      document.querySelectorAll('.admin-spot-option').forEach((input) => {
+        input.checked = input.value === 'Gate.io';
+      });
+      document.querySelectorAll('.admin-futures-option').forEach((input) => {
+        input.checked = input.value === 'Gate.io Futures';
+      });
       loadMonitoringData({ focusSymbol: symbol, silent: true });
       renderBlacklist();
     } catch (e) {
@@ -5374,6 +5427,33 @@ if (blacklistList) {
 
 if (discoverTopAssetsBtn) {
   discoverTopAssetsBtn.addEventListener('click', discoverTopAssets);
+}
+
+if (topAssetsPageSizeSelect) {
+  const initial = Number(topAssetsPageSizeSelect.value);
+  if (Number.isFinite(initial) && initial > 0) {
+    topAssetsState.perPage = initial;
+  }
+  topAssetsPageSizeSelect.addEventListener('change', () => {
+    const next = Number(topAssetsPageSizeSelect.value);
+    if (!Number.isFinite(next) || next <= 0) return;
+    topAssetsState.perPage = next;
+    topAssetsState.page = 1;
+    renderTopAssetsList();
+  });
+}
+
+if (topAssetsLimitSelect) {
+  const initialLimit = Number(topAssetsLimitSelect.value);
+  if (Number.isFinite(initialLimit) && initialLimit > 0) {
+    topAssetsState.limit = initialLimit;
+  }
+  topAssetsLimitSelect.addEventListener('change', () => {
+    const nextLimit = Number(topAssetsLimitSelect.value);
+    if (Number.isFinite(nextLimit) && nextLimit > 0) {
+      topAssetsState.limit = nextLimit;
+    }
+  });
 }
 
 if (topAssetsPrev) {

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -4207,8 +4207,10 @@ const monitoringPaginationStatus = document.getElementById('monitoringPagination
 const monitoringPaginationPrev = document.getElementById('monitoringPaginationPrev');
 const monitoringPaginationNext = document.getElementById('monitoringPaginationNext');
 const adminStatusLabel = document.getElementById('adminStatusLabel');
+const adminStatusLabelInline = document.getElementById('adminStatusLabelInline');
 const adminLoginFeedback = document.getElementById('adminLoginFeedback');
 const adminTools = document.getElementById('adminTools');
+const adminDiscoveryTools = document.getElementById('adminDiscoveryTools');
 const adminLoginForm = document.getElementById('adminLoginForm');
 const adminPasswordInput = document.getElementById('adminPassword');
 const adminAddCoinForm = document.getElementById('adminAddCoinForm');
@@ -4869,13 +4871,17 @@ if (adminLoginForm) {
       adminLoginFeedback.classList.remove('muted');
       adminLoginFeedback.style.color = '#3fe7c3';
       adminStatusLabel.textContent = 'Conectado';
+      if (adminStatusLabelInline) adminStatusLabelInline.textContent = 'Conectado';
       if (adminTools) adminTools.classList.remove('hidden');
+      if (adminDiscoveryTools) adminDiscoveryTools.classList.remove('hidden');
     } else {
       isAdmin = false;
       adminLoginFeedback.textContent = 'Senha incorreta';
       adminLoginFeedback.classList.add('muted');
       adminStatusLabel.textContent = 'Visitante';
+      if (adminStatusLabelInline) adminStatusLabelInline.textContent = 'Visitante';
       if (adminTools) adminTools.classList.add('hidden');
+      if (adminDiscoveryTools) adminDiscoveryTools.classList.add('hidden');
     }
     if (adminPasswordInput) adminPasswordInput.value = '';
   });
@@ -4962,6 +4968,64 @@ function normalizeMonitoringSymbolInput(value) {
   return str;
 }
 
+function applyMonitoringSymbols(list) {
+  const entries = Array.isArray(list) ? list : [];
+  monitoringMeta.clear();
+  entries.forEach((item) => {
+    const normalized = normalizeMonitoringSymbolInput(item?.symbol);
+    if (!normalized) return;
+    monitoringMeta.set(normalized, item?.meta || {});
+  });
+  if (!monitoringMeta.size) {
+    monitoringMeta.set('CPOOL_USDT', { name: 'Clearpool', risk: 'Baixo' });
+    monitoringMeta.set('MAT_USDT', { name: 'Mycelium', risk: 'Médio' });
+    monitoringMeta.set('FARM_USDT', { name: 'Harvest Finance', risk: 'Baixo' });
+  }
+  trackedMonitoringSymbols = Array.from(monitoringMeta.keys());
+  updateMonitoringSelectors();
+  renderMonitoringTable();
+}
+
+async function hydrateMonitoringSymbolsFromServer() {
+  try {
+    const resp = await fetch('/api/monitoring/symbols');
+    const data = await safeJson(resp);
+    if (resp.ok && Array.isArray(data?.symbols)) {
+      applyMonitoringSymbols(data.symbols);
+      return;
+    }
+  } catch (e) {
+    console.warn('[monitoring] fallback para símbolos locais', e?.message || e);
+  }
+  applyMonitoringSymbols(Array.from(monitoringMeta.entries()).map(([symbol, meta]) => ({ symbol, meta })));
+}
+
+async function persistMonitoringSymbol(symbol, meta = {}) {
+  const response = await fetch('/api/monitoring/symbols', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ symbol, meta })
+  });
+  const data = await safeJson(response);
+  if (!response.ok) {
+    throw new Error(data?.error || 'Falha ao salvar ativo');
+  }
+  applyMonitoringSymbols(data?.symbols || []);
+  return data;
+}
+
+async function removeMonitoringSymbol(symbol) {
+  const response = await fetch(`/api/monitoring/symbols/${encodeURIComponent(symbol)}`, {
+    method: 'DELETE'
+  });
+  const data = await safeJson(response);
+  if (!response.ok) {
+    throw new Error(data?.error || 'Falha ao remover ativo');
+  }
+  applyMonitoringSymbols(data?.symbols || []);
+  return data;
+}
+
 async function discoverTopAssets() {
   if (!requireAdmin()) return;
   const selected = getSelectedTopExchanges();
@@ -5006,7 +5070,7 @@ function getSelectedDiscoveredAssets() {
 }
 
 if (adminAddCoinForm) {
-  adminAddCoinForm.addEventListener('submit', (event) => {
+  adminAddCoinForm.addEventListener('submit', async (event) => {
     event.preventDefault();
     if (!requireAdmin()) return;
     const symbolInput = document.getElementById('adminCoinSymbol');
@@ -5015,7 +5079,7 @@ if (adminAddCoinForm) {
     const spotInput = document.getElementById('adminCoinSpot');
     const futuresInput = document.getElementById('adminCoinFutures');
     if (!symbolInput || !nameInput) return;
-    const symbol = symbolInput.value.trim().toUpperCase();
+    const symbol = normalizeMonitoringSymbolInput(symbolInput.value);
     const name = nameInput.value.trim() || symbol;
     if (!symbol) return;
     const risk = riskInput?.value || 'Médio';
@@ -5027,36 +5091,44 @@ if (adminAddCoinForm) {
       .split(',')
       .map((entry) => entry.trim())
       .filter(Boolean);
-    monitoringMeta.set(symbol, { name, risk, spotHint, futuresHint });
-    if (!trackedMonitoringSymbols.includes(symbol)) {
-      trackedMonitoringSymbols.push(symbol);
+    try {
+      await persistMonitoringSymbol(symbol, { name, risk, spotHint, futuresHint });
+      blacklist.delete(symbol);
+      symbolInput.value = '';
+      nameInput.value = '';
+      if (riskInput) riskInput.value = 'Médio';
+      if (spotInput) spotInput.value = '';
+      if (futuresInput) futuresInput.value = '';
+      loadMonitoringData({ focusSymbol: symbol, silent: true });
+      renderBlacklist();
+    } catch (e) {
+      if (adminLoginFeedback) {
+        adminLoginFeedback.textContent = e.message || 'Falha ao salvar ativo';
+        adminLoginFeedback.style.color = '#ff6b9a';
+      }
     }
-    symbolInput.value = '';
-    nameInput.value = '';
-    if (riskInput) riskInput.value = 'Médio';
-    if (spotInput) spotInput.value = '';
-    if (futuresInput) futuresInput.value = '';
-    loadMonitoringData({ focusSymbol: symbol, silent: true });
-    updateMonitoringSelectors();
-    renderBlacklist();
   });
 }
 
 if (adminRemoveCoinForm) {
-  adminRemoveCoinForm.addEventListener('submit', (event) => {
+  adminRemoveCoinForm.addEventListener('submit', async (event) => {
     event.preventDefault();
     if (!requireAdmin()) return;
     const symbol = adminRemoveCoinSelect?.value;
     if (!symbol) return;
-    const idx = trackedMonitoringSymbols.indexOf(symbol);
-    if (idx >= 0) trackedMonitoringSymbols.splice(idx, 1);
-    monitoringMeta.delete(symbol);
-    blacklist.delete(symbol);
-    purgeMonitoringHistoryCache(symbol);
-    monitoringRows = monitoringRows.filter((coin) => coin.symbol !== symbol);
-    updateMonitoringSelectors();
-    renderMonitoringTable();
-    renderBlacklist();
+    try {
+      await removeMonitoringSymbol(symbol);
+      blacklist.delete(symbol);
+      purgeMonitoringHistoryCache(symbol);
+      monitoringRows = monitoringRows.filter((coin) => coin.symbol !== symbol);
+      renderMonitoringTable();
+      renderBlacklist();
+    } catch (e) {
+      if (adminLoginFeedback) {
+        adminLoginFeedback.textContent = e.message || 'Falha ao remover ativo';
+        adminLoginFeedback.style.color = '#ff6b9a';
+      }
+    }
   });
 }
 
@@ -5110,7 +5182,7 @@ if (topAssetsNext) {
 }
 
 if (addSelectedTopAssetsBtn) {
-  addSelectedTopAssetsBtn.addEventListener('click', () => {
+  addSelectedTopAssetsBtn.addEventListener('click', async () => {
     if (!requireAdmin()) return;
     const selected = getSelectedDiscoveredAssets();
     if (!selected.length) {
@@ -5121,32 +5193,34 @@ if (addSelectedTopAssetsBtn) {
       return;
     }
     const added = [];
-    selected.forEach(({ symbol, label }) => {
-      const normalized = normalizeMonitoringSymbolInput(symbol);
-      if (!normalized) return;
-      if (!monitoringMeta.has(normalized)) {
-        monitoringMeta.set(normalized, { name: label || normalized, risk: 'Médio' });
-      }
-      if (!trackedMonitoringSymbols.includes(normalized)) {
-        trackedMonitoringSymbols.push(normalized);
+    try {
+      for (const { symbol, label } of selected) {
+        const normalized = normalizeMonitoringSymbolInput(symbol);
+        if (!normalized) continue;
+        await persistMonitoringSymbol(normalized, { name: label || normalized, risk: 'Médio' });
+        blacklist.delete(normalized);
         added.push(normalized);
       }
-      blacklist.delete(normalized);
-    });
-    updateMonitoringSelectors();
-    renderBlacklist();
-    renderMonitoringTable();
-    if (added.length) {
-      loadMonitoringData({ focusSymbol: added[0], silent: true });
+      renderBlacklist();
+      renderMonitoringTable();
+      if (added.length) {
+        loadMonitoringData({ focusSymbol: added[0], silent: true });
+        if (topAssetsStatus) {
+          topAssetsStatus.textContent = `Adicionados ${added.length} ativo(s) ao monitoramento.`;
+          topAssetsStatus.classList.remove('error');
+        }
+      }
+    } catch (e) {
       if (topAssetsStatus) {
-        topAssetsStatus.textContent = `Adicionados ${added.length} ativo(s) ao monitoramento.`;
-        topAssetsStatus.classList.remove('error');
+        topAssetsStatus.textContent = e.message || 'Erro ao adicionar ativos';
+        topAssetsStatus.classList.add('error');
       }
     }
   });
 }
 
-function bootstrapMonitoring() {
+async function bootstrapMonitoring() {
+  await hydrateMonitoringSymbolsFromServer();
   updateMonitoringSelectors();
   renderMonitoringTable();
   if (filterMinArbValueEl && filterMinArbEl) {
@@ -5158,4 +5232,4 @@ function bootstrapMonitoring() {
   scheduleMonitoringAutoRefresh();
 }
 
-bootstrapMonitoring();
+bootstrapMonitoring().catch((err) => console.error('Erro ao iniciar monitoramento', err));

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -4193,6 +4193,11 @@ const monitoringHistorySpotSelect = document.getElementById('monitoringHistorySp
 const monitoringHistoryFuturesSelect = document.getElementById('monitoringHistoryFutures');
 const monitoringHistorySourceEl = document.getElementById('monitoringHistorySource');
 const monitoringHistoryStatusEl = document.getElementById('monitoringHistoryStatus');
+const monitoringRefreshIntervalSelect = document.getElementById('monitoringRefreshInterval');
+const monitoringPaginationInfo = document.getElementById('monitoringPaginationInfo');
+const monitoringPaginationStatus = document.getElementById('monitoringPaginationStatus');
+const monitoringPaginationPrev = document.getElementById('monitoringPaginationPrev');
+const monitoringPaginationNext = document.getElementById('monitoringPaginationNext');
 const adminStatusLabel = document.getElementById('adminStatusLabel');
 const adminLoginFeedback = document.getElementById('adminLoginFeedback');
 const adminTools = document.getElementById('adminTools');
@@ -4204,6 +4209,12 @@ const adminRemoveCoinSelect = document.getElementById('adminRemoveCoinSelect');
 const blacklistForm = document.getElementById('blacklistForm');
 const blacklistInput = document.getElementById('blacklistInput');
 const blacklistList = document.getElementById('blacklistList');
+
+const MONITORING_PAGE_SIZE = 10;
+const monitoringPaginationState = { page: 1, perPage: MONITORING_PAGE_SIZE };
+let monitoringFilteredRows = [];
+const MONITORING_REFRESH_DEFAULT_SECONDS = 3;
+let monitoringAutoRefreshTimer = null;
 
 function getCheckedValues(selector) {
   return Array.from(document.querySelectorAll(selector))
@@ -4221,6 +4232,64 @@ function getMonitoringName(symbol, fallbackLabel = null) {
   const normalized = symbol.toUpperCase();
   const meta = monitoringMeta.get(normalized);
   return meta?.name || fallbackLabel || normalized;
+}
+
+function resetMonitoringPagination() {
+  monitoringPaginationState.page = 1;
+}
+
+function updateMonitoringPaginationUI(totalRows) {
+  const total = Number(totalRows) || 0;
+  const totalPages = total ? Math.max(1, Math.ceil(total / monitoringPaginationState.perPage)) : 1;
+  if (monitoringPaginationState.page < 1) {
+    monitoringPaginationState.page = 1;
+  }
+  if (!total) {
+    monitoringPaginationState.page = 1;
+  } else if (monitoringPaginationState.page > totalPages) {
+    monitoringPaginationState.page = totalPages;
+  }
+  const start = total ? (monitoringPaginationState.page - 1) * monitoringPaginationState.perPage + 1 : 0;
+  const end = total ? Math.min(start + monitoringPaginationState.perPage - 1, total) : 0;
+  if (monitoringPaginationInfo) {
+    monitoringPaginationInfo.textContent = total
+      ? `Mostrando ${start}–${end} de ${total} oportunidades`
+      : 'Nenhuma oportunidade encontrada';
+  }
+  if (monitoringPaginationStatus) {
+    monitoringPaginationStatus.textContent = total
+      ? `Página ${monitoringPaginationState.page} de ${totalPages}`
+      : 'Página 0 de 0';
+  }
+  if (monitoringPaginationPrev) monitoringPaginationPrev.disabled = monitoringPaginationState.page <= 1 || !total;
+  if (monitoringPaginationNext) monitoringPaginationNext.disabled = monitoringPaginationState.page >= totalPages || !total;
+}
+
+function changeMonitoringPage(delta) {
+  if (!Number.isFinite(delta) || !monitoringFilteredRows.length) return;
+  const totalPages = Math.max(1, Math.ceil(monitoringFilteredRows.length / monitoringPaginationState.perPage));
+  const nextPage = Math.min(Math.max(1, monitoringPaginationState.page + delta), totalPages);
+  if (nextPage === monitoringPaginationState.page) return;
+  monitoringPaginationState.page = nextPage;
+  renderMonitoringTable();
+}
+
+function getMonitoringRefreshSeconds() {
+  const seconds = Number(monitoringRefreshIntervalSelect?.value);
+  if (!Number.isFinite(seconds)) return MONITORING_REFRESH_DEFAULT_SECONDS;
+  return Math.min(Math.max(seconds, 1), 5);
+}
+
+function scheduleMonitoringAutoRefresh() {
+  if (monitoringAutoRefreshTimer) {
+    clearInterval(monitoringAutoRefreshTimer);
+    monitoringAutoRefreshTimer = null;
+  }
+  const intervalMs = getMonitoringRefreshSeconds() * 1000;
+  monitoringAutoRefreshTimer = setInterval(() => {
+    if (document.hidden) return;
+    loadMonitoringData({ silent: true });
+  }, intervalMs);
 }
 
 function resetMonitoringHistory() {
@@ -4349,6 +4418,9 @@ async function loadMonitoringData({ focusSymbol = null, silent = false } = {}) {
     monitoringLoading = false;
     return;
   }
+  if (monitoringLoading && silent) {
+    return;
+  }
   try {
     monitoringLoading = true;
     monitoringLastFetchError = null;
@@ -4400,6 +4472,8 @@ async function loadMonitoringData({ focusSymbol = null, silent = false } = {}) {
     if (monitoringTableBody) {
       monitoringTableBody.innerHTML = `<tr><td colspan="9">Erro ao carregar dados de arbitragem: ${err.message || err}</td></tr>`;
     }
+    monitoringFilteredRows = [];
+    updateMonitoringPaginationUI(0);
     renderMonitoringSummary([]);
   } finally {
     monitoringLoading = false;
@@ -4458,6 +4532,9 @@ function renderMonitoringTable() {
     return bArb - aArb;
   });
 
+  monitoringFilteredRows = filtered;
+  updateMonitoringPaginationUI(filtered.length);
+
   if (!filtered.length) {
     const emptyMessage = monitoringLoading
       ? 'Atualizando dados de arbitragem...'
@@ -4469,7 +4546,10 @@ function renderMonitoringTable() {
     return;
   }
 
-  monitoringTableBody.innerHTML = filtered.map((coin) => {
+  const startIndex = (monitoringPaginationState.page - 1) * monitoringPaginationState.perPage;
+  const visibleCoins = filtered.slice(startIndex, startIndex + monitoringPaginationState.perPage);
+
+  monitoringTableBody.innerHTML = visibleCoins.map((coin) => {
     const metaInfo = monitoringMeta.get(coin.symbol);
     const arbLabel = Number.isFinite(coin.arb) ? `${coin.arb.toFixed(2)}%` : '—';
     const fundingLabel = Number.isFinite(coin.funding) ? `${(coin.funding * 100).toFixed(3)}%` : '—';
@@ -4658,21 +4738,37 @@ async function updateMonitoringChart(symbolInput) {
 const filterInputs = [filterSearchEl, filterVolumeEl, filterStabilityEl];
 filterInputs.forEach((input) => {
   if (!input) return;
-  input.addEventListener('input', () => renderMonitoringTable());
+  const eventName = input.tagName === 'SELECT' ? 'change' : 'input';
+  input.addEventListener(eventName, () => {
+    resetMonitoringPagination();
+    renderMonitoringTable();
+  });
 });
 
 if (filterMinArbEl) {
   filterMinArbEl.addEventListener('input', () => {
     if (filterMinArbValueEl) filterMinArbValueEl.textContent = `${filterMinArbEl.value}%`;
+    resetMonitoringPagination();
     renderMonitoringTable();
   });
 }
 
 ['.filter-spot', '.filter-futures', '.filter-risk'].forEach((selector) => {
   document.querySelectorAll(selector).forEach((input) => {
-    input.addEventListener('change', () => renderMonitoringTable());
+    input.addEventListener('change', () => {
+      resetMonitoringPagination();
+      renderMonitoringTable();
+    });
   });
 });
+
+if (monitoringPaginationPrev) {
+  monitoringPaginationPrev.addEventListener('click', () => changeMonitoringPage(-1));
+}
+
+if (monitoringPaginationNext) {
+  monitoringPaginationNext.addEventListener('click', () => changeMonitoringPage(1));
+}
 
 if (monitoringTableBody) {
   monitoringTableBody.addEventListener('click', (event) => {
@@ -4711,6 +4807,19 @@ if (refreshMonitoringChartBtn) {
     updateMonitoringChart(symbol);
   });
 }
+
+if (monitoringRefreshIntervalSelect) {
+  monitoringRefreshIntervalSelect.addEventListener('change', () => {
+    scheduleMonitoringAutoRefresh();
+    loadMonitoringData({ silent: true });
+  });
+}
+
+document.addEventListener('visibilitychange', () => {
+  if (!document.hidden) {
+    loadMonitoringData({ silent: true });
+  }
+});
 
 if (adminLoginForm) {
   adminLoginForm.addEventListener('submit', (event) => {
@@ -4830,6 +4939,7 @@ function bootstrapMonitoring() {
   if (filterMinArbValueEl && filterMinArbEl) filterMinArbValueEl.textContent = `${filterMinArbEl.value}%`;
   renderBlacklist();
   loadMonitoringData();
+  scheduleMonitoringAutoRefresh();
 }
 
 bootstrapMonitoring();

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -4567,12 +4567,12 @@ function updateMonitoringHistoryExtremes(entry) {
   const closeStats = entry?.stats?.close;
   const formatRange = (stats) => {
     if (!stats || !Number.isFinite(stats.min) || !Number.isFinite(stats.max)) return '–';
-    const minStr = stats.min.toFixed(3).replace(/\.0+$/, '').replace(/(\.\d*[1-9])0+$/, '$1');
-    const maxStr = stats.max.toFixed(3).replace(/\.0+$/, '').replace(/(\.\d*[1-9])0+$/, '$1');
-    return `${minStr}% a ${maxStr}%`;
+    const minStr = Number(stats.min.toFixed(3)).toString();
+    const maxStr = Number(stats.max.toFixed(3)).toString();
+    return `<span class="extreme-min">${minStr}%</span> a <span class="extreme-max">${maxStr}%</span>`;
   };
-  openLabel.textContent = formatRange(openStats);
-  closeLabel.textContent = formatRange(closeStats);
+  openLabel.innerHTML = formatRange(openStats);
+  closeLabel.innerHTML = formatRange(closeStats);
 }
 
 async function fetchMonitoringHistorySeries(symbol, intervalKey, spotKey, futuresKey) {
@@ -4730,7 +4730,12 @@ function formatVolume(value) {
 
 function formatPriceCompact(value) {
   if (!Number.isFinite(value)) return '—';
-  if (value >= 1) return value.toFixed(4).replace(/\.0+$/, '').replace(/(\.\d*[1-9])0+$/, '$1');
+  const absVal = Math.abs(value);
+  const decimalPart = value.toString().split('.')[1];
+  if ((absVal > 0 && absVal < 0.000001) || (decimalPart && decimalPart.length > 8)) {
+    return value.toExponential(2);
+  }
+  if (value >= 1 || value <= -1) return value.toFixed(4).replace(/\.0+$/, '').replace(/(\.\d*[1-9])0+$/, '$1');
   return value.toFixed(6).replace(/0+$/, '').replace(/\.$/, '');
 }
 
@@ -4768,13 +4773,11 @@ function updateArbUptime(key, arb) {
   return entry.start ? formatUptime(now - entry.start) : '—';
 }
 
-function renderLegDetails(label, ask, bid, askNotional, bidNotional) {
-  const lines = [];
-  const askVolLabel = Number.isFinite(askNotional) ? `${formatVolume(askNotional)} USDT` : 's/ dado';
-  const bidVolLabel = Number.isFinite(bidNotional) ? `${formatVolume(bidNotional)} USDT` : 's/ dado';
-  lines.push(`<div class="quote-chip ask"><span>${label}</span><strong>Ask ${formatPriceCompact(ask)}</strong><em>Vol: ${askVolLabel}</em></div>`);
-  lines.push(`<div class="quote-chip bid"><span>${label}</span><strong>Bid ${formatPriceCompact(bid)}</strong><em>Vol: ${bidVolLabel}</em></div>`);
-  return lines.join('');
+function renderLegDetails(label, price, notional, side) {
+  const volLabel = Number.isFinite(notional) ? `${formatVolume(notional)} USDT` : 's/ dado';
+  const sideLabel = side === 'bid' ? 'Bid' : 'Ask';
+  const chipClass = side === 'bid' ? 'bid' : 'ask';
+  return `<div class="quote-chip ${chipClass}"><span>${label}</span><strong>${sideLabel} ${formatPriceCompact(price)}</strong><em>Vol: ${volLabel}</em></div>`;
 }
 
 function renderMonitoringTable() {
@@ -4850,12 +4853,12 @@ function renderMonitoringTable() {
       : metaInfo?.futuresHint?.length
         ? `${metaInfo.futuresHint.join(', ')} (config)`
         : 'Sem dados';
-    const spotDetail = renderLegDetails(coin.spotExchanges[0] || 'SPOT', coin.spotAsk, coin.spotBid, coin.spotAskNotional, coin.spotBidNotional);
-    const futuresDetail = renderLegDetails(coin.futuresExchanges[0] || 'FUTUROS', coin.futuresAsk, coin.futuresBid, coin.futuresAskNotional, coin.futuresBidNotional);
+    const spotDetail = renderLegDetails(coin.spotExchanges[0] || 'SPOT', coin.spotAsk, coin.spotAskNotional, 'ask');
+    const futuresDetail = renderLegDetails(coin.futuresExchanges[0] || 'FUTUROS', coin.futuresBid, coin.futuresBidNotional, 'bid');
     return `
       <tr>
         <td><strong>${coin.symbol}</strong><br/><span class="muted">${coin.name}</span></td>
-        <td>${arbLabel}<div class="uptime-chip">⬆︎ acima de 0% por ${uptime}</div></td>
+        <td>${arbLabel}<div class="uptime-chip">${uptime}</div></td>
         <td><div class="exchange-header">${spotList}</div>${spotDetail}</td>
         <td><div class="exchange-header">${futuresList}</div>${futuresDetail}</td>
         <td>${formatVolume(coin.volume24h)} USDT</td>
@@ -4981,7 +4984,7 @@ function ensureMonitoringChart() {
             callback: (value) => {
               const num = Number(value);
               if (!Number.isFinite(num)) return `${value}%`;
-              const formatted = num.toFixed(3).replace(/\.0+$/, '').replace(/(\.\d*[1-9])0+$/, '$1');
+              const formatted = Number(num.toFixed(3)).toString();
               return `${formatted}%`;
             }
           }

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -4182,6 +4182,24 @@ let monitoringLoading = true;
 let monitoringLastFetchError = null;
 
 const MONITORING_VISIBILITY_STORAGE_KEY = 'monitoringChartVisibility';
+const MONITORING_COLUMNS_STORAGE_KEY = 'monitoringColumnVisibility';
+
+function loadMonitoringColumns() {
+  try {
+    const raw = localStorage.getItem(MONITORING_COLUMNS_STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object') return parsed;
+  } catch {}
+  return {};
+}
+
+function persistMonitoringColumns(value) {
+  try {
+    localStorage.setItem(MONITORING_COLUMNS_STORAGE_KEY, JSON.stringify(value));
+  } catch {}
+}
+
 function loadMonitoringVisibility() {
   try {
     const raw = localStorage.getItem(MONITORING_VISIBILITY_STORAGE_KEY);
@@ -4198,7 +4216,9 @@ function persistMonitoringVisibility(map) {
   } catch {}
 }
 
+let monitoringColumnVisibility = loadMonitoringColumns();
 let monitoringDatasetVisibility = loadMonitoringVisibility();
+monitoringColumnVisibility = { ...MONITORING_DEFAULT_COLUMNS, ...monitoringColumnVisibility };
 
 const blacklist = new Set();
 const ADMIN_PASSWORD = 'arbisync@2024';
@@ -4222,6 +4242,7 @@ const monitoringOpenRangeEl = document.getElementById('monitoringOpenRange');
 const monitoringCloseRangeEl = document.getElementById('monitoringCloseRange');
 const monitoringRefreshIntervalSelect = document.getElementById('monitoringRefreshInterval');
 const monitoringRefreshToggleBtn = document.getElementById('monitoringRefreshToggle');
+const monitoringColumnToggles = Array.from(document.querySelectorAll('.monitoring-column-toggle'));
 const monitoringPaginationInfo = document.getElementById('monitoringPaginationInfo');
 const monitoringPaginationStatus = document.getElementById('monitoringPaginationStatus');
 const monitoringPaginationPrev = document.getElementById('monitoringPaginationPrev');
@@ -4257,6 +4278,7 @@ let monitoringFilteredRows = [];
 const MONITORING_REFRESH_DEFAULT_SECONDS = 3;
 let monitoringAutoRefreshTimer = null;
 let monitoringAutoRefreshPaused = false;
+const MONITORING_DEFAULT_COLUMNS = { spot: true, futures: true, volume: true, favorite: true, actions: true };
 const TOP_ASSETS_PAGE_SIZE = 8;
 const TOP_ASSETS_LIMIT_DEFAULT = 60;
 const topAssetsState = { items: [], page: 1, perPage: TOP_ASSETS_PAGE_SIZE, limit: TOP_ASSETS_LIMIT_DEFAULT };
@@ -4792,9 +4814,17 @@ function renderLegDetails(price, notional, side, fallbackVolume, fallbackSize) {
   const fallback = Number.isFinite(fallbackVolume) ? fallbackVolume : null;
   const volValue = Number.isFinite(computedNotional) && computedNotional > 0 ? computedNotional : fallback;
   const volLabel = Number.isFinite(volValue) ? `${formatVolume(volValue)} USDT` : 's/ dado';
-  const sideLabel = side === 'bid' ? 'Bid' : 'Ask';
   const chipClass = side === 'bid' ? 'bid' : 'ask';
-  return `<div class="quote-chip ${chipClass}"><strong>${sideLabel} ${formatPriceCompact(price)}</strong><em>Vol: ${volLabel}</em></div>`;
+  return `<div class="quote-chip ${chipClass}"><strong>${formatPriceCompact(price)}</strong><em>Vol: ${volLabel}</em></div>`;
+}
+
+function applyMonitoringColumnVisibility() {
+  Object.entries(MONITORING_DEFAULT_COLUMNS).forEach(([key]) => {
+    const visible = monitoringColumnVisibility[key] !== false;
+    document.querySelectorAll(`.col-${key}`).forEach((el) => el.classList.toggle('col-hidden', !visible));
+    const toggle = monitoringColumnToggles.find((input) => input.dataset.col === key);
+    if (toggle) toggle.checked = visible;
+  });
 }
 
 function renderMonitoringTable() {
@@ -4847,6 +4877,7 @@ function renderMonitoringTable() {
         ? `Última tentativa falhou: ${monitoringLastFetchError.message || monitoringLastFetchError}`
         : 'Nenhuma moeda atende aos filtros ativos.';
     monitoringTableBody.innerHTML = `<tr><td colspan="7">${emptyMessage}</td></tr>`;
+    applyMonitoringColumnVisibility();
     renderMonitoringSummary(merged);
     return;
   }
@@ -4875,20 +4906,16 @@ function renderMonitoringTable() {
     const futuresDetail = renderLegDetails(coin.futuresBid, coin.futuresBidNotional, 'bid', coin.futuresVolume, coin.futuresBidSize);
     const spotVolumeLabel = Number.isFinite(coin.spotVolume) ? `${formatVolume(coin.spotVolume)} USDT` : 's/ dado';
     const futuresVolumeLabel = Number.isFinite(coin.futuresVolume) ? `${formatVolume(coin.futuresVolume)} USDT` : 's/ dado';
+    const volume24hCell = `<div class="volume-inline"><span>${spotVolumeLabel}</span><span>|</span><span>${futuresVolumeLabel}</span></div>`;
     return `
       <tr>
-        <td><strong>${coin.symbol}</strong><br/><span class="muted">${coin.name}</span></td>
-        <td>${arbLabel}${uptime ? `<div class="uptime-chip">${uptime}</div>` : ''}</td>
-        <td><div class="exchange-header">${spotList}</div><div class="quote-chip-container">${spotDetail}</div></td>
-        <td><div class="exchange-header">${futuresList}</div><div class="quote-chip-container">${futuresDetail}</div></td>
-        <td>
-          <div class="volume-badges compact">
-            <span class="volume-badge"><strong>${coin.spotExchanges[0] || 'SPOT'}</strong><span class="asset-volume">${spotVolumeLabel}</span></span>
-            <span class="volume-badge"><strong>${coin.futuresExchanges[0] || 'FUTUROS'}</strong><span class="asset-volume">${futuresVolumeLabel}</span></span>
-          </div>
-        </td>
-        <td>${isFavorite ? '<span class="monitoring-favorite-flag">★ Favorito</span>' : '—'}</td>
-        <td class="monitoring-actions-cell">
+        <td class="col-symbol"><strong>${coin.symbol}</strong><br/><span class="muted">${coin.name}</span></td>
+        <td class="col-arb">${arbLabel}${uptime ? `<div class="uptime-chip">${uptime}</div>` : ''}</td>
+        <td class="col-spot"><div class="exchange-header">${spotList}</div><div class="quote-chip-container">${spotDetail}</div></td>
+        <td class="col-futures"><div class="exchange-header">${futuresList}</div><div class="quote-chip-container">${futuresDetail}</div></td>
+        <td class="col-volume">${volume24hCell}</td>
+        <td class="col-favorite">${isFavorite ? '<span class="monitoring-favorite-flag">★ Favorito</span>' : '—'}</td>
+        <td class="monitoring-actions-cell col-actions">
           <button
             type="button"
             class="monitoring-view-chart"
@@ -4916,6 +4943,7 @@ function renderMonitoringTable() {
       </tr>`;
   }).join('');
 
+  applyMonitoringColumnVisibility();
   renderMonitoringSummary(merged);
 
   if (merged.length && monitoringPairSelect && !monitoringPairSelect.value) {
@@ -5256,6 +5284,23 @@ if (monitoringRefreshIntervalSelect) {
       loadMonitoringData({ silent: true, updateChart: false });
     }
   });
+}
+
+if (monitoringColumnToggles.length) {
+  monitoringColumnToggles.forEach((input) => {
+    const key = input.dataset.col;
+    if (key && key in monitoringColumnVisibility) {
+      input.checked = monitoringColumnVisibility[key] !== false;
+    }
+    input.addEventListener('change', () => {
+      const colKey = input.dataset.col;
+      if (!colKey) return;
+      monitoringColumnVisibility[colKey] = input.checked;
+      persistMonitoringColumns(monitoringColumnVisibility);
+      applyMonitoringColumnVisibility();
+    });
+  });
+  applyMonitoringColumnVisibility();
 }
 
 document.addEventListener('visibilitychange', () => {

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -4285,6 +4285,7 @@ const TOP_ASSETS_LIMIT_DEFAULT = 60;
 const topAssetsState = { items: [], page: 1, perPage: TOP_ASSETS_PAGE_SIZE, limit: TOP_ASSETS_LIMIT_DEFAULT };
 const topAssetsSelection = new Set();
 const monitoringFavorites = new Set();
+const monitoringFavoriteSnapshots = new Map();
 const monitoringArbTimers = new Map();
 let executionToastTimer = null;
 
@@ -4392,6 +4393,7 @@ function setFavorite(key, enabled) {
     monitoringFavorites.add(normalized);
   } else {
     monitoringFavorites.delete(normalized);
+    monitoringFavoriteSnapshots.delete(normalized);
   }
   persistMonitoringFavorites();
 }
@@ -4674,7 +4676,9 @@ async function loadMonitoringData({ focusSymbol = null, silent = false, updateCh
     if (!response.ok) throw new Error(`Falha ao buscar dados (${response.status})`);
     const payload = await safeJson(response);
     const entries = Array.isArray(payload?.symbols) ? payload.symbols : [];
-    monitoringRows = entries.flatMap((entry) => {
+    const favoriteKeys = new Set(monitoringFavorites);
+    const snapshotSeen = new Set();
+    const baseRows = entries.flatMap((entry) => {
       const symbol = (entry?.symbol || '').toUpperCase();
       if (!symbol) return [];
       const name = getMonitoringName(symbol, entry?.label || symbol);
@@ -4728,6 +4732,21 @@ async function loadMonitoringData({ focusSymbol = null, silent = false, updateCh
       }
       return combos;
     });
+
+    for (const coin of baseRows) {
+      const key = buildOpportunityKey(coin);
+      snapshotSeen.add(key);
+      if (favoriteKeys.has(key)) {
+        monitoringFavoriteSnapshots.set(key, coin);
+      }
+    }
+
+    const missingFavorites = Array.from(favoriteKeys).filter((key) => !snapshotSeen.has(key));
+    const recoveredFavorites = missingFavorites
+      .map((key) => monitoringFavoriteSnapshots.get(key))
+      .filter(Boolean);
+
+    monitoringRows = [...baseRows, ...recoveredFavorites];
     resetMonitoringHistory();
     renderMonitoringTable();
     updateMonitoringSelectors();
@@ -4758,7 +4777,8 @@ function formatVolume(value) {
   if (value >= 1_000) return `${(value / 1_000).toFixed(1)}k`;
   if (value >= 10) return value.toFixed(1);
   if (value >= 1) return value.toFixed(2);
-  return value.toExponential(2);
+  if (value >= 0.01) return value.toFixed(4);
+  return value.toFixed(6);
 }
 
 function formatPriceCompact(value) {

--- a/server.js
+++ b/server.js
@@ -4486,40 +4486,45 @@ async function fetchMexcFuturesTicker(meta) {
   let bidSize = toBaseSize(payload.bid1Size ?? payload.bidVol);
   let askSize = toBaseSize(payload.ask1Size ?? payload.askVol);
 
-  if (!Number.isFinite(bidSize) || bidSize <= 0 || !Number.isFinite(askSize) || askSize <= 0) {
-    try {
-      const depth = await monitoringHttp.get('https://contract.mexc.com/api/v1/contract/depth', {
-        params: { symbol: meta.mexcFutures, depth: 1 }
-      });
-      const bids = Array.isArray(depth?.data?.bids) ? depth.data.bids : [];
-      const asks = Array.isArray(depth?.data?.asks) ? depth.data.asks : [];
-      if (bids.length) {
-        const bidPrice = toNumber(bids[0].price ?? bids[0][0]);
-        const bidContracts = toNumber(bids[0].vol ?? bids[0].amount ?? bids[0][1]);
-        bid = bidPrice ?? bid;
-        const depthBidSize = toBaseSize(bidContracts);
-        bidSize = Number.isFinite(depthBidSize) ? depthBidSize : bidSize;
+  let depthBids = [];
+  let depthAsks = [];
+  try {
+    const depthResp = await monitoringHttp.get(`https://contract.mexc.com/api/v1/contract/depth/${meta.mexcFutures}`, {
+      params: { limit: 5 }
+    });
+    const depthPayload = depthResp?.data?.data || depthResp?.data || {};
+    depthBids = Array.isArray(depthPayload?.bids) ? depthPayload.bids : [];
+    depthAsks = Array.isArray(depthPayload?.asks) ? depthPayload.asks : [];
+  } catch (err) {
+    const status = err?.response?.status;
+    const reason = err?.message || err;
+    if (status === 404) {
+      if (!mexcFuturesDepthWarnings.has(meta.mexcFutures)) {
+        mexcFuturesDepthWarnings.add(meta.mexcFutures);
+        console.info('[monitoring] mexc futures depth indisponível (404)', meta.mexcFutures);
       }
-      if (asks.length) {
-        const askPrice = toNumber(asks[0].price ?? asks[0][0]);
-        const askContracts = toNumber(asks[0].vol ?? asks[0].amount ?? asks[0][1]);
-        ask = askPrice ?? ask;
-        const depthAskSize = toBaseSize(askContracts);
-        askSize = Number.isFinite(depthAskSize) ? depthAskSize : askSize;
-      }
-    } catch (err) {
-      const status = err?.response?.status;
-      const reason = err?.message || err;
-      if (status === 404) {
-        if (!mexcFuturesDepthWarnings.has(meta.mexcFutures)) {
-          mexcFuturesDepthWarnings.add(meta.mexcFutures);
-          console.info('[monitoring] mexc futures depth indisponível (404)', meta.mexcFutures);
-        }
-      } else {
-        console.warn('[monitoring] mexc futures depth fallback falhou', meta.mexcFutures, 'status=', status || 'n/a', 'reason=', reason);
-      }
+    } else {
+      console.warn('[monitoring] mexc futures depth fallback falhou', meta.mexcFutures, 'status=', status || 'n/a', 'reason=', reason);
     }
   }
+
+  const applyDepthSize = (entry, setter) => {
+    if (!entry) return;
+    const price = toNumber(entry.price ?? entry[0]);
+    const contracts = toNumber(entry.vol ?? entry.amount ?? entry[1]);
+    const baseSize = toBaseSize(contracts);
+    if (Number.isFinite(price)) setter('price', price);
+    if (Number.isFinite(baseSize) && baseSize > 0) setter('size', baseSize);
+  };
+
+  applyDepthSize(depthBids[0], (field, value) => {
+    if (field === 'price') bid = value ?? bid;
+    if (field === 'size') bidSize = value;
+  });
+  applyDepthSize(depthAsks[0], (field, value) => {
+    if (field === 'price') ask = value ?? ask;
+    if (field === 'size') askSize = value;
+  });
 
   return {
     bid,

--- a/server.js
+++ b/server.js
@@ -4760,6 +4760,7 @@ async function fetchBybitTopFuturesAssets() {
 }
 
 const TOP_ASSET_LIMIT = 60;
+const TOP_ASSET_LIMIT_MAX = 200;
 const topAssetProviders = [
   { key: 'gate_spot', label: 'Gate.io Spot', type: 'spot', list: fetchGateTopSpotAssets },
   { key: 'mexc_spot', label: 'MEXC Spot', type: 'spot', list: fetchMexcTopSpotAssets },
@@ -4788,7 +4789,12 @@ async function collectTopAssets(provider) {
   }
 }
 
-async function buildTopAssetsResponse(selectedKeys) {
+async function buildTopAssetsResponse(selectedKeys, limitInput) {
+  const safeLimit = (() => {
+    const raw = Number(limitInput);
+    if (!Number.isFinite(raw) || raw <= 0) return TOP_ASSET_LIMIT;
+    return Math.min(Math.max(5, Math.round(raw)), TOP_ASSET_LIMIT_MAX);
+  })();
   const providers = selectedKeys?.length
     ? selectedKeys.map((key) => findTopAssetProvider(key)).filter(Boolean)
     : topAssetProviders;
@@ -4821,12 +4827,12 @@ async function buildTopAssetsResponse(selectedKeys) {
       volumes: item.volumes.sort((a, b) => (b.volume || 0) - (a.volume || 0))
     }))
     .sort((a, b) => (b.bestVolume || 0) - (a.bestVolume || 0))
-    .slice(0, TOP_ASSET_LIMIT);
+    .slice(0, safeLimit);
   const errors = responses.filter((entry) => entry.error).map((entry) => ({
     provider: entry.provider?.label || entry.provider?.key,
     error: entry.error
   }));
-  return { assets, errors, exchanges: providers.map((p) => p.key) };
+  return { assets, errors, exchanges: providers.map((p) => p.key), limit: safeLimit };
 }
 
 async function fetchHistoryDataset(provider, meta, intervalKey, limit) {
@@ -5056,7 +5062,8 @@ app.get('/api/monitoring/top-assets', async (req, res) => {
       .split(',')
       .map((key) => key.trim())
       .filter(Boolean);
-    const result = await buildTopAssetsResponse(selected);
+    const limit = Number(req.query.limit);
+    const result = await buildTopAssetsResponse(selected, limit);
     res.json({ ...result, updatedAt: new Date().toISOString() });
   } catch (err) {
     console.error('[monitoring] erro ao buscar ativos mais negociados', err);

--- a/server.js
+++ b/server.js
@@ -4424,15 +4424,39 @@ async function fetchGateFuturesTicker(meta) {
   });
   const payload = Array.isArray(data) ? data[0] : data;
   if (!payload) throw new Error('Resposta vazia');
+  let bid = toNumber(payload.highest_bid);
+  let ask = toNumber(payload.lowest_ask);
+  let bidSize = toNumber(payload.highest_bid_size);
+  let askSize = toNumber(payload.lowest_ask_size);
+
+  if (!Number.isFinite(bidSize) || bidSize <= 0 || !Number.isFinite(askSize) || askSize <= 0) {
+    try {
+      const depth = await monitoringHttp.get('https://api.gateio.ws/api/v4/futures/usdt/order_book', {
+        params: { contract: meta.gateFutures, limit: 1 }
+      });
+      const bids = Array.isArray(depth?.data?.bids) ? depth.data.bids : [];
+      const asks = Array.isArray(depth?.data?.asks) ? depth.data.asks : [];
+      if (bids.length) {
+        bid = toNumber(bids[0].p) ?? bid;
+        bidSize = toNumber(bids[0].s) ?? bidSize;
+      }
+      if (asks.length) {
+        ask = toNumber(asks[0].p) ?? ask;
+        askSize = toNumber(asks[0].s) ?? askSize;
+      }
+    } catch (err) {
+      console.warn('[monitoring] gate futures depth fallback falhou', meta.gateFutures, err?.message || err);
+    }
+  }
   return {
-    bid: toNumber(payload.highest_bid),
-    ask: toNumber(payload.lowest_ask),
+    bid,
+    ask,
     last: toNumber(payload.last),
     volume: toNumber(payload.volume_24h_quote ?? payload.volume_24h),
-    bidSize: toNumber(payload.highest_bid_size),
-    askSize: toNumber(payload.lowest_ask_size),
-    bidNotional: computeNotional(toNumber(payload.highest_bid), toNumber(payload.highest_bid_size)),
-    askNotional: computeNotional(toNumber(payload.lowest_ask), toNumber(payload.lowest_ask_size)),
+    bidSize,
+    askSize,
+    bidNotional: computeNotional(bid, bidSize),
+    askNotional: computeNotional(ask, askSize),
     fundingRate: toNumber(payload.funding_rate),
     changePct: toNumber(payload.change_percentage)
   };
@@ -4447,8 +4471,8 @@ async function fetchMexcFuturesTicker(meta) {
 
   let bid = toNumber(payload.bid1);
   let ask = toNumber(payload.ask1);
-  let bidSize = toNumber(payload.bid1Size ?? payload.bidVol);
-  let askSize = toNumber(payload.ask1Size ?? payload.askVol);
+  let bidSize = toNumber(payload.bid1Size ?? payload.bidVol ?? payload.turnover ?? payload.amount24);
+  let askSize = toNumber(payload.ask1Size ?? payload.askVol ?? payload.turnover ?? payload.amount24);
 
   if (!Number.isFinite(bidSize) || bidSize <= 0 || !Number.isFinite(askSize) || askSize <= 0) {
     try {
@@ -4459,11 +4483,11 @@ async function fetchMexcFuturesTicker(meta) {
       const asks = Array.isArray(depth?.data?.asks) ? depth.data.asks : [];
       if (bids.length) {
         bid = toNumber(bids[0].price) ?? bid;
-        bidSize = toNumber(bids[0].vol) ?? bidSize;
+        bidSize = toNumber(bids[0].vol ?? bids[0].amount) ?? bidSize;
       }
       if (asks.length) {
         ask = toNumber(asks[0].price) ?? ask;
-        askSize = toNumber(asks[0].vol) ?? askSize;
+        askSize = toNumber(asks[0].vol ?? asks[0].amount) ?? askSize;
       }
     } catch (err) {
       const status = err?.response?.status;

--- a/server.js
+++ b/server.js
@@ -30,6 +30,8 @@ const monitoringHttp = axios.create({
 
 // Avoid spamming the console when a MEXC futures symbol lacks depth support
 const mexcFuturesDepthWarnings = new Set();
+// Skip repeated Gate futures history fetches for symbols that are not listed
+const gateFuturesHistoryUnavailable = new Set();
 
 const SPOT_EXCHANGES = {
   gate: { key: 'gate', label: 'Gate.io' },
@@ -5123,6 +5125,9 @@ function buildMonitoringMetrics(spotTickers, futuresTickers, historyPoints) {
 }
 
 async function fetchArbHistory(meta) {
+  if (gateFuturesHistoryUnavailable.has(meta.symbol)) {
+    return [];
+  }
   try {
     const [spotResp, futuresResp] = await Promise.all([
       monitoringHttp.get('https://api.gateio.ws/api/v4/spot/candlesticks', {
@@ -5166,10 +5171,14 @@ async function fetchArbHistory(meta) {
     points.sort((a, b) => a.timestamp - b.timestamp);
     return points;
   } catch (err) {
+    const reason = describeAxiosError(err);
+    if (reason?.includes('CONTRACT_NOT_FOUND')) {
+      gateFuturesHistoryUnavailable.add(meta.symbol);
+    }
     console.warn(
       '[monitoring] histórico indisponível',
       `${meta.symbol} (Gate spot=${meta.gateSpot}, futures=${meta.gateFutures}, intervalo=1h, candles=24)`,
-      describeAxiosError(err)
+      reason
     );
     return [];
   }

--- a/server.js
+++ b/server.js
@@ -4010,18 +4010,18 @@ function describeAxiosError(err) {
 }
 
 const MONITORING_HISTORY_INTERVALS = {
-  '1m': {
-    label: '1 minuto',
-    minutes: 1,
-    gate: '1m',
-    mexc: '1m',
+  '3m': {
+    label: '3 minutos',
+    minutes: 3,
+    gate: '3m',
+    mexc: '3m',
     mexcFutures: 'Min1',
-    bitget: '1min',
-    bitgetFutures: '1m',
-    kucoin: '1min',
-    kucoinFutures: 1 * 60,
-    binance: '1m',
-    bybit: '1'
+    bitget: '3min',
+    bitgetFutures: '3m',
+    kucoin: '3min',
+    kucoinFutures: 3 * 60,
+    binance: '3m',
+    bybit: '3'
   },
   '5m': {
     label: '5 minutos',
@@ -4129,6 +4129,25 @@ function sortHistoryPoints(points) {
   return points.sort((a, b) => a.timestamp - b.timestamp);
 }
 
+function aggregateHistoryPoints(points, size) {
+  if (!Array.isArray(points) || size <= 1) return points;
+  const aggregated = [];
+  const sorted = sortHistoryPoints(points.slice());
+  for (let i = 0; i < sorted.length; i += size) {
+    const chunk = sorted.slice(i, i + size);
+    if (!chunk.length) continue;
+    const first = chunk[0];
+    const last = chunk[chunk.length - 1];
+    aggregated.push({
+      timestamp: first.timestamp,
+      open: first.open,
+      close: last.close,
+      volume: chunk.reduce((sum, entry) => sum + (Number.isFinite(entry.volume) ? entry.volume : 0), 0)
+    });
+  }
+  return aggregated;
+}
+
 function bucketizeHistoryCandles(candles, bucketMs) {
   const map = new Map();
   for (const candle of candles) {
@@ -4139,9 +4158,27 @@ function bucketizeHistoryCandles(candles, bucketMs) {
   return map;
 }
 
-function computeArbPct(futuresPrice, spotPrice) {
-  if (!Number.isFinite(futuresPrice) || !Number.isFinite(spotPrice) || spotPrice === 0) return null;
-  return ((futuresPrice - spotPrice) / spotPrice) * 100;
+function formatArbValue(value) {
+  if (!Number.isFinite(value)) return null;
+  return Number(value.toFixed(4));
+}
+
+function computeSpreadPct(sellPrice, buyPrice) {
+  const sell = toNumber(sellPrice);
+  const buy = toNumber(buyPrice);
+  if (!Number.isFinite(sell) || !Number.isFinite(buy) || buy <= 0) return null;
+  return ((sell - buy) / buy) * 100;
+}
+
+function computeMidArbValue(openValue, closeValue) {
+  const open = Number.isFinite(openValue) ? openValue : null;
+  const close = Number.isFinite(closeValue) ? closeValue : null;
+  if (open !== null && close !== null) {
+    return Number(((open + close) / 2).toFixed(4));
+  }
+  if (close !== null) return Number(close.toFixed(4));
+  if (open !== null) return Number(open.toFixed(4));
+  return null;
 }
 
 function buildHistorySeries(spotCandles, futuresCandles, intervalMinutes) {
@@ -4153,13 +4190,16 @@ function buildHistorySeries(spotCandles, futuresCandles, intervalMinutes) {
     const bucket = Math.floor(spot.timestamp / bucketMs) * bucketMs;
     const futures = futuresMap.get(bucket);
     if (!futures) continue;
-    const openArb = computeArbPct(futures.open, spot.open);
-    const closeArb = computeArbPct(futures.close, spot.close);
-    if (!Number.isFinite(closeArb)) continue;
+    const openArb = computeSpreadPct(futures.open, spot.open);
+    const closeArb = computeSpreadPct(spot.close, futures.close);
+    if (!Number.isFinite(openArb) && !Number.isFinite(closeArb)) continue;
+    const openArbPct = formatArbValue(openArb);
+    const closeArbPct = formatArbValue(closeArb);
     points.push({
       timestamp: bucket,
-      openArbPct: Number.isFinite(openArb) ? Number(openArb.toFixed(4)) : Number(closeArb.toFixed(4)),
-      closeArbPct: Number(Number(closeArb).toFixed(4)),
+      openArbPct,
+      closeArbPct,
+      midArbPct: computeMidArbValue(openArb, closeArb),
       spotVolume: spot.volume,
       futuresVolume: futures.volume
     });
@@ -4416,6 +4456,7 @@ async function fetchMexcSpotHistory(meta, intervalKey, limit) {
 
 async function fetchMexcFuturesHistory(meta, intervalKey, limit) {
   const interval = getHistoryIntervalConfig(intervalKey).mexcFutures;
+  const aggregateSize = intervalKey === '3m' ? 3 : 1;
   const { data } = await monitoringHttp.get(`https://contract.mexc.com/api/v1/contract/kline/${meta.mexcFutures}`, {
     params: { interval }
   });
@@ -4436,7 +4477,9 @@ async function fetchMexcFuturesHistory(meta, intervalKey, limit) {
     });
     if (point) points.push(point);
   }
-  return sortHistoryPoints(points);
+  const sortedPoints = sortHistoryPoints(points);
+  const aggregated = aggregateSize > 1 ? aggregateHistoryPoints(sortedPoints, aggregateSize) : sortedPoints;
+  return limitHistoryPoints(aggregated, limit);
 }
 
 async function fetchBitgetSpotHistory(meta, intervalKey, limit) {
@@ -4694,15 +4737,16 @@ async function fetchArbHistory(meta) {
       const spotClose = toNumber(entry?.[2]);
       const futuresOpen = toNumber(futuresEntry?.o);
       const futuresClose = toNumber(futuresEntry?.c);
-      if (!Number.isFinite(spotClose) || !Number.isFinite(futuresClose) || spotClose <= 0) continue;
-      const closeArb = ((futuresClose - spotClose) / spotClose) * 100;
-      const openArb = Number.isFinite(spotOpen) && Number.isFinite(futuresOpen) && spotOpen > 0
-        ? ((futuresOpen - spotOpen) / spotOpen) * 100
-        : closeArb;
+      const openArbRaw = computeSpreadPct(futuresOpen, spotOpen);
+      const closeArbRaw = computeSpreadPct(spotClose, futuresClose);
+      if (!Number.isFinite(openArbRaw) && !Number.isFinite(closeArbRaw)) continue;
+      const openArbPct = formatArbValue(openArbRaw);
+      const closeArbPct = formatArbValue(closeArbRaw);
       points.push({
         timestamp: ts * 1000,
-        arbPct: Number(closeArb.toFixed(4)),
-        openArbPct: Number(openArb.toFixed(4)),
+        arbPct: computeMidArbValue(openArbRaw, closeArbRaw),
+        openArbPct,
+        closeArbPct,
         spotVolume: toNumber(entry?.[6] ?? entry?.[1]),
         futuresVolume: toNumber(futuresEntry?.sum ?? futuresEntry?.v)
       });

--- a/server.js
+++ b/server.js
@@ -4652,7 +4652,7 @@ async function fetchGateTopFuturesAssets() {
 async function fetchMexcTopSpotAssets() {
   const { data } = await monitoringHttp.get('https://api.mexc.com/api/v3/ticker/24hr');
   return (Array.isArray(data) ? data : [])
-    .map((item) => ({ symbol: normalizeMonitoringSymbol(item.symbol), volume: toNumber(item.quoteVolume ?? item.volume)) })
+    .map((item) => ({ symbol: normalizeMonitoringSymbol(item.symbol), volume: toNumber(item.quoteVolume ?? item.volume) }))
     .filter((item) => item.symbol && item.symbol.endsWith('_USDT') && Number.isFinite(item.volume));
 }
 
@@ -4660,7 +4660,7 @@ async function fetchMexcTopFuturesAssets() {
   const { data } = await monitoringHttp.get('https://contract.mexc.com/api/v1/contract/ticker');
   const list = Array.isArray(data?.data) ? data.data : [];
   return list
-    .map((item) => ({ symbol: normalizeMonitoringSymbol(item.symbol), volume: toNumber(item.amount24 ?? item.volume)) })
+    .map((item) => ({ symbol: normalizeMonitoringSymbol(item.symbol), volume: toNumber(item.amount24 ?? item.volume) }))
     .filter((item) => item.symbol && item.symbol.endsWith('_USDT') && Number.isFinite(item.volume));
 }
 
@@ -4676,7 +4676,7 @@ async function fetchBitgetTopFuturesAssets() {
   const { data } = await monitoringHttp.get('https://api.bitget.com/api/mix/v1/market/tickers', { params: { productType: 'umcbl' } });
   const list = Array.isArray(data?.data) ? data.data : [];
   return list
-    .map((item) => ({ symbol: normalizeMonitoringSymbol(item.symbol), volume: toNumber(item.usdtVolume ?? item.quoteVolume)) })
+    .map((item) => ({ symbol: normalizeMonitoringSymbol(item.symbol), volume: toNumber(item.usdtVolume ?? item.quoteVolume) }))
     .filter((item) => item.symbol && item.symbol.endsWith('_USDT') && Number.isFinite(item.volume));
 }
 
@@ -4684,7 +4684,7 @@ async function fetchKucoinTopSpotAssets() {
   const { data } = await monitoringHttp.get('https://api.kucoin.com/api/v1/market/allTickers');
   const list = Array.isArray(data?.data?.ticker) ? data.data.ticker : [];
   return list
-    .map((item) => ({ symbol: normalizeMonitoringSymbol(item.symbol), volume: toNumber(item.volValue || item.vol)) })
+    .map((item) => ({ symbol: normalizeMonitoringSymbol(item.symbol), volume: toNumber(item.volValue || item.vol) }))
     .filter((item) => item.symbol && item.symbol.endsWith('_USDT') && Number.isFinite(item.volume));
 }
 
@@ -4692,21 +4692,21 @@ async function fetchKucoinTopFuturesAssets() {
   const { data } = await monitoringHttp.get('https://api-futures.kucoin.com/api/v1/allTickers');
   const list = Array.isArray(data?.data?.ticker) ? data.data.ticker : [];
   return list
-    .map((item) => ({ symbol: normalizeMonitoringSymbol(item.symbol), volume: toNumber(item.turnover ?? item.turnoverValue)) })
+    .map((item) => ({ symbol: normalizeMonitoringSymbol(item.symbol), volume: toNumber(item.turnover ?? item.turnoverValue) }))
     .filter((item) => item.symbol && item.symbol.endsWith('_USDT') && Number.isFinite(item.volume));
 }
 
 async function fetchBinanceTopSpotAssets() {
   const { data } = await monitoringHttp.get('https://data-api.binance.vision/api/v3/ticker/24hr');
   return (Array.isArray(data) ? data : [])
-    .map((item) => ({ symbol: normalizeMonitoringSymbol(item.symbol), volume: toNumber(item.quoteVolume ?? item.volume)) })
+    .map((item) => ({ symbol: normalizeMonitoringSymbol(item.symbol), volume: toNumber(item.quoteVolume ?? item.volume) }))
     .filter((item) => item.symbol && item.symbol.endsWith('_USDT') && Number.isFinite(item.volume));
 }
 
 async function fetchBinanceTopFuturesAssets() {
   const { data } = await monitoringHttp.get('https://fapi.binance.com/fapi/v1/ticker/24hr');
   return (Array.isArray(data) ? data : [])
-    .map((item) => ({ symbol: normalizeMonitoringSymbol(item.symbol), volume: toNumber(item.quoteVolume ?? item.volume)) })
+    .map((item) => ({ symbol: normalizeMonitoringSymbol(item.symbol), volume: toNumber(item.quoteVolume ?? item.volume) }))
     .filter((item) => item.symbol && item.symbol.endsWith('_USDT') && Number.isFinite(item.volume));
 }
 
@@ -4714,7 +4714,7 @@ async function fetchBybitTopSpotAssets() {
   const { data } = await monitoringHttp.get('https://api.bybit.com/v5/market/tickers', { params: { category: 'spot' } });
   const list = Array.isArray(data?.result?.list) ? data.result.list : [];
   return list
-    .map((item) => ({ symbol: normalizeMonitoringSymbol(item.symbol), volume: toNumber(item.qv ?? item.qv24h ?? item.volume)) })
+    .map((item) => ({ symbol: normalizeMonitoringSymbol(item.symbol), volume: toNumber(item.qv ?? item.qv24h ?? item.volume) }))
     .filter((item) => item.symbol && item.symbol.endsWith('_USDT') && Number.isFinite(item.volume));
 }
 
@@ -4722,7 +4722,7 @@ async function fetchBybitTopFuturesAssets() {
   const { data } = await monitoringHttp.get('https://api.bybit.com/v5/market/tickers', { params: { category: 'linear' } });
   const list = Array.isArray(data?.result?.list) ? data.result.list : [];
   return list
-    .map((item) => ({ symbol: normalizeMonitoringSymbol(item.symbol), volume: toNumber(item.turnover24h ?? item.turnover ?? item.volume)) })
+    .map((item) => ({ symbol: normalizeMonitoringSymbol(item.symbol), volume: toNumber(item.turnover24h ?? item.turnover ?? item.volume) }))
     .filter((item) => item.symbol && item.symbol.endsWith('_USDT') && Number.isFinite(item.volume));
 }
 

--- a/server.js
+++ b/server.js
@@ -21,6 +21,20 @@ const DEFAULT_RISK_TEST_QUOTE = (() => {
 const app = express();
 const PORT = 3000;
 
+const MONITORING_DEFAULT_SYMBOLS = ['CPOOL_USDT', 'MAT_USDT', 'FARM_USDT'];
+const MONITORING_DEFAULT_LABELS = {
+  CPOOL_USDT: 'Clearpool',
+  MAT_USDT: 'Mycelium',
+  FARM_USDT: 'Harvest Finance'
+};
+
+const monitoringHttp = axios.create({
+  timeout: 9000,
+  headers: {
+    'User-Agent': 'ArbiSync-Monitor/1.0'
+  }
+});
+
 const SPOT_EXCHANGES = {
   gate: { key: 'gate', label: 'Gate.io' },
   bitget: { key: 'bitget', label: 'Bitget' }
@@ -3937,6 +3951,422 @@ async function pollOpenOrders() {
 setInterval(() => {
   pollOpenOrders().catch(err => console.error('[POLL]', err));
 }, 4000);
+
+function normalizeMonitoringSymbol(value) {
+  if (!value && value !== 0) return null;
+  const str = String(value).trim().toUpperCase();
+  if (!str) return null;
+  if (str.includes('-')) return str.replace(/-/g, '_');
+  if (str.includes('_')) return str;
+  const match = str.match(/^([A-Z0-9]+)(USDT)$/);
+  if (match) return `${match[1]}_${match[2]}`;
+  return str;
+}
+
+function buildSymbolMeta(raw) {
+  const normalized = normalizeMonitoringSymbol(raw);
+  if (!normalized) return null;
+  const [base, quote] = normalized.split('_');
+  if (!base || !quote) return null;
+  const baseUpper = base.toUpperCase();
+  const quoteUpper = quote.toUpperCase();
+  const compact = `${baseUpper}${quoteUpper}`;
+  return {
+    symbol: `${baseUpper}_${quoteUpper}`,
+    base: baseUpper,
+    quote: quoteUpper,
+    compact,
+    dashed: `${baseUpper}-${quoteUpper}`,
+    gateSpot: `${baseUpper}_${quoteUpper}`,
+    gateFutures: `${baseUpper}_${quoteUpper}`,
+    mexcSpot: `${baseUpper}${quoteUpper}`,
+    mexcFutures: `${baseUpper}_${quoteUpper}`,
+    bitgetSpot: `${compact}_SPBL`,
+    bitgetFutures: `${compact}_UMCBL`,
+    kucoinFutures: `${compact}M`,
+    bybit: compact
+  };
+}
+
+function toNumber(value) {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+}
+
+function describeAxiosError(err) {
+  if (!err) return 'erro desconhecido';
+  if (err.response) {
+    const { status, statusText, data } = err.response;
+    const prefix = [status, statusText].filter(Boolean).join(' ').trim();
+    if (typeof data === 'string') {
+      return [prefix, data.slice(0, 160)].filter(Boolean).join(' — ');
+    }
+    if (data && typeof data === 'object') {
+      return [prefix, JSON.stringify(data).slice(0, 160)].filter(Boolean).join(' — ');
+    }
+    return prefix || err.message || 'erro HTTP';
+  }
+  return err.message || String(err);
+}
+
+async function fetchGateSpotTicker(meta) {
+  const { data } = await monitoringHttp.get('https://api.gateio.ws/api/v4/spot/tickers', {
+    params: { currency_pair: meta.gateSpot }
+  });
+  const payload = Array.isArray(data) ? data[0] : data;
+  if (!payload) throw new Error('Resposta vazia');
+  return {
+    bid: toNumber(payload.highest_bid),
+    ask: toNumber(payload.lowest_ask),
+    last: toNumber(payload.last),
+    volume: toNumber(payload.quote_volume ?? payload.base_volume),
+    changePct: toNumber(payload.change_percentage)
+  };
+}
+
+async function fetchMexcSpotTicker(meta) {
+  const { data } = await monitoringHttp.get('https://api.mexc.com/api/v3/ticker/24hr', {
+    params: { symbol: meta.mexcSpot }
+  });
+  if (!data || data.code) throw new Error(data?.msg || 'Sem dados MEXC');
+  return {
+    bid: toNumber(data.bidPrice),
+    ask: toNumber(data.askPrice),
+    last: toNumber(data.lastPrice),
+    volume: toNumber(data.quoteVolume),
+    changePct: toNumber(data.priceChangePercent)
+  };
+}
+
+async function fetchBitgetSpotTicker(meta) {
+  const { data } = await monitoringHttp.get('https://api.bitget.com/api/spot/v1/market/ticker', {
+    params: { symbol: meta.bitgetSpot }
+  });
+  if (!data || data.code !== '00000' || !data.data) {
+    throw new Error(data?.msg || 'Erro Bitget spot');
+  }
+  const payload = data.data;
+  return {
+    bid: toNumber(payload.buyOne),
+    ask: toNumber(payload.sellOne),
+    last: toNumber(payload.close),
+    volume: toNumber(payload.usdtVol ?? payload.quoteVol),
+    changePct: toNumber(payload.change ?? payload.changeUtc)
+  };
+}
+
+async function fetchKucoinSpotTicker(meta) {
+  const { data } = await monitoringHttp.get('https://api.kucoin.com/api/v1/market/stats', {
+    params: { symbol: meta.dashed }
+  });
+  if (!data || data.code !== '200000' || !data.data) {
+    throw new Error(data?.msg || 'Erro KuCoin spot');
+  }
+  const payload = data.data;
+  return {
+    bid: toNumber(payload.buy),
+    ask: toNumber(payload.sell),
+    last: toNumber(payload.last),
+    volume: toNumber(payload.volValue),
+    changePct: toNumber(payload.changeRate) ? toNumber(payload.changeRate) * 100 : null
+  };
+}
+
+async function fetchBinanceSpotTicker(meta) {
+  const { data } = await monitoringHttp.get('https://data-api.binance.vision/api/v3/ticker/24hr', {
+    params: { symbol: meta.compact }
+  });
+  if (data?.code && data?.code !== 200) throw new Error(data.msg || 'Erro Binance spot');
+  if (!data?.lastPrice) throw new Error('Ticker indisponível');
+  return {
+    bid: toNumber(data.bidPrice),
+    ask: toNumber(data.askPrice),
+    last: toNumber(data.lastPrice),
+    volume: toNumber(data.quoteVolume),
+    changePct: toNumber(data.priceChangePercent)
+  };
+}
+
+async function fetchBybitSpotTicker(meta) {
+  const { data } = await monitoringHttp.get('https://api.bybit.com/v5/market/tickers', {
+    params: { category: 'spot', symbol: meta.bybit }
+  });
+  if (data?.retCode !== 0) throw new Error(data?.retMsg || 'Erro Bybit spot');
+  const first = data?.result?.list?.[0];
+  if (!first) throw new Error('Ticker não encontrado');
+  return {
+    bid: toNumber(first.bid1Price),
+    ask: toNumber(first.ask1Price),
+    last: toNumber(first.lastPrice),
+    volume: toNumber(first.turnover24h),
+    changePct: toNumber(first.price24hPcnt) ? toNumber(first.price24hPcnt) * 100 : null
+  };
+}
+
+async function fetchGateFuturesTicker(meta) {
+  const { data } = await monitoringHttp.get('https://api.gateio.ws/api/v4/futures/usdt/tickers', {
+    params: { contract: meta.gateFutures }
+  });
+  const payload = Array.isArray(data) ? data[0] : data;
+  if (!payload) throw new Error('Resposta vazia');
+  return {
+    bid: toNumber(payload.highest_bid),
+    ask: toNumber(payload.lowest_ask),
+    last: toNumber(payload.last),
+    volume: toNumber(payload.volume_24h_quote ?? payload.volume_24h),
+    fundingRate: toNumber(payload.funding_rate),
+    changePct: toNumber(payload.change_percentage)
+  };
+}
+
+async function fetchMexcFuturesTicker(meta) {
+  const { data } = await monitoringHttp.get('https://contract.mexc.com/api/v1/contract/ticker', {
+    params: { symbol: meta.mexcFutures }
+  });
+  if (!data || data.code !== 0 || !data.data) throw new Error(data?.msg || 'Erro MEXC futures');
+  const payload = data.data;
+  return {
+    bid: toNumber(payload.bid1),
+    ask: toNumber(payload.ask1),
+    last: toNumber(payload.lastPrice),
+    volume: toNumber(payload.amount24),
+    fundingRate: toNumber(payload.fundingRate),
+    changePct: toNumber(payload.riseFallRate) ? toNumber(payload.riseFallRate) * 100 : null
+  };
+}
+
+async function fetchBitgetFuturesTicker(meta) {
+  const { data } = await monitoringHttp.get('https://api.bitget.com/api/mix/v1/market/ticker', {
+    params: { symbol: meta.bitgetFutures }
+  });
+  if (!data || data.code !== '00000' || !data.data) {
+    throw new Error(data?.msg || 'Erro Bitget futures');
+  }
+  const payload = data.data;
+  return {
+    bid: toNumber(payload.bestBid),
+    ask: toNumber(payload.bestAsk),
+    last: toNumber(payload.last),
+    volume: toNumber(payload.quoteVolume ?? payload.usdtVolume),
+    fundingRate: toNumber(payload.fundingRate),
+    changePct: toNumber(payload.priceChangePercent)
+  };
+}
+
+async function fetchKucoinFuturesTicker(meta) {
+  const { data } = await monitoringHttp.get('https://api-futures.kucoin.com/api/v1/ticker', {
+    params: { symbol: meta.kucoinFutures }
+  });
+  if (!data || data.code !== '200000' || !data.data) {
+    throw new Error(data?.msg || 'Erro KuCoin futures');
+  }
+  const payload = data.data;
+  return {
+    bid: toNumber(payload.bestBidPrice),
+    ask: toNumber(payload.bestAskPrice),
+    last: toNumber(payload.price),
+    volume: toNumber(payload.turnover),
+    fundingRate: toNumber(payload.fundingRate),
+    changePct: toNumber(payload.changeRate) ? toNumber(payload.changeRate) * 100 : null
+  };
+}
+
+async function fetchBinanceFuturesTicker(meta) {
+  const { data } = await monitoringHttp.get('https://fapi.binance.com/fapi/v1/ticker/24hr', {
+    params: { symbol: meta.compact }
+  });
+  if (data?.code && data?.code !== 200) throw new Error(data.msg || 'Erro Binance futures');
+  if (!data?.lastPrice) throw new Error('Ticker indisponível');
+  return {
+    bid: toNumber(data.bidPrice),
+    ask: toNumber(data.askPrice),
+    last: toNumber(data.lastPrice),
+    volume: toNumber(data.quoteVolume),
+    fundingRate: null,
+    changePct: toNumber(data.priceChangePercent)
+  };
+}
+
+async function fetchBybitFuturesTicker(meta) {
+  const { data } = await monitoringHttp.get('https://api.bybit.com/v5/market/tickers', {
+    params: { category: 'linear', symbol: meta.bybit }
+  });
+  if (data?.retCode !== 0) throw new Error(data?.retMsg || 'Erro Bybit futures');
+  const payload = data?.result?.list?.[0];
+  if (!payload) throw new Error('Ticker não encontrado');
+  return {
+    bid: toNumber(payload.bid1Price),
+    ask: toNumber(payload.ask1Price),
+    last: toNumber(payload.lastPrice),
+    volume: toNumber(payload.turnover24h),
+    fundingRate: toNumber(payload.fundingRate),
+    changePct: toNumber(payload.price24hPcnt) ? toNumber(payload.price24hPcnt) * 100 : null
+  };
+}
+
+const monitoringSpotProviders = [
+  { key: 'gate_spot', label: 'Gate.io', type: 'spot', fetch: fetchGateSpotTicker },
+  { key: 'mexc_spot', label: 'MEXC', type: 'spot', fetch: fetchMexcSpotTicker },
+  { key: 'bitget_spot', label: 'Bitget', type: 'spot', fetch: fetchBitgetSpotTicker },
+  { key: 'kucoin_spot', label: 'KuCoin', type: 'spot', fetch: fetchKucoinSpotTicker },
+  { key: 'binance_spot', label: 'Binance', type: 'spot', fetch: fetchBinanceSpotTicker },
+  { key: 'bybit_spot', label: 'Bybit', type: 'spot', fetch: fetchBybitSpotTicker }
+];
+
+const monitoringFuturesProviders = [
+  { key: 'gate_futures', label: 'Gate.io Futures', type: 'futures', fetch: fetchGateFuturesTicker },
+  { key: 'mexc_futures', label: 'MEXC Futures', type: 'futures', fetch: fetchMexcFuturesTicker },
+  { key: 'bitget_futures', label: 'Bitget Futures', type: 'futures', fetch: fetchBitgetFuturesTicker },
+  { key: 'kucoin_futures', label: 'KuCoin Futures', type: 'futures', fetch: fetchKucoinFuturesTicker },
+  { key: 'binance_futures', label: 'Binance Futures', type: 'futures', fetch: fetchBinanceFuturesTicker },
+  { key: 'bybit_futures', label: 'Bybit Futures', type: 'futures', fetch: fetchBybitFuturesTicker }
+];
+
+async function fetchMonitoringTicker(provider, meta) {
+  try {
+    const payload = await provider.fetch(meta);
+    return { key: provider.key, exchange: provider.label, type: provider.type, symbol: meta.symbol, ...payload };
+  } catch (err) {
+    return {
+      key: provider.key,
+      exchange: provider.label,
+      type: provider.type,
+      symbol: meta.symbol,
+      error: describeAxiosError(err)
+    };
+  }
+}
+
+function pickBestSpot(tickers) {
+  return tickers
+    .filter((ticker) => !ticker.error && Number.isFinite(ticker.ask) && ticker.ask > 0)
+    .reduce((best, ticker) => (!best || ticker.ask < best.ask ? ticker : best), null);
+}
+
+function pickBestFutures(tickers) {
+  return tickers
+    .filter((ticker) => !ticker.error && Number.isFinite(ticker.bid))
+    .reduce((best, ticker) => (!best || ticker.bid > best.bid ? ticker : best), null);
+}
+
+function buildMonitoringMetrics(spotTickers, futuresTickers, historyPoints) {
+  const bestSpot = pickBestSpot(spotTickers);
+  const bestFutures = pickBestFutures(futuresTickers);
+  let arbPct = null;
+  if (bestSpot && bestFutures && bestSpot.ask > 0) {
+    arbPct = ((bestFutures.bid - bestSpot.ask) / bestSpot.ask) * 100;
+  }
+  const volume24h = spotTickers.reduce((acc, ticker) => acc + (Number.isFinite(ticker.volume) ? ticker.volume : 0), 0);
+  const fundingRates = futuresTickers
+    .map((ticker) => ticker.fundingRate)
+    .filter((value) => Number.isFinite(value));
+  const fundingRate = fundingRates.length ? fundingRates.reduce((sum, value) => sum + value, 0) / fundingRates.length : null;
+  const arbValues = historyPoints.map((point) => toNumber(point.arbPct)).filter((value) => Number.isFinite(value));
+  const volatilityPct = arbValues.length ? Math.max(...arbValues) - Math.min(...arbValues) : null;
+  const stability = Number.isFinite(volatilityPct) ? (volatilityPct > 6 ? 'Volátil' : 'Estável') : 'Indefinido';
+  let riskLabel = 'Indefinido';
+  if (Number.isFinite(volatilityPct)) {
+    if (volatilityPct > 10) riskLabel = 'Alto';
+    else if (volatilityPct > 5) riskLabel = 'Médio';
+    else riskLabel = 'Baixo';
+  }
+  const depthLabel = volume24h >= 1_000_000 ? 'Alta' : volume24h >= 300_000 ? 'Média' : 'Baixa';
+  return {
+    arbPct,
+    bestSpotExchange: bestSpot?.exchange || null,
+    bestFuturesExchange: bestFutures?.exchange || null,
+    volume24h,
+    depthLabel,
+    fundingRate,
+    volatilityPct,
+    stability,
+    riskLabel
+  };
+}
+
+async function fetchArbHistory(meta) {
+  try {
+    const [spotResp, futuresResp] = await Promise.all([
+      monitoringHttp.get('https://api.gateio.ws/api/v4/spot/candlesticks', {
+        params: { currency_pair: meta.gateSpot, interval: '1h', limit: 24 }
+      }),
+      monitoringHttp.get('https://api.gateio.ws/api/v4/futures/usdt/candlesticks', {
+        params: { contract: meta.gateFutures, interval: '1h', limit: 24 }
+      })
+    ]);
+    const spotCandles = Array.isArray(spotResp.data) ? spotResp.data : [];
+    const futuresCandles = Array.isArray(futuresResp.data) ? futuresResp.data : [];
+    const futuresByTs = new Map();
+    for (const candle of futuresCandles) {
+      const ts = Number(candle?.t);
+      if (Number.isFinite(ts)) futuresByTs.set(ts, candle);
+    }
+    const points = [];
+    for (const entry of spotCandles) {
+      const ts = Number(entry?.[0]);
+      if (!Number.isFinite(ts)) continue;
+      const futuresEntry = futuresByTs.get(ts);
+      if (!futuresEntry) continue;
+      const spotOpen = toNumber(entry?.[5]);
+      const spotClose = toNumber(entry?.[2]);
+      const futuresOpen = toNumber(futuresEntry?.o);
+      const futuresClose = toNumber(futuresEntry?.c);
+      if (!Number.isFinite(spotClose) || !Number.isFinite(futuresClose) || spotClose <= 0) continue;
+      const closeArb = ((futuresClose - spotClose) / spotClose) * 100;
+      const openArb = Number.isFinite(spotOpen) && Number.isFinite(futuresOpen) && spotOpen > 0
+        ? ((futuresOpen - spotOpen) / spotOpen) * 100
+        : closeArb;
+      points.push({
+        timestamp: ts * 1000,
+        arbPct: Number(closeArb.toFixed(4)),
+        openArbPct: Number(openArb.toFixed(4)),
+        spotVolume: toNumber(entry?.[6] ?? entry?.[1]),
+        futuresVolume: toNumber(futuresEntry?.sum ?? futuresEntry?.v)
+      });
+    }
+    points.sort((a, b) => a.timestamp - b.timestamp);
+    return points;
+  } catch (err) {
+    console.warn('[monitoring] histórico indisponível', meta.symbol, err.message || err);
+    return [];
+  }
+}
+
+async function fetchMonitoringSymbol(symbolInput) {
+  const meta = buildSymbolMeta(symbolInput);
+  if (!meta) return { symbol: null, error: 'Símbolo inválido' };
+  const [spot, futures, history] = await Promise.all([
+    Promise.all(monitoringSpotProviders.map((provider) => fetchMonitoringTicker(provider, meta))),
+    Promise.all(monitoringFuturesProviders.map((provider) => fetchMonitoringTicker(provider, meta))),
+    fetchArbHistory(meta)
+  ]);
+  return {
+    symbol: meta.symbol,
+    label: MONITORING_DEFAULT_LABELS[meta.symbol] || meta.symbol,
+    spot,
+    futures,
+    metrics: buildMonitoringMetrics(spot, futures, history),
+    history: { interval: '1h', source: 'Gate.io', points: history }
+  };
+}
+
+app.get('/api/monitoring/markets', async (req, res) => {
+  try {
+    const symbolsParam = String(req.query.symbols || '').trim();
+    const requested = symbolsParam
+      ? symbolsParam.split(',').map((s) => normalizeMonitoringSymbol(s)).filter(Boolean)
+      : MONITORING_DEFAULT_SYMBOLS;
+    const uniqueSymbols = Array.from(new Set(requested));
+    if (!uniqueSymbols.length) {
+      return res.json({ updatedAt: new Date().toISOString(), symbols: [] });
+    }
+    const results = await Promise.all(uniqueSymbols.map((symbol) => fetchMonitoringSymbol(symbol)));
+    res.json({ updatedAt: new Date().toISOString(), symbols: results });
+  } catch (err) {
+    console.error('[monitoring] erro ao coletar mercados', err);
+    res.status(500).json({ error: err.message || err });
+  }
+});
 
 app.get('/api/history', async (_req, res) => {
   try { await pollOpenOrders(); } catch {}

--- a/server.js
+++ b/server.js
@@ -4469,10 +4469,22 @@ async function fetchMexcFuturesTicker(meta) {
   if (!data || data.code !== 0 || !data.data) throw new Error(data?.msg || 'Erro MEXC futures');
   const payload = data.data;
 
+  let contractSize = 1;
+  try {
+    const mergedMeta = await getMergedMeta(meta.symbol);
+    contractSize = Number(mergedMeta?.mexc?.contractSize) || 1;
+  } catch (err) {
+    console.warn('[monitoring] falha ao obter contractSize MEXC', meta.symbol, err?.message || err);
+  }
+  const toBaseSize = (contracts) => {
+    const num = toNumber(contracts);
+    return Number.isFinite(num) && num > 0 ? num * contractSize : null;
+  };
+
   let bid = toNumber(payload.bid1);
   let ask = toNumber(payload.ask1);
-  let bidSize = toNumber(payload.bid1Size ?? payload.bidVol ?? payload.turnover ?? payload.amount24);
-  let askSize = toNumber(payload.ask1Size ?? payload.askVol ?? payload.turnover ?? payload.amount24);
+  let bidSize = toBaseSize(payload.bid1Size ?? payload.bidVol);
+  let askSize = toBaseSize(payload.ask1Size ?? payload.askVol);
 
   if (!Number.isFinite(bidSize) || bidSize <= 0 || !Number.isFinite(askSize) || askSize <= 0) {
     try {
@@ -4482,12 +4494,18 @@ async function fetchMexcFuturesTicker(meta) {
       const bids = Array.isArray(depth?.data?.bids) ? depth.data.bids : [];
       const asks = Array.isArray(depth?.data?.asks) ? depth.data.asks : [];
       if (bids.length) {
-        bid = toNumber(bids[0].price) ?? bid;
-        bidSize = toNumber(bids[0].vol ?? bids[0].amount) ?? bidSize;
+        const bidPrice = toNumber(bids[0].price ?? bids[0][0]);
+        const bidContracts = toNumber(bids[0].vol ?? bids[0].amount ?? bids[0][1]);
+        bid = bidPrice ?? bid;
+        const depthBidSize = toBaseSize(bidContracts);
+        bidSize = Number.isFinite(depthBidSize) ? depthBidSize : bidSize;
       }
       if (asks.length) {
-        ask = toNumber(asks[0].price) ?? ask;
-        askSize = toNumber(asks[0].vol ?? asks[0].amount) ?? askSize;
+        const askPrice = toNumber(asks[0].price ?? asks[0][0]);
+        const askContracts = toNumber(asks[0].vol ?? asks[0].amount ?? asks[0][1]);
+        ask = askPrice ?? ask;
+        const depthAskSize = toBaseSize(askContracts);
+        askSize = Number.isFinite(depthAskSize) ? depthAskSize : askSize;
       }
     } catch (err) {
       const status = err?.response?.status;

--- a/server.js
+++ b/server.js
@@ -4419,7 +4419,7 @@ async function fetchMexcFuturesTicker(meta) {
     bid: toNumber(payload.bid1),
     ask: toNumber(payload.ask1),
     last: toNumber(payload.lastPrice),
-    volume: toNumber(payload.amount24),
+    volume: toNumber(payload.turnover24 ?? payload.amount24),
     bidSize: toNumber(payload.bid1Size),
     askSize: toNumber(payload.ask1Size),
     bidNotional: computeNotional(toNumber(payload.bid1), toNumber(payload.bid1Size)),

--- a/server.js
+++ b/server.js
@@ -4635,6 +4635,167 @@ function findFuturesProvider(key) {
   return monitoringFuturesProviders.find((provider) => provider.key === key);
 }
 
+async function fetchGateTopSpotAssets() {
+  const { data } = await monitoringHttp.get('https://api.gateio.ws/api/v4/spot/tickers');
+  return (Array.isArray(data) ? data : [])
+    .map((item) => ({ symbol: normalizeMonitoringSymbol(item.currency_pair), volume: toNumber(item.quote_volume ?? item.base_volume) }))
+    .filter((item) => item.symbol && item.symbol.endsWith('_USDT') && Number.isFinite(item.volume));
+}
+
+async function fetchGateTopFuturesAssets() {
+  const { data } = await monitoringHttp.get('https://api.gateio.ws/api/v4/futures/usdt/tickers');
+  return (Array.isArray(data) ? data : [])
+    .map((item) => ({ symbol: normalizeMonitoringSymbol(item.contract), volume: toNumber(item.volume_usd ?? item.volume_quote ?? item.volume) }))
+    .filter((item) => item.symbol && item.symbol.endsWith('_USDT') && Number.isFinite(item.volume));
+}
+
+async function fetchMexcTopSpotAssets() {
+  const { data } = await monitoringHttp.get('https://api.mexc.com/api/v3/ticker/24hr');
+  return (Array.isArray(data) ? data : [])
+    .map((item) => ({ symbol: normalizeMonitoringSymbol(item.symbol), volume: toNumber(item.quoteVolume ?? item.volume)) })
+    .filter((item) => item.symbol && item.symbol.endsWith('_USDT') && Number.isFinite(item.volume));
+}
+
+async function fetchMexcTopFuturesAssets() {
+  const { data } = await monitoringHttp.get('https://contract.mexc.com/api/v1/contract/ticker');
+  const list = Array.isArray(data?.data) ? data.data : [];
+  return list
+    .map((item) => ({ symbol: normalizeMonitoringSymbol(item.symbol), volume: toNumber(item.amount24 ?? item.volume)) })
+    .filter((item) => item.symbol && item.symbol.endsWith('_USDT') && Number.isFinite(item.volume));
+}
+
+async function fetchBitgetTopSpotAssets() {
+  const { data } = await monitoringHttp.get('https://api.bitget.com/api/spot/v1/market/tickers');
+  const list = Array.isArray(data?.data) ? data.data : [];
+  return list
+    .map((item) => ({ symbol: normalizeMonitoringSymbol(item.symbol), volume: toNumber(item.usdtVolume ?? item.quoteVolume ?? item.baseVolume) }))
+    .filter((item) => item.symbol && item.symbol.endsWith('_USDT') && Number.isFinite(item.volume));
+}
+
+async function fetchBitgetTopFuturesAssets() {
+  const { data } = await monitoringHttp.get('https://api.bitget.com/api/mix/v1/market/tickers', { params: { productType: 'umcbl' } });
+  const list = Array.isArray(data?.data) ? data.data : [];
+  return list
+    .map((item) => ({ symbol: normalizeMonitoringSymbol(item.symbol), volume: toNumber(item.usdtVolume ?? item.quoteVolume)) })
+    .filter((item) => item.symbol && item.symbol.endsWith('_USDT') && Number.isFinite(item.volume));
+}
+
+async function fetchKucoinTopSpotAssets() {
+  const { data } = await monitoringHttp.get('https://api.kucoin.com/api/v1/market/allTickers');
+  const list = Array.isArray(data?.data?.ticker) ? data.data.ticker : [];
+  return list
+    .map((item) => ({ symbol: normalizeMonitoringSymbol(item.symbol), volume: toNumber(item.volValue || item.vol)) })
+    .filter((item) => item.symbol && item.symbol.endsWith('_USDT') && Number.isFinite(item.volume));
+}
+
+async function fetchKucoinTopFuturesAssets() {
+  const { data } = await monitoringHttp.get('https://api-futures.kucoin.com/api/v1/allTickers');
+  const list = Array.isArray(data?.data?.ticker) ? data.data.ticker : [];
+  return list
+    .map((item) => ({ symbol: normalizeMonitoringSymbol(item.symbol), volume: toNumber(item.turnover ?? item.turnoverValue)) })
+    .filter((item) => item.symbol && item.symbol.endsWith('_USDT') && Number.isFinite(item.volume));
+}
+
+async function fetchBinanceTopSpotAssets() {
+  const { data } = await monitoringHttp.get('https://data-api.binance.vision/api/v3/ticker/24hr');
+  return (Array.isArray(data) ? data : [])
+    .map((item) => ({ symbol: normalizeMonitoringSymbol(item.symbol), volume: toNumber(item.quoteVolume ?? item.volume)) })
+    .filter((item) => item.symbol && item.symbol.endsWith('_USDT') && Number.isFinite(item.volume));
+}
+
+async function fetchBinanceTopFuturesAssets() {
+  const { data } = await monitoringHttp.get('https://fapi.binance.com/fapi/v1/ticker/24hr');
+  return (Array.isArray(data) ? data : [])
+    .map((item) => ({ symbol: normalizeMonitoringSymbol(item.symbol), volume: toNumber(item.quoteVolume ?? item.volume)) })
+    .filter((item) => item.symbol && item.symbol.endsWith('_USDT') && Number.isFinite(item.volume));
+}
+
+async function fetchBybitTopSpotAssets() {
+  const { data } = await monitoringHttp.get('https://api.bybit.com/v5/market/tickers', { params: { category: 'spot' } });
+  const list = Array.isArray(data?.result?.list) ? data.result.list : [];
+  return list
+    .map((item) => ({ symbol: normalizeMonitoringSymbol(item.symbol), volume: toNumber(item.qv ?? item.qv24h ?? item.volume)) })
+    .filter((item) => item.symbol && item.symbol.endsWith('_USDT') && Number.isFinite(item.volume));
+}
+
+async function fetchBybitTopFuturesAssets() {
+  const { data } = await monitoringHttp.get('https://api.bybit.com/v5/market/tickers', { params: { category: 'linear' } });
+  const list = Array.isArray(data?.result?.list) ? data.result.list : [];
+  return list
+    .map((item) => ({ symbol: normalizeMonitoringSymbol(item.symbol), volume: toNumber(item.turnover24h ?? item.turnover ?? item.volume)) })
+    .filter((item) => item.symbol && item.symbol.endsWith('_USDT') && Number.isFinite(item.volume));
+}
+
+const TOP_ASSET_LIMIT = 60;
+const topAssetProviders = [
+  { key: 'gate_spot', label: 'Gate.io Spot', type: 'spot', list: fetchGateTopSpotAssets },
+  { key: 'mexc_spot', label: 'MEXC Spot', type: 'spot', list: fetchMexcTopSpotAssets },
+  { key: 'bitget_spot', label: 'Bitget Spot', type: 'spot', list: fetchBitgetTopSpotAssets },
+  { key: 'kucoin_spot', label: 'KuCoin Spot', type: 'spot', list: fetchKucoinTopSpotAssets },
+  { key: 'binance_spot', label: 'Binance Spot', type: 'spot', list: fetchBinanceTopSpotAssets },
+  { key: 'bybit_spot', label: 'Bybit Spot', type: 'spot', list: fetchBybitTopSpotAssets },
+  { key: 'gate_futures', label: 'Gate.io Futures', type: 'futures', list: fetchGateTopFuturesAssets },
+  { key: 'mexc_futures', label: 'MEXC Futures', type: 'futures', list: fetchMexcTopFuturesAssets },
+  { key: 'bitget_futures', label: 'Bitget Futures', type: 'futures', list: fetchBitgetTopFuturesAssets },
+  { key: 'kucoin_futures', label: 'KuCoin Futures', type: 'futures', list: fetchKucoinTopFuturesAssets },
+  { key: 'binance_futures', label: 'Binance Futures', type: 'futures', list: fetchBinanceTopFuturesAssets },
+  { key: 'bybit_futures', label: 'Bybit Futures', type: 'futures', list: fetchBybitTopFuturesAssets }
+];
+
+function findTopAssetProvider(key) {
+  return topAssetProviders.find((provider) => provider.key === key);
+}
+
+async function collectTopAssets(provider) {
+  try {
+    const assets = await provider.list();
+    return { provider, assets, error: null };
+  } catch (err) {
+    return { provider, assets: [], error: describeAxiosError(err) };
+  }
+}
+
+async function buildTopAssetsResponse(selectedKeys) {
+  const providers = selectedKeys?.length
+    ? selectedKeys.map((key) => findTopAssetProvider(key)).filter(Boolean)
+    : topAssetProviders;
+  if (!providers.length) return { assets: [], errors: [] };
+  const responses = await Promise.all(providers.map((provider) => collectTopAssets(provider)));
+  const merged = new Map();
+  for (const { provider, assets } of responses) {
+    for (const asset of assets) {
+      const meta = buildSymbolMeta(asset.symbol);
+      if (!meta || !meta.quote || meta.quote !== 'USDT') continue;
+      const current = merged.get(meta.symbol) || {
+        symbol: meta.symbol,
+        label: MONITORING_DEFAULT_LABELS?.[meta.symbol] || meta.symbol,
+        exchanges: new Set(),
+        volumes: [],
+        bestVolume: 0
+      };
+      current.exchanges.add(provider.label);
+      if (Number.isFinite(asset.volume)) {
+        current.volumes.push({ exchange: provider.label, volume: asset.volume });
+        current.bestVolume = Math.max(current.bestVolume, asset.volume);
+      }
+      merged.set(meta.symbol, current);
+    }
+  }
+  const assets = Array.from(merged.values())
+    .map((item) => ({
+      ...item,
+      exchanges: Array.from(item.exchanges).sort(),
+      volumes: item.volumes.sort((a, b) => (b.volume || 0) - (a.volume || 0))
+    }))
+    .sort((a, b) => (b.bestVolume || 0) - (a.bestVolume || 0))
+    .slice(0, TOP_ASSET_LIMIT);
+  const errors = responses.filter((entry) => entry.error).map((entry) => ({
+    provider: entry.provider?.label || entry.provider?.key,
+    error: entry.error
+  }));
+  return { assets, errors, exchanges: providers.map((p) => p.key) };
+}
+
 async function fetchHistoryDataset(provider, meta, intervalKey, limit) {
   if (!provider || typeof provider.history !== 'function') {
     return { candles: [], error: 'Histórico não disponível para esta corretora' };
@@ -4831,6 +4992,20 @@ app.get('/api/monitoring/history', async (req, res) => {
     });
   } catch (err) {
     console.error('[monitoring] erro ao montar histórico', err);
+    res.status(500).json({ error: err.message || err });
+  }
+});
+
+app.get('/api/monitoring/top-assets', async (req, res) => {
+  try {
+    const selected = String(req.query.exchanges || '')
+      .split(',')
+      .map((key) => key.trim())
+      .filter(Boolean);
+    const result = await buildTopAssetsResponse(selected);
+    res.json({ ...result, updatedAt: new Date().toISOString() });
+  } catch (err) {
+    console.error('[monitoring] erro ao buscar ativos mais negociados', err);
     res.status(500).json({ error: err.message || err });
   }
 });

--- a/server.js
+++ b/server.js
@@ -21,13 +21,6 @@ const DEFAULT_RISK_TEST_QUOTE = (() => {
 const app = express();
 const PORT = 3000;
 
-const MONITORING_DEFAULT_SYMBOLS = DEFAULT_MONITORING_SYMBOLS.map((item) => item.symbol);
-const MONITORING_DEFAULT_LABELS = {
-  CPOOL_USDT: 'Clearpool',
-  MAT_USDT: 'Mycelium',
-  FARM_USDT: 'Harvest Finance'
-};
-
 const monitoringHttp = axios.create({
   timeout: 9000,
   headers: {
@@ -87,6 +80,12 @@ const DEFAULT_MONITORING_SYMBOLS = [
   { symbol: 'MAT_USDT', meta: { name: 'Mycelium', risk: 'Médio', spotHint: ['Gate.io', 'KuCoin'], futuresHint: ['Bybit', 'MEXC Futures'] } },
   { symbol: 'FARM_USDT', meta: { name: 'Harvest Finance', risk: 'Baixo', spotHint: ['Gate.io', 'Binance'], futuresHint: ['MEXC Futures'] } }
 ];
+const MONITORING_DEFAULT_SYMBOLS = DEFAULT_MONITORING_SYMBOLS.map((item) => item.symbol);
+const MONITORING_DEFAULT_LABELS = {
+  CPOOL_USDT: 'Clearpool',
+  MAT_USDT: 'Mycelium',
+  FARM_USDT: 'Harvest Finance'
+};
 let monitoringSymbolMeta = new Map();
 
 let orderHistory = [];

--- a/server.js
+++ b/server.js
@@ -1774,8 +1774,10 @@ app.post('/api/symbol', async (req, res) => {
 
 // ===== /api/data — ask/bid de Gate e bid/ask de MEXC + diffs para open/close
 app.get('/api/data', async (req, res) => {
+  let requestedSymbol = null;
+  let debugSpotExchange = null;
   try {
-    const requestedSymbol = String(req.query.symbol || currentSymbol || '').toUpperCase();
+    requestedSymbol = String(req.query.symbol || currentSymbol || '').toUpperCase();
     if (!requestedSymbol) {
       return res.status(400).json({ error: 'Símbolo inválido.' });
     }
@@ -1786,6 +1788,7 @@ app.get('/api/data', async (req, res) => {
       ? normalizeSpotExchange(req.query.spotExchange)
       : (positionState?.spotExchange || currentSpotExchange);
     const spotInfo = getSpotInfo(requestedSpot);
+    debugSpotExchange = spotInfo.normalized;
     const { asks: spotAsksRaw, bids: spotBidsRaw } = await fetchSpotOrderBook(requestedSymbol, 5, spotInfo.normalized);
     const m = await axios.get(`https://contract.mexc.com/api/v1/contract/depth/${requestedSymbol}?limit=5`);
 
@@ -1965,7 +1968,11 @@ app.get('/api/data', async (req, res) => {
       close: { diff: closeLevels[0]?.diffPct ?? null, levels: closeLevels }
     });
   } catch (e) {
-    console.error('[ERRO /api/data]:', e.response?.data || e.message);
+    console.error(
+      '[ERRO /api/data]:',
+      requestedSymbol ? `${requestedSymbol} spot=${debugSpotExchange || 'desconhecido'}` : 'símbolo não definido',
+      describeAxiosError(e)
+    );
     res.status(500).json({ error: 'Erro ao obter dados.' });
   }
 });
@@ -4843,8 +4850,13 @@ async function fetchHistoryDataset(provider, meta, intervalKey, limit) {
     const candles = await provider.history(meta, intervalKey, limit);
     return { candles, error: null };
   } catch (err) {
-    console.warn(`[monitoring] histórico ${provider.key} falhou`, err?.message || err);
-    return { candles: [], error: err?.message || String(err) };
+    const human = describeAxiosError(err);
+    console.warn(
+      `[monitoring] histórico ${provider.key} falhou`,
+      `${meta.symbol} (intervalo=${intervalKey}, candles=${limit}) —`,
+      human
+    );
+    return { candles: [], error: human };
   }
 }
 
@@ -4954,7 +4966,11 @@ async function fetchArbHistory(meta) {
     points.sort((a, b) => a.timestamp - b.timestamp);
     return points;
   } catch (err) {
-    console.warn('[monitoring] histórico indisponível', meta.symbol, err.message || err);
+    console.warn(
+      '[monitoring] histórico indisponível',
+      `${meta.symbol} (Gate spot=${meta.gateSpot}, futures=${meta.gateFutures}, intervalo=1h, candles=24)`,
+      describeAxiosError(err)
+    );
     return [];
   }
 }

--- a/server.js
+++ b/server.js
@@ -4009,6 +4009,171 @@ function describeAxiosError(err) {
   return err.message || String(err);
 }
 
+const MONITORING_HISTORY_INTERVALS = {
+  '1m': {
+    label: '1 minuto',
+    minutes: 1,
+    gate: '1m',
+    mexc: '1m',
+    mexcFutures: 'Min1',
+    bitget: '1min',
+    bitgetFutures: '1m',
+    kucoin: '1min',
+    kucoinFutures: 1 * 60,
+    binance: '1m',
+    bybit: '1'
+  },
+  '5m': {
+    label: '5 minutos',
+    minutes: 5,
+    gate: '5m',
+    mexc: '5m',
+    mexcFutures: 'Min5',
+    bitget: '5min',
+    bitgetFutures: '5m',
+    kucoin: '5min',
+    kucoinFutures: 5 * 60,
+    binance: '5m',
+    bybit: '5'
+  },
+  '15m': {
+    label: '15 minutos',
+    minutes: 15,
+    gate: '15m',
+    mexc: '15m',
+    mexcFutures: 'Min15',
+    bitget: '15min',
+    bitgetFutures: '15m',
+    kucoin: '15min',
+    kucoinFutures: 15 * 60,
+    binance: '15m',
+    bybit: '15'
+  },
+  '30m': {
+    label: '30 minutos',
+    minutes: 30,
+    gate: '30m',
+    mexc: '30m',
+    mexcFutures: 'Min30',
+    bitget: '30min',
+    bitgetFutures: '30m',
+    kucoin: '30min',
+    kucoinFutures: 30 * 60,
+    binance: '30m',
+    bybit: '30'
+  },
+  '1h': {
+    label: '1 hora',
+    minutes: 60,
+    gate: '1h',
+    mexc: '1h',
+    mexcFutures: 'Min60',
+    bitget: '1hour',
+    bitgetFutures: '1h',
+    kucoin: '1hour',
+    kucoinFutures: 60 * 60,
+    binance: '1h',
+    bybit: '60'
+  },
+  '4h': {
+    label: '4 horas',
+    minutes: 240,
+    gate: '4h',
+    mexc: '4h',
+    mexcFutures: 'Hour4',
+    bitget: '4hour',
+    bitgetFutures: '4h',
+    kucoin: '4hour',
+    kucoinFutures: 240 * 60,
+    binance: '4h',
+    bybit: '240'
+  }
+};
+
+const MONITORING_HISTORY_DEFAULT_INTERVAL = '1h';
+
+function getHistoryIntervalConfig(key) {
+  return MONITORING_HISTORY_INTERVALS[key] || MONITORING_HISTORY_INTERVALS[MONITORING_HISTORY_DEFAULT_INTERVAL];
+}
+
+function computeHistoryLimit(intervalKey) {
+  const interval = getHistoryIntervalConfig(intervalKey);
+  const desired = Math.ceil((24 * 60) / interval.minutes);
+  return desired;
+}
+
+function computeHistoryWindow(intervalKey, limit) {
+  const interval = getHistoryIntervalConfig(intervalKey);
+  const seconds = interval.minutes * 60 * limit;
+  const end = Math.floor(Date.now() / 1000);
+  const start = Math.max(0, end - seconds);
+  return { start, end };
+}
+
+function toMsTimestamp(value) {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return null;
+  return num < 1e12 ? num * 1000 : num;
+}
+
+function normalizeHistoryPoint({ timestamp, open, close, volume }) {
+  const ts = toMsTimestamp(timestamp);
+  const o = toNumber(open);
+  const c = toNumber(close);
+  const v = toNumber(volume);
+  if (!Number.isFinite(ts) || !Number.isFinite(o) || !Number.isFinite(c)) return null;
+  return { timestamp: ts, open: o, close: c, volume: Number.isFinite(v) ? v : null };
+}
+
+function sortHistoryPoints(points) {
+  return points.sort((a, b) => a.timestamp - b.timestamp);
+}
+
+function bucketizeHistoryCandles(candles, bucketMs) {
+  const map = new Map();
+  for (const candle of candles) {
+    const bucket = Math.floor(candle.timestamp / bucketMs) * bucketMs;
+    if (!Number.isFinite(bucket)) continue;
+    map.set(bucket, candle);
+  }
+  return map;
+}
+
+function computeArbPct(futuresPrice, spotPrice) {
+  if (!Number.isFinite(futuresPrice) || !Number.isFinite(spotPrice) || spotPrice === 0) return null;
+  return ((futuresPrice - spotPrice) / spotPrice) * 100;
+}
+
+function buildHistorySeries(spotCandles, futuresCandles, intervalMinutes) {
+  if (!spotCandles.length || !futuresCandles.length) return [];
+  const bucketMs = intervalMinutes * 60 * 1000;
+  const futuresMap = bucketizeHistoryCandles(futuresCandles, bucketMs);
+  const points = [];
+  for (const spot of spotCandles) {
+    const bucket = Math.floor(spot.timestamp / bucketMs) * bucketMs;
+    const futures = futuresMap.get(bucket);
+    if (!futures) continue;
+    const openArb = computeArbPct(futures.open, spot.open);
+    const closeArb = computeArbPct(futures.close, spot.close);
+    if (!Number.isFinite(closeArb)) continue;
+    points.push({
+      timestamp: bucket,
+      openArbPct: Number.isFinite(openArb) ? Number(openArb.toFixed(4)) : Number(closeArb.toFixed(4)),
+      closeArbPct: Number(Number(closeArb).toFixed(4)),
+      spotVolume: spot.volume,
+      futuresVolume: futures.volume
+    });
+  }
+  return sortHistoryPoints(points);
+}
+
+function limitHistoryPoints(points, limit) {
+  if (!Array.isArray(points)) return [];
+  const sorted = sortHistoryPoints(points);
+  if (!Number.isFinite(limit) || limit <= 0 || sorted.length <= limit) return sorted;
+  return sorted.slice(sorted.length - limit);
+}
+
 async function fetchGateSpotTicker(meta) {
   const { data } = await monitoringHttp.get('https://api.gateio.ws/api/v4/spot/tickers', {
     params: { currency_pair: meta.gateSpot }
@@ -4204,23 +4369,241 @@ async function fetchBybitFuturesTicker(meta) {
   };
 }
 
+async function fetchGateSpotHistory(meta, intervalKey, limit) {
+  const interval = getHistoryIntervalConfig(intervalKey).gate;
+  const { data } = await monitoringHttp.get('https://api.gateio.ws/api/v4/spot/candlesticks', {
+    params: { currency_pair: meta.gateSpot, interval, limit }
+  });
+  const rows = Array.isArray(data) ? data : [];
+  const points = rows.map((row) => normalizeHistoryPoint({
+    timestamp: row?.[0],
+    open: row?.[5],
+    close: row?.[2],
+    volume: row?.[6] ?? row?.[1]
+  })).filter(Boolean);
+  return limitHistoryPoints(points, limit);
+}
+
+async function fetchGateFuturesHistory(meta, intervalKey, limit) {
+  const interval = getHistoryIntervalConfig(intervalKey).gate;
+  const { data } = await monitoringHttp.get('https://api.gateio.ws/api/v4/futures/usdt/candlesticks', {
+    params: { contract: meta.gateFutures, interval, limit }
+  });
+  const rows = Array.isArray(data) ? data : [];
+  const points = rows.map((row) => {
+    if (Array.isArray(row)) {
+      return normalizeHistoryPoint({ timestamp: row?.[0], open: row?.[5], close: row?.[2], volume: row?.[6] ?? row?.[1] });
+    }
+    return normalizeHistoryPoint({ timestamp: row?.t ?? row?.time, open: row?.o, close: row?.c, volume: row?.sum ?? row?.v });
+  }).filter(Boolean);
+  return limitHistoryPoints(points, limit);
+}
+
+async function fetchMexcSpotHistory(meta, intervalKey, limit) {
+  const interval = getHistoryIntervalConfig(intervalKey).mexc;
+  const { data } = await monitoringHttp.get('https://api.mexc.com/api/v3/klines', {
+    params: { symbol: meta.mexcSpot, interval, limit }
+  });
+  if (!Array.isArray(data)) return [];
+  const points = data.map((entry) => normalizeHistoryPoint({
+    timestamp: entry?.[0],
+    open: entry?.[1],
+    close: entry?.[4],
+    volume: entry?.[7] ?? entry?.[5]
+  })).filter(Boolean);
+  return limitHistoryPoints(points, limit);
+}
+
+async function fetchMexcFuturesHistory(meta, intervalKey, limit) {
+  const interval = getHistoryIntervalConfig(intervalKey).mexcFutures;
+  const { data } = await monitoringHttp.get(`https://contract.mexc.com/api/v1/contract/kline/${meta.mexcFutures}`, {
+    params: { interval }
+  });
+  if (!data || data.code !== 0 || !data.data) return [];
+  const payload = data.data;
+  const times = Array.isArray(payload.time) ? payload.time : [];
+  const opens = Array.isArray(payload.open) ? payload.open : [];
+  const closes = Array.isArray(payload.close) ? payload.close : [];
+  const volumes = Array.isArray(payload.vol) ? payload.vol : payload.amount;
+  const startIndex = Math.max(0, times.length - limit);
+  const points = [];
+  for (let i = startIndex; i < times.length; i += 1) {
+    const point = normalizeHistoryPoint({
+      timestamp: times[i],
+      open: opens[i],
+      close: closes[i],
+      volume: volumes?.[i]
+    });
+    if (point) points.push(point);
+  }
+  return sortHistoryPoints(points);
+}
+
+async function fetchBitgetSpotHistory(meta, intervalKey, limit) {
+  const interval = getHistoryIntervalConfig(intervalKey).bitget;
+  const { data } = await monitoringHttp.get('https://api.bitget.com/api/spot/v1/market/candles', {
+    params: { symbol: meta.bitgetSpot, period: interval, limit }
+  });
+  if (!data || data.code !== '00000' || !Array.isArray(data.data)) return [];
+  const points = data.data.map((entry) => normalizeHistoryPoint({
+    timestamp: entry?.ts ?? entry?.[0],
+    open: entry?.open ?? entry?.[1],
+    close: entry?.close ?? entry?.[4],
+    volume: entry?.quoteVol ?? entry?.[5]
+  })).filter(Boolean);
+  return limitHistoryPoints(points, limit);
+}
+
+async function fetchBitgetFuturesHistory(meta, intervalKey, limit) {
+  const interval = getHistoryIntervalConfig(intervalKey).bitgetFutures;
+  const { data } = await monitoringHttp.get('https://api.bitget.com/api/v2/mix/market/candles', {
+    params: {
+      productType: 'umcbl',
+      symbol: `${meta.base}${meta.quote}`,
+      granularity: interval,
+      limit
+    }
+  });
+  if (!data || data.code !== '00000' || !Array.isArray(data.data)) return [];
+  const points = data.data.map((entry) => normalizeHistoryPoint({
+    timestamp: entry?.[0],
+    open: entry?.[1],
+    close: entry?.[4],
+    volume: entry?.[6]
+  })).filter(Boolean);
+  return limitHistoryPoints(points, limit);
+}
+
+async function fetchKucoinSpotHistory(meta, intervalKey, limit) {
+  const interval = getHistoryIntervalConfig(intervalKey).kucoin;
+  const { start, end } = computeHistoryWindow(intervalKey, limit);
+  const { data } = await monitoringHttp.get('https://api.kucoin.com/api/v1/market/candles', {
+    params: { symbol: meta.dashed, type: interval, startAt: start, endAt: end }
+  });
+  if (!data || data.code !== '200000' || !Array.isArray(data.data)) return [];
+  const points = data.data.map((entry) => normalizeHistoryPoint({
+    timestamp: entry?.[0],
+    open: entry?.[1],
+    close: entry?.[2],
+    volume: entry?.[6] ?? entry?.[5]
+  })).filter(Boolean);
+  return limitHistoryPoints(points, limit);
+}
+
+async function fetchKucoinFuturesHistory(meta, intervalKey, limit) {
+  const granularity = getHistoryIntervalConfig(intervalKey).kucoinFutures;
+  const { start, end } = computeHistoryWindow(intervalKey, limit);
+  const { data } = await monitoringHttp.get('https://api-futures.kucoin.com/api/v1/kline/query', {
+    params: { symbol: meta.kucoinFutures, granularity, from: start, to: end }
+  });
+  if (!data || data.code !== '200000' || !Array.isArray(data.data)) return [];
+  const points = data.data.map((entry) => normalizeHistoryPoint({
+    timestamp: entry?.[0],
+    open: entry?.[1],
+    close: entry?.[2],
+    volume: entry?.[6] ?? entry?.[5]
+  })).filter(Boolean);
+  return limitHistoryPoints(points, limit);
+}
+
+async function fetchBinanceSpotHistory(meta, intervalKey, limit) {
+  const interval = getHistoryIntervalConfig(intervalKey).binance;
+  const { data } = await monitoringHttp.get('https://data-api.binance.vision/api/v3/klines', {
+    params: { symbol: meta.compact, interval, limit }
+  });
+  if (!Array.isArray(data)) return [];
+  const points = data.map((entry) => normalizeHistoryPoint({
+    timestamp: entry?.[0],
+    open: entry?.[1],
+    close: entry?.[4],
+    volume: entry?.[7] ?? entry?.[5]
+  })).filter(Boolean);
+  return limitHistoryPoints(points, limit);
+}
+
+async function fetchBinanceFuturesHistory(meta, intervalKey, limit) {
+  const interval = getHistoryIntervalConfig(intervalKey).binance;
+  const { data } = await monitoringHttp.get('https://fapi.binance.com/fapi/v1/klines', {
+    params: { symbol: meta.compact, interval, limit }
+  });
+  if (!Array.isArray(data)) return [];
+  const points = data.map((entry) => normalizeHistoryPoint({
+    timestamp: entry?.[0],
+    open: entry?.[1],
+    close: entry?.[4],
+    volume: entry?.[7] ?? entry?.[5]
+  })).filter(Boolean);
+  return limitHistoryPoints(points, limit);
+}
+
+async function fetchBybitSpotHistory(meta, intervalKey, limit) {
+  const interval = getHistoryIntervalConfig(intervalKey).bybit;
+  const { data } = await monitoringHttp.get('https://api.bybit.com/v5/market/kline', {
+    params: { category: 'spot', symbol: meta.bybit, interval, limit }
+  });
+  if (data?.retCode !== 0 || !Array.isArray(data?.result?.list)) return [];
+  const points = data.result.list.map((entry) => normalizeHistoryPoint({
+    timestamp: entry?.[0],
+    open: entry?.[1],
+    close: entry?.[4],
+    volume: entry?.[6] ?? entry?.[5]
+  })).filter(Boolean);
+  return limitHistoryPoints(points, limit);
+}
+
+async function fetchBybitFuturesHistory(meta, intervalKey, limit) {
+  const interval = getHistoryIntervalConfig(intervalKey).bybit;
+  const { data } = await monitoringHttp.get('https://api.bybit.com/v5/market/kline', {
+    params: { category: 'linear', symbol: meta.bybit, interval, limit }
+  });
+  if (data?.retCode !== 0 || !Array.isArray(data?.result?.list)) return [];
+  const points = data.result.list.map((entry) => normalizeHistoryPoint({
+    timestamp: entry?.[0],
+    open: entry?.[1],
+    close: entry?.[4],
+    volume: entry?.[6] ?? entry?.[5]
+  })).filter(Boolean);
+  return limitHistoryPoints(points, limit);
+}
+
 const monitoringSpotProviders = [
-  { key: 'gate_spot', label: 'Gate.io', type: 'spot', fetch: fetchGateSpotTicker },
-  { key: 'mexc_spot', label: 'MEXC', type: 'spot', fetch: fetchMexcSpotTicker },
-  { key: 'bitget_spot', label: 'Bitget', type: 'spot', fetch: fetchBitgetSpotTicker },
-  { key: 'kucoin_spot', label: 'KuCoin', type: 'spot', fetch: fetchKucoinSpotTicker },
-  { key: 'binance_spot', label: 'Binance', type: 'spot', fetch: fetchBinanceSpotTicker },
-  { key: 'bybit_spot', label: 'Bybit', type: 'spot', fetch: fetchBybitSpotTicker }
+  { key: 'gate_spot', label: 'Gate.io', type: 'spot', fetch: fetchGateSpotTicker, history: fetchGateSpotHistory },
+  { key: 'mexc_spot', label: 'MEXC', type: 'spot', fetch: fetchMexcSpotTicker, history: fetchMexcSpotHistory },
+  { key: 'bitget_spot', label: 'Bitget', type: 'spot', fetch: fetchBitgetSpotTicker, history: fetchBitgetSpotHistory },
+  { key: 'kucoin_spot', label: 'KuCoin', type: 'spot', fetch: fetchKucoinSpotTicker, history: fetchKucoinSpotHistory },
+  { key: 'binance_spot', label: 'Binance', type: 'spot', fetch: fetchBinanceSpotTicker, history: fetchBinanceSpotHistory },
+  { key: 'bybit_spot', label: 'Bybit', type: 'spot', fetch: fetchBybitSpotTicker, history: fetchBybitSpotHistory }
 ];
 
 const monitoringFuturesProviders = [
-  { key: 'gate_futures', label: 'Gate.io Futures', type: 'futures', fetch: fetchGateFuturesTicker },
-  { key: 'mexc_futures', label: 'MEXC Futures', type: 'futures', fetch: fetchMexcFuturesTicker },
-  { key: 'bitget_futures', label: 'Bitget Futures', type: 'futures', fetch: fetchBitgetFuturesTicker },
-  { key: 'kucoin_futures', label: 'KuCoin Futures', type: 'futures', fetch: fetchKucoinFuturesTicker },
-  { key: 'binance_futures', label: 'Binance Futures', type: 'futures', fetch: fetchBinanceFuturesTicker },
-  { key: 'bybit_futures', label: 'Bybit Futures', type: 'futures', fetch: fetchBybitFuturesTicker }
+  { key: 'gate_futures', label: 'Gate.io Futures', type: 'futures', fetch: fetchGateFuturesTicker, history: fetchGateFuturesHistory },
+  { key: 'mexc_futures', label: 'MEXC Futures', type: 'futures', fetch: fetchMexcFuturesTicker, history: fetchMexcFuturesHistory },
+  { key: 'bitget_futures', label: 'Bitget Futures', type: 'futures', fetch: fetchBitgetFuturesTicker, history: fetchBitgetFuturesHistory },
+  { key: 'kucoin_futures', label: 'KuCoin Futures', type: 'futures', fetch: fetchKucoinFuturesTicker, history: fetchKucoinFuturesHistory },
+  { key: 'binance_futures', label: 'Binance Futures', type: 'futures', fetch: fetchBinanceFuturesTicker, history: fetchBinanceFuturesHistory },
+  { key: 'bybit_futures', label: 'Bybit Futures', type: 'futures', fetch: fetchBybitFuturesTicker, history: fetchBybitFuturesHistory }
 ];
+
+function findSpotProvider(key) {
+  return monitoringSpotProviders.find((provider) => provider.key === key);
+}
+
+function findFuturesProvider(key) {
+  return monitoringFuturesProviders.find((provider) => provider.key === key);
+}
+
+async function fetchHistoryDataset(provider, meta, intervalKey, limit) {
+  if (!provider || typeof provider.history !== 'function') {
+    return { candles: [], error: 'Histórico não disponível para esta corretora' };
+  }
+  try {
+    const candles = await provider.history(meta, intervalKey, limit);
+    return { candles, error: null };
+  } catch (err) {
+    console.warn(`[monitoring] histórico ${provider.key} falhou`, err?.message || err);
+    return { candles: [], error: err?.message || String(err) };
+  }
+}
 
 async function fetchMonitoringTicker(provider, meta) {
   try {
@@ -4364,6 +4747,46 @@ app.get('/api/monitoring/markets', async (req, res) => {
     res.json({ updatedAt: new Date().toISOString(), symbols: results });
   } catch (err) {
     console.error('[monitoring] erro ao coletar mercados', err);
+    res.status(500).json({ error: err.message || err });
+  }
+});
+
+app.get('/api/monitoring/history', async (req, res) => {
+  try {
+    const symbolInput = req.query.symbol;
+    const meta = buildSymbolMeta(symbolInput);
+    if (!meta) {
+      return res.status(400).json({ error: 'Símbolo inválido' });
+    }
+    const intervalKeyRaw = String(req.query.interval || '').toLowerCase();
+    const intervalKey = MONITORING_HISTORY_INTERVALS[intervalKeyRaw] ? intervalKeyRaw : MONITORING_HISTORY_DEFAULT_INTERVAL;
+    const intervalConfig = getHistoryIntervalConfig(intervalKey);
+    const limit = computeHistoryLimit(intervalKey);
+    const spotKey = req.query.spot && findSpotProvider(req.query.spot) ? req.query.spot : monitoringSpotProviders[0].key;
+    const futuresKey = req.query.futures && findFuturesProvider(req.query.futures)
+      ? req.query.futures
+      : monitoringFuturesProviders[0].key;
+    const spotProvider = findSpotProvider(spotKey) || monitoringSpotProviders[0];
+    const futuresProvider = findFuturesProvider(futuresKey) || monitoringFuturesProviders[0];
+    const [spotResult, futuresResult] = await Promise.all([
+      fetchHistoryDataset(spotProvider, meta, intervalKey, limit),
+      fetchHistoryDataset(futuresProvider, meta, intervalKey, limit)
+    ]);
+    const points = buildHistorySeries(spotResult.candles, futuresResult.candles, intervalConfig.minutes);
+    res.json({
+      symbol: meta.symbol,
+      label: MONITORING_DEFAULT_LABELS[meta.symbol] || meta.symbol,
+      interval: { key: intervalKey, label: intervalConfig.label, minutes: intervalConfig.minutes },
+      spot: { key: spotProvider.key, label: spotProvider.label },
+      futures: { key: futuresProvider.key, label: futuresProvider.label },
+      points,
+      spotError: spotResult.error,
+      futuresError: futuresResult.error,
+      requestedCandles: limit,
+      updatedAt: new Date().toISOString()
+    });
+  } catch (err) {
+    console.error('[monitoring] erro ao montar histórico', err);
     res.status(500).json({ error: err.message || err });
   }
 });

--- a/server.js
+++ b/server.js
@@ -4020,6 +4020,12 @@ function toNumber(value) {
   return Number.isFinite(num) ? num : null;
 }
 
+function computeNotional(price, size) {
+  if (!Number.isFinite(price) || !Number.isFinite(size)) return null;
+  const notional = price * size;
+  return Number.isFinite(notional) ? notional : null;
+}
+
 function serializeMonitoringSymbols() {
   return Array.from(monitoringSymbolMeta.entries()).map(([symbol, meta]) => ({
     symbol,
@@ -4222,10 +4228,12 @@ function listMonitoringSymbols() {
 }
 
 function buildHistorySeries(spotCandles, futuresCandles, intervalMinutes) {
-  if (!spotCandles.length || !futuresCandles.length) return [];
+  if (!spotCandles.length || !futuresCandles.length) return { points: [], stats: null };
   const bucketMs = intervalMinutes * 60 * 1000;
   const futuresMap = bucketizeHistoryCandles(futuresCandles, bucketMs);
   const points = [];
+  const openValues = [];
+  const closeValues = [];
   for (const spot of spotCandles) {
     const bucket = Math.floor(spot.timestamp / bucketMs) * bucketMs;
     const futures = futuresMap.get(bucket);
@@ -4235,6 +4243,8 @@ function buildHistorySeries(spotCandles, futuresCandles, intervalMinutes) {
     if (!Number.isFinite(openArb) && !Number.isFinite(closeArb)) continue;
     const openArbPct = formatArbValue(openArb);
     const closeArbPct = formatArbValue(closeArb);
+    if (Number.isFinite(openArbPct)) openValues.push(openArbPct);
+    if (Number.isFinite(closeArbPct)) closeValues.push(closeArbPct);
     points.push({
       timestamp: bucket,
       openArbPct,
@@ -4244,7 +4254,14 @@ function buildHistorySeries(spotCandles, futuresCandles, intervalMinutes) {
       futuresVolume: futures.volume
     });
   }
-  return sortHistoryPoints(points);
+  const sortedPoints = sortHistoryPoints(points);
+  const stats = !openValues.length && !closeValues.length
+    ? null
+    : {
+        open: openValues.length ? { min: Math.min(...openValues), max: Math.max(...openValues) } : null,
+        close: closeValues.length ? { min: Math.min(...closeValues), max: Math.max(...closeValues) } : null
+      };
+  return { points: sortedPoints, stats };
 }
 
 function limitHistoryPoints(points, limit) {
@@ -4265,6 +4282,10 @@ async function fetchGateSpotTicker(meta) {
     ask: toNumber(payload.lowest_ask),
     last: toNumber(payload.last),
     volume: toNumber(payload.quote_volume ?? payload.base_volume),
+    bidSize: toNumber(payload.highest_bid_size),
+    askSize: toNumber(payload.lowest_ask_size),
+    bidNotional: computeNotional(toNumber(payload.highest_bid), toNumber(payload.highest_bid_size)),
+    askNotional: computeNotional(toNumber(payload.lowest_ask), toNumber(payload.lowest_ask_size)),
     changePct: toNumber(payload.change_percentage)
   };
 }
@@ -4279,6 +4300,10 @@ async function fetchMexcSpotTicker(meta) {
     ask: toNumber(data.askPrice),
     last: toNumber(data.lastPrice),
     volume: toNumber(data.quoteVolume),
+    bidSize: toNumber(data.bidQty),
+    askSize: toNumber(data.askQty),
+    bidNotional: computeNotional(toNumber(data.bidPrice), toNumber(data.bidQty)),
+    askNotional: computeNotional(toNumber(data.askPrice), toNumber(data.askQty)),
     changePct: toNumber(data.priceChangePercent)
   };
 }
@@ -4296,6 +4321,10 @@ async function fetchBitgetSpotTicker(meta) {
     ask: toNumber(payload.sellOne),
     last: toNumber(payload.close),
     volume: toNumber(payload.usdtVol ?? payload.quoteVol),
+    bidSize: toNumber(payload.bidSz),
+    askSize: toNumber(payload.askSz),
+    bidNotional: computeNotional(toNumber(payload.buyOne), toNumber(payload.bidSz)),
+    askNotional: computeNotional(toNumber(payload.sellOne), toNumber(payload.askSz)),
     changePct: toNumber(payload.change ?? payload.changeUtc)
   };
 }
@@ -4313,6 +4342,10 @@ async function fetchKucoinSpotTicker(meta) {
     ask: toNumber(payload.sell),
     last: toNumber(payload.last),
     volume: toNumber(payload.volValue),
+    bidSize: toNumber(payload.buySize),
+    askSize: toNumber(payload.sellSize),
+    bidNotional: computeNotional(toNumber(payload.buy), toNumber(payload.buySize)),
+    askNotional: computeNotional(toNumber(payload.sell), toNumber(payload.sellSize)),
     changePct: toNumber(payload.changeRate) ? toNumber(payload.changeRate) * 100 : null
   };
 }
@@ -4328,6 +4361,10 @@ async function fetchBinanceSpotTicker(meta) {
     ask: toNumber(data.askPrice),
     last: toNumber(data.lastPrice),
     volume: toNumber(data.quoteVolume),
+    bidSize: toNumber(data.bidQty),
+    askSize: toNumber(data.askQty),
+    bidNotional: computeNotional(toNumber(data.bidPrice), toNumber(data.bidQty)),
+    askNotional: computeNotional(toNumber(data.askPrice), toNumber(data.askQty)),
     changePct: toNumber(data.priceChangePercent)
   };
 }
@@ -4344,6 +4381,10 @@ async function fetchBybitSpotTicker(meta) {
     ask: toNumber(first.ask1Price),
     last: toNumber(first.lastPrice),
     volume: toNumber(first.turnover24h),
+    bidSize: toNumber(first.bid1Size),
+    askSize: toNumber(first.ask1Size),
+    bidNotional: computeNotional(toNumber(first.bid1Price), toNumber(first.bid1Size)),
+    askNotional: computeNotional(toNumber(first.ask1Price), toNumber(first.ask1Size)),
     changePct: toNumber(first.price24hPcnt) ? toNumber(first.price24hPcnt) * 100 : null
   };
 }
@@ -4359,6 +4400,10 @@ async function fetchGateFuturesTicker(meta) {
     ask: toNumber(payload.lowest_ask),
     last: toNumber(payload.last),
     volume: toNumber(payload.volume_24h_quote ?? payload.volume_24h),
+    bidSize: toNumber(payload.highest_bid_size),
+    askSize: toNumber(payload.lowest_ask_size),
+    bidNotional: computeNotional(toNumber(payload.highest_bid), toNumber(payload.highest_bid_size)),
+    askNotional: computeNotional(toNumber(payload.lowest_ask), toNumber(payload.lowest_ask_size)),
     fundingRate: toNumber(payload.funding_rate),
     changePct: toNumber(payload.change_percentage)
   };
@@ -4375,6 +4420,10 @@ async function fetchMexcFuturesTicker(meta) {
     ask: toNumber(payload.ask1),
     last: toNumber(payload.lastPrice),
     volume: toNumber(payload.amount24),
+    bidSize: toNumber(payload.bid1Size),
+    askSize: toNumber(payload.ask1Size),
+    bidNotional: computeNotional(toNumber(payload.bid1), toNumber(payload.bid1Size)),
+    askNotional: computeNotional(toNumber(payload.ask1), toNumber(payload.ask1Size)),
     fundingRate: toNumber(payload.fundingRate),
     changePct: toNumber(payload.riseFallRate) ? toNumber(payload.riseFallRate) * 100 : null
   };
@@ -4393,6 +4442,10 @@ async function fetchBitgetFuturesTicker(meta) {
     ask: toNumber(payload.bestAsk),
     last: toNumber(payload.last),
     volume: toNumber(payload.quoteVolume ?? payload.usdtVolume),
+    bidSize: toNumber(payload.bestBidSize ?? payload.bidSz),
+    askSize: toNumber(payload.bestAskSize ?? payload.askSz),
+    bidNotional: computeNotional(toNumber(payload.bestBid), toNumber(payload.bestBidSize ?? payload.bidSz)),
+    askNotional: computeNotional(toNumber(payload.bestAsk), toNumber(payload.bestAskSize ?? payload.askSz)),
     fundingRate: toNumber(payload.fundingRate),
     changePct: toNumber(payload.priceChangePercent)
   };
@@ -4411,6 +4464,10 @@ async function fetchKucoinFuturesTicker(meta) {
     ask: toNumber(payload.bestAskPrice),
     last: toNumber(payload.price),
     volume: toNumber(payload.turnover),
+    bidSize: toNumber(payload.bestBidSize),
+    askSize: toNumber(payload.bestAskSize),
+    bidNotional: computeNotional(toNumber(payload.bestBidPrice), toNumber(payload.bestBidSize)),
+    askNotional: computeNotional(toNumber(payload.bestAskPrice), toNumber(payload.bestAskSize)),
     fundingRate: toNumber(payload.fundingRate),
     changePct: toNumber(payload.changeRate) ? toNumber(payload.changeRate) * 100 : null
   };
@@ -4427,6 +4484,10 @@ async function fetchBinanceFuturesTicker(meta) {
     ask: toNumber(data.askPrice),
     last: toNumber(data.lastPrice),
     volume: toNumber(data.quoteVolume),
+    bidSize: toNumber(data.bidQty),
+    askSize: toNumber(data.askQty),
+    bidNotional: computeNotional(toNumber(data.bidPrice), toNumber(data.bidQty)),
+    askNotional: computeNotional(toNumber(data.askPrice), toNumber(data.askQty)),
     fundingRate: null,
     changePct: toNumber(data.priceChangePercent)
   };
@@ -4444,6 +4505,10 @@ async function fetchBybitFuturesTicker(meta) {
     ask: toNumber(payload.ask1Price),
     last: toNumber(payload.lastPrice),
     volume: toNumber(payload.turnover24h),
+    bidSize: toNumber(payload.bid1Size),
+    askSize: toNumber(payload.ask1Size),
+    bidNotional: computeNotional(toNumber(payload.bid1Price), toNumber(payload.bid1Size)),
+    askNotional: computeNotional(toNumber(payload.ask1Price), toNumber(payload.ask1Size)),
     fundingRate: toNumber(payload.fundingRate),
     changePct: toNumber(payload.price24hPcnt) ? toNumber(payload.price24hPcnt) * 100 : null
   };
@@ -5053,14 +5118,15 @@ app.get('/api/monitoring/history', async (req, res) => {
       fetchHistoryDataset(spotProvider, meta, intervalKey, limit),
       fetchHistoryDataset(futuresProvider, meta, intervalKey, limit)
     ]);
-    const points = buildHistorySeries(spotResult.candles, futuresResult.candles, intervalConfig.minutes);
+    const historySeries = buildHistorySeries(spotResult.candles, futuresResult.candles, intervalConfig.minutes);
     res.json({
       symbol: meta.symbol,
       label: MONITORING_DEFAULT_LABELS[meta.symbol] || meta.symbol,
       interval: { key: intervalKey, label: intervalConfig.label, minutes: intervalConfig.minutes },
       spot: { key: spotProvider.key, label: spotProvider.label },
       futures: { key: futuresProvider.key, label: futuresProvider.label },
-      points,
+      points: historySeries.points,
+      stats: historySeries.stats,
       spotError: spotResult.error,
       futuresError: futuresResult.error,
       requestedCandles: limit,

--- a/server.js
+++ b/server.js
@@ -4419,7 +4419,7 @@ async function fetchMexcFuturesTicker(meta) {
     bid: toNumber(payload.bid1),
     ask: toNumber(payload.ask1),
     last: toNumber(payload.lastPrice),
-    volume: toNumber(payload.turnover24 ?? payload.amount24),
+    volume: toNumber(payload.turnover24 ?? payload.amount24 ?? payload.volume),
     bidSize: toNumber(payload.bid1Size),
     askSize: toNumber(payload.ask1Size),
     bidNotional: computeNotional(toNumber(payload.bid1), toNumber(payload.bid1Size)),
@@ -4459,11 +4459,13 @@ async function fetchKucoinFuturesTicker(meta) {
     throw new Error(data?.msg || 'Erro KuCoin futures');
   }
   const payload = data.data;
+  const contract = await getKucoinFuturesContract(meta.kucoinFutures);
+  const contractVolume = toNumber(contract?.turnoverOf24h ?? contract?.turnover ?? contract?.turnoverValue);
   return {
     bid: toNumber(payload.bestBidPrice),
     ask: toNumber(payload.bestAskPrice),
     last: toNumber(payload.price),
-    volume: toNumber(payload.turnover),
+    volume: Number.isFinite(contractVolume) ? contractVolume : toNumber(payload.turnover),
     bidSize: toNumber(payload.bestBidSize),
     askSize: toNumber(payload.bestAskSize),
     bidNotional: computeNotional(toNumber(payload.bestBidPrice), toNumber(payload.bestBidSize)),
@@ -4471,6 +4473,29 @@ async function fetchKucoinFuturesTicker(meta) {
     fundingRate: toNumber(payload.fundingRate),
     changePct: toNumber(payload.changeRate) ? toNumber(payload.changeRate) * 100 : null
   };
+}
+
+const KUCOIN_FUTURES_CACHE_MS = 30_000;
+let kucoinFuturesContractCache = { ts: 0, data: [] };
+
+async function loadKucoinFuturesContracts(force = false) {
+  const now = Date.now();
+  if (!force && kucoinFuturesContractCache.data.length && now - kucoinFuturesContractCache.ts < KUCOIN_FUTURES_CACHE_MS) {
+    return kucoinFuturesContractCache.data;
+  }
+  try {
+    const { data } = await monitoringHttp.get('https://api-futures.kucoin.com/api/v1/contracts/active');
+    const list = Array.isArray(data?.data) ? data.data : [];
+    kucoinFuturesContractCache = { ts: now, data: list };
+    return list;
+  } catch (err) {
+    return kucoinFuturesContractCache.data;
+  }
+}
+
+async function getKucoinFuturesContract(symbol) {
+  const list = await loadKucoinFuturesContracts();
+  return list.find((item) => item.symbol === symbol);
 }
 
 async function fetchBinanceFuturesTicker(meta) {
@@ -4794,10 +4819,9 @@ async function fetchKucoinTopSpotAssets() {
 }
 
 async function fetchKucoinTopFuturesAssets() {
-  const { data } = await monitoringHttp.get('https://api-futures.kucoin.com/api/v1/allTickers');
-  const list = Array.isArray(data?.data?.ticker) ? data.data.ticker : [];
+  const list = await loadKucoinFuturesContracts();
   return list
-    .map((item) => ({ symbol: normalizeMonitoringSymbol(item.symbol), volume: toNumber(item.turnover ?? item.turnoverValue) }))
+    .map((item) => ({ symbol: normalizeMonitoringSymbol(item.symbol), volume: toNumber(item.turnoverOf24h ?? item.turnoverValue ?? item.turnover) }))
     .filter((item) => item.symbol && item.symbol.endsWith('_USDT') && Number.isFinite(item.volume));
 }
 

--- a/server.js
+++ b/server.js
@@ -28,6 +28,9 @@ const monitoringHttp = axios.create({
   }
 });
 
+// Avoid spamming the console when a MEXC futures symbol lacks depth support
+const mexcFuturesDepthWarnings = new Set();
+
 const SPOT_EXCHANGES = {
   gate: { key: 'gate', label: 'Gate.io' },
   bitget: { key: 'bitget', label: 'Bitget' }
@@ -4463,7 +4466,16 @@ async function fetchMexcFuturesTicker(meta) {
         askSize = toNumber(asks[0].vol) ?? askSize;
       }
     } catch (err) {
-      console.warn('[monitoring] mexc futures depth fallback falhou', meta.mexcFutures, err?.message || err);
+      const status = err?.response?.status;
+      const reason = err?.message || err;
+      if (status === 404) {
+        if (!mexcFuturesDepthWarnings.has(meta.mexcFutures)) {
+          mexcFuturesDepthWarnings.add(meta.mexcFutures);
+          console.info('[monitoring] mexc futures depth indisponível (404)', meta.mexcFutures);
+        }
+      } else {
+        console.warn('[monitoring] mexc futures depth fallback falhou', meta.mexcFutures, 'status=', status || 'n/a', 'reason=', reason);
+      }
     }
   }
 

--- a/server.js
+++ b/server.js
@@ -4277,15 +4277,41 @@ async function fetchGateSpotTicker(meta) {
   });
   const payload = Array.isArray(data) ? data[0] : data;
   if (!payload) throw new Error('Resposta vazia');
+
+  let bid = toNumber(payload.highest_bid);
+  let ask = toNumber(payload.lowest_ask);
+  let bidSize = toNumber(payload.highest_bid_size);
+  let askSize = toNumber(payload.lowest_ask_size);
+
+  if (!Number.isFinite(bidSize) || bidSize <= 0 || !Number.isFinite(askSize) || askSize <= 0) {
+    try {
+      const depth = await monitoringHttp.get('https://api.gateio.ws/api/v4/spot/order_book', {
+        params: { currency_pair: meta.gateSpot, limit: 1 }
+      });
+      const bids = Array.isArray(depth?.data?.bids) ? depth.data.bids : [];
+      const asks = Array.isArray(depth?.data?.asks) ? depth.data.asks : [];
+      if (bids.length) {
+        bid = toNumber(bids[0][0]) ?? bid;
+        bidSize = toNumber(bids[0][1]) ?? bidSize;
+      }
+      if (asks.length) {
+        ask = toNumber(asks[0][0]) ?? ask;
+        askSize = toNumber(asks[0][1]) ?? askSize;
+      }
+    } catch (err) {
+      console.warn('[monitoring] gate spot depth fallback falhou', meta.gateSpot, err?.message || err);
+    }
+  }
+
   return {
-    bid: toNumber(payload.highest_bid),
-    ask: toNumber(payload.lowest_ask),
+    bid,
+    ask,
     last: toNumber(payload.last),
     volume: toNumber(payload.quote_volume ?? payload.base_volume),
-    bidSize: toNumber(payload.highest_bid_size),
-    askSize: toNumber(payload.lowest_ask_size),
-    bidNotional: computeNotional(toNumber(payload.highest_bid), toNumber(payload.highest_bid_size)),
-    askNotional: computeNotional(toNumber(payload.lowest_ask), toNumber(payload.lowest_ask_size)),
+    bidSize,
+    askSize,
+    bidNotional: computeNotional(bid, bidSize),
+    askNotional: computeNotional(ask, askSize),
     changePct: toNumber(payload.change_percentage)
   };
 }
@@ -4415,15 +4441,41 @@ async function fetchMexcFuturesTicker(meta) {
   });
   if (!data || data.code !== 0 || !data.data) throw new Error(data?.msg || 'Erro MEXC futures');
   const payload = data.data;
+
+  let bid = toNumber(payload.bid1);
+  let ask = toNumber(payload.ask1);
+  let bidSize = toNumber(payload.bid1Size ?? payload.bidVol);
+  let askSize = toNumber(payload.ask1Size ?? payload.askVol);
+
+  if (!Number.isFinite(bidSize) || bidSize <= 0 || !Number.isFinite(askSize) || askSize <= 0) {
+    try {
+      const depth = await monitoringHttp.get('https://contract.mexc.com/api/v1/contract/depth', {
+        params: { symbol: meta.mexcFutures, depth: 1 }
+      });
+      const bids = Array.isArray(depth?.data?.bids) ? depth.data.bids : [];
+      const asks = Array.isArray(depth?.data?.asks) ? depth.data.asks : [];
+      if (bids.length) {
+        bid = toNumber(bids[0].price) ?? bid;
+        bidSize = toNumber(bids[0].vol) ?? bidSize;
+      }
+      if (asks.length) {
+        ask = toNumber(asks[0].price) ?? ask;
+        askSize = toNumber(asks[0].vol) ?? askSize;
+      }
+    } catch (err) {
+      console.warn('[monitoring] mexc futures depth fallback falhou', meta.mexcFutures, err?.message || err);
+    }
+  }
+
   return {
-    bid: toNumber(payload.bid1),
-    ask: toNumber(payload.ask1),
+    bid,
+    ask,
     last: toNumber(payload.lastPrice),
     volume: toNumber(payload.turnover24 ?? payload.amount24 ?? payload.volume),
-    bidSize: toNumber(payload.bid1Size),
-    askSize: toNumber(payload.ask1Size),
-    bidNotional: computeNotional(toNumber(payload.bid1), toNumber(payload.bid1Size)),
-    askNotional: computeNotional(toNumber(payload.ask1), toNumber(payload.ask1Size)),
+    bidSize,
+    askSize,
+    bidNotional: computeNotional(bid, bidSize),
+    askNotional: computeNotional(ask, askSize),
     fundingRate: toNumber(payload.fundingRate),
     changePct: toNumber(payload.riseFallRate) ? toNumber(payload.riseFallRate) * 100 : null
   };

--- a/server.js
+++ b/server.js
@@ -21,7 +21,7 @@ const DEFAULT_RISK_TEST_QUOTE = (() => {
 const app = express();
 const PORT = 3000;
 
-const MONITORING_DEFAULT_SYMBOLS = ['CPOOL_USDT', 'MAT_USDT', 'FARM_USDT'];
+const MONITORING_DEFAULT_SYMBOLS = DEFAULT_MONITORING_SYMBOLS.map((item) => item.symbol);
 const MONITORING_DEFAULT_LABELS = {
   CPOOL_USDT: 'Clearpool',
   MAT_USDT: 'Mycelium',
@@ -82,6 +82,12 @@ const SPREAD_WINDOW_MS = 24 * 60 * 60 * 1000;
 
 const autoMetaCache = new Map();
 const overridesBySymbol = new Map();
+const DEFAULT_MONITORING_SYMBOLS = [
+  { symbol: 'CPOOL_USDT', meta: { name: 'Clearpool', risk: 'Baixo', spotHint: ['Gate.io', 'Binance'], futuresHint: ['MEXC Futures', 'Gate.io Futures'] } },
+  { symbol: 'MAT_USDT', meta: { name: 'Mycelium', risk: 'Médio', spotHint: ['Gate.io', 'KuCoin'], futuresHint: ['Bybit', 'MEXC Futures'] } },
+  { symbol: 'FARM_USDT', meta: { name: 'Harvest Finance', risk: 'Baixo', spotHint: ['Gate.io', 'Binance'], futuresHint: ['MEXC Futures'] } }
+];
+let monitoringSymbolMeta = new Map();
 
 let orderHistory = [];
 
@@ -356,6 +362,21 @@ try {
 } catch (e) {
   console.warn('[SQLite] Falha ao carregar estado:', e?.message || e);
 }
+
+function hydrateMonitoringSymbols() {
+  try {
+    const stored = db.loadMonitoringSymbols();
+    if (stored && stored.length) {
+      monitoringSymbolMeta = new Map(stored.map((item) => [String(item.symbol).toUpperCase(), item.meta || {}]));
+      return;
+    }
+  } catch (e) {
+    console.warn('[SQLite] Falha ao carregar monitoring_symbols:', e?.message || e);
+  }
+  monitoringSymbolMeta = new Map(DEFAULT_MONITORING_SYMBOLS.map((item) => [item.symbol, item.meta]));
+}
+
+hydrateMonitoringSymbols();
 
 try {
   const savedPos = db.loadPositionState();
@@ -3993,6 +4014,13 @@ function toNumber(value) {
   return Number.isFinite(num) ? num : null;
 }
 
+function serializeMonitoringSymbols() {
+  return Array.from(monitoringSymbolMeta.entries()).map(([symbol, meta]) => ({
+    symbol,
+    meta: meta || {}
+  }));
+}
+
 function describeAxiosError(err) {
   if (!err) return 'erro desconhecido';
   if (err.response) {
@@ -4179,6 +4207,12 @@ function computeMidArbValue(openValue, closeValue) {
   if (close !== null) return Number(close.toFixed(4));
   if (open !== null) return Number(open.toFixed(4));
   return null;
+}
+
+function listMonitoringSymbols() {
+  const symbols = Array.from(monitoringSymbolMeta.keys());
+  if (symbols.length) return symbols;
+  return MONITORING_DEFAULT_SYMBOLS;
 }
 
 function buildHistorySeries(spotCandles, futuresCandles, intervalMinutes) {
@@ -4943,7 +4977,7 @@ app.get('/api/monitoring/markets', async (req, res) => {
     const symbolsParam = String(req.query.symbols || '').trim();
     const requested = symbolsParam
       ? symbolsParam.split(',').map((s) => normalizeMonitoringSymbol(s)).filter(Boolean)
-      : MONITORING_DEFAULT_SYMBOLS;
+      : listMonitoringSymbols();
     const uniqueSymbols = Array.from(new Set(requested));
     if (!uniqueSymbols.length) {
       return res.json({ updatedAt: new Date().toISOString(), symbols: [] });
@@ -4954,6 +4988,27 @@ app.get('/api/monitoring/markets', async (req, res) => {
     console.error('[monitoring] erro ao coletar mercados', err);
     res.status(500).json({ error: err.message || err });
   }
+});
+
+app.get('/api/monitoring/symbols', (req, res) => {
+  res.json({ symbols: serializeMonitoringSymbols() });
+});
+
+app.post('/api/monitoring/symbols', (req, res) => {
+  const normalized = normalizeMonitoringSymbol(req.body?.symbol);
+  if (!normalized) return res.status(400).json({ error: 'Símbolo inválido' });
+  const meta = req.body?.meta && typeof req.body.meta === 'object' ? req.body.meta : {};
+  monitoringSymbolMeta.set(normalized, meta);
+  try { db.upsertMonitoringSymbol(normalized, meta); } catch (e) { console.warn('[SQLite] upsert monitoring symbol:', e?.message || e); }
+  res.json({ ok: true, symbols: serializeMonitoringSymbols() });
+});
+
+app.delete('/api/monitoring/symbols/:symbol', (req, res) => {
+  const normalized = normalizeMonitoringSymbol(req.params.symbol);
+  if (!normalized) return res.status(400).json({ error: 'Símbolo inválido' });
+  monitoringSymbolMeta.delete(normalized);
+  try { db.deleteMonitoringSymbol(normalized); } catch (e) { console.warn('[SQLite] delete monitoring symbol:', e?.message || e); }
+  res.json({ ok: true, symbols: serializeMonitoringSymbols() });
 });
 
 app.get('/api/monitoring/history', async (req, res) => {


### PR DESCRIPTION
## Summary
- add a collapsible lateral menu and split the UI between execução and monitoramento
- implement the new monitoramento dashboard with filters, charts, and admin tools for managing moedas/blacklists
- wire up the frontend logic for the sidebar, monitoring table, chart, filters, and admin login/management flows

## Testing
- Not Run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a4c604fac832f9e19a3db717de729)