### PR TITLE
Restrict monitoring to configured exchanges

### DIFF
--- a/public/scripts.js
+++ b/public/scripts.js
@@ -4359,6 +4359,24 @@ let executionToastTimer = null;
 const EXECUTION_SPOT_PROVIDERS = ['Gate.io', 'Bitget'];
 const EXECUTION_FUTURES_PROVIDERS = ['MEXC Futures'];
 
+const MONITORING_SPOT_OPTIONS = [
+  { key: 'gate_spot', label: 'Gate.io (SPOT)' },
+  { key: 'mexc_spot', label: 'MEXC (SPOT)' },
+  { key: 'bitget_spot', label: 'Bitget (SPOT)' },
+  { key: 'kucoin_spot', label: 'KuCoin (SPOT)' },
+  { key: 'binance_spot', label: 'Binance (SPOT)' },
+  { key: 'bybit_spot', label: 'Bybit (SPOT)' }
+];
+
+const MONITORING_FUTURES_OPTIONS = [
+  { key: 'gate_futures', label: 'Gate.io Futures' },
+  { key: 'mexc_futures', label: 'MEXC Futures' },
+  { key: 'bitget_futures', label: 'Bitget Futures' },
+  { key: 'kucoin_futures', label: 'KuCoin Futures' },
+  { key: 'binance_futures', label: 'Binance Futures' },
+  { key: 'bybit_futures', label: 'Bybit Futures' }
+];
+
 function getCheckedValues(selector) {
   return Array.from(document.querySelectorAll(selector))
     .filter((el) => el.checked)
@@ -4410,6 +4428,37 @@ function resolveHistoryExchangeKey(label, type) {
   if (type === 'spot') return SPOT_LABEL_TO_KEY[normalized] || null;
   if (type === 'futures') return FUTURES_LABEL_TO_KEY[normalized] || null;
   return null;
+}
+
+function resolveHistoryOptions(symbol, type) {
+  const baseOptions = type === 'spot' ? MONITORING_SPOT_OPTIONS : MONITORING_FUTURES_OPTIONS;
+  const meta = monitoringMeta.get(String(symbol || '').toUpperCase());
+  const hints = Array.isArray(meta?.[type === 'spot' ? 'spotHint' : 'futuresHint'])
+    ? meta[type === 'spot' ? 'spotHint' : 'futuresHint']
+    : [];
+  if (!hints.length) return baseOptions;
+  const allowedKeys = new Set(hints.map((hint) => resolveHistoryExchangeKey(hint, type)).filter(Boolean));
+  const filtered = baseOptions.filter((option) => allowedKeys.has(option.key));
+  return filtered.length ? filtered : baseOptions;
+}
+
+function syncHistorySelectOptions(selectEl, options, fallbackKey) {
+  if (!selectEl) return;
+  const previous = selectEl.value;
+  selectEl.innerHTML = options.map((option) => `<option value="${option.key}">${option.label}</option>`).join('');
+  const preferred = options.some((option) => option.key === previous)
+    ? previous
+    : options.some((option) => option.key === fallbackKey)
+      ? fallbackKey
+      : options[0]?.key || '';
+  if (preferred) selectEl.value = preferred;
+}
+
+function syncMonitoringHistoryExchanges(symbol) {
+  const spotOptions = resolveHistoryOptions(symbol, 'spot');
+  const futuresOptions = resolveHistoryOptions(symbol, 'futures');
+  syncHistorySelectOptions(monitoringHistorySpotSelect, spotOptions, MONITORING_HISTORY_DEFAULTS.spot);
+  syncHistorySelectOptions(monitoringHistoryFuturesSelect, futuresOptions, MONITORING_HISTORY_DEFAULTS.futures);
 }
 
 function buildOpportunityKey(coin) {
@@ -5149,6 +5198,7 @@ async function updateMonitoringChart(symbolInput) {
   const fallbackSymbol = monitoringPairSelect?.value || monitoringRows[0]?.symbol || trackedMonitoringSymbols[0];
   const symbol = String(symbolInput || fallbackSymbol || '').toUpperCase();
   if (!symbol) return;
+  syncMonitoringHistoryExchanges(symbol);
   const intervalKey = monitoringHistoryIntervalSelect?.value || MONITORING_HISTORY_DEFAULTS.interval;
   const spotKey = monitoringHistorySpotSelect?.value || MONITORING_HISTORY_DEFAULTS.spot;
   const futuresKey = monitoringHistoryFuturesSelect?.value || MONITORING_HISTORY_DEFAULTS.futures;

--- a/server.js
+++ b/server.js
@@ -4873,6 +4873,44 @@ const monitoringFuturesProviders = [
   { key: 'bybit_futures', label: 'Bybit Futures', type: 'futures', fetch: fetchBybitFuturesTicker, history: fetchBybitFuturesHistory }
 ];
 
+const MONITORING_EXCHANGE_ALIASES = {
+  spot: {
+    'gate.io': 'gate_spot',
+    gate: 'gate_spot',
+    'mexc': 'mexc_spot',
+    'bitget': 'bitget_spot',
+    'kucoin': 'kucoin_spot',
+    'binance': 'binance_spot',
+    'bybit': 'bybit_spot'
+  },
+  futures: {
+    'gate.io futures': 'gate_futures',
+    'gate futures': 'gate_futures',
+    'mexc futures': 'mexc_futures',
+    'bitget futures': 'bitget_futures',
+    'kucoin futures': 'kucoin_futures',
+    'binance futures': 'binance_futures',
+    'bybit futures': 'bybit_futures'
+  }
+};
+
+function normalizeExchangeHint(value, type) {
+  const normalized = String(value || '').trim().toLowerCase();
+  if (!normalized || (type !== 'spot' && type !== 'futures')) return null;
+  return MONITORING_EXCHANGE_ALIASES[type][normalized] || null;
+}
+
+function resolveSelectedProviders(symbolMeta, type) {
+  const providers = type === 'spot' ? monitoringSpotProviders : monitoringFuturesProviders;
+  const hints = Array.isArray(symbolMeta?.[type === 'spot' ? 'spotHint' : 'futuresHint'])
+    ? symbolMeta[type === 'spot' ? 'spotHint' : 'futuresHint']
+    : [];
+  if (!hints.length) return providers;
+  const allowedKeys = new Set(hints.map((hint) => normalizeExchangeHint(hint, type)).filter(Boolean));
+  const filtered = providers.filter((provider) => allowedKeys.has(provider.key));
+  return filtered.length ? filtered : providers;
+}
+
 function findSpotProvider(key) {
   return monitoringSpotProviders.find((provider) => provider.key === key);
 }
@@ -5246,9 +5284,12 @@ async function fetchArbHistory(meta) {
 async function fetchMonitoringSymbol(symbolInput) {
   const meta = buildSymbolMeta(symbolInput);
   if (!meta) return { symbol: null, error: 'Símbolo inválido' };
+  const symbolMeta = monitoringSymbolMeta.get(meta.symbol) || {};
+  const spotProviders = resolveSelectedProviders(symbolMeta, 'spot');
+  const futuresProviders = resolveSelectedProviders(symbolMeta, 'futures');
   const [spot, futures, history] = await Promise.all([
-    Promise.all(monitoringSpotProviders.map((provider) => fetchMonitoringTicker(provider, meta))),
-    Promise.all(monitoringFuturesProviders.map((provider) => fetchMonitoringTicker(provider, meta))),
+    Promise.all(spotProviders.map((provider) => fetchMonitoringTicker(provider, meta))),
+    Promise.all(futuresProviders.map((provider) => fetchMonitoringTicker(provider, meta))),
     fetchArbHistory(meta)
   ]);
   return {


### PR DESCRIPTION
## Summary
- use the configured spot/futures exchanges of each monitored asset when collecting real-time arbitrage data
- limit the monitoring history selectors to the exchanges configured for the selected asset

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69358a59f8c8832faa17ce37d235197d)