### PR TITLE
Fix Bitget Futures volume retrieval for monitoring table

### DIFF
--- a/server.js
+++ b/server.js
@@ -4525,13 +4525,18 @@ async function fetchMexcFuturesTicker(meta) {
 }
 
 async function fetchBitgetFuturesTicker(meta) {
-  const [lastResp, dayResp] = await Promise.all([
+  const [lastResp, dayResp, bookResp] = await Promise.all([
     monitoringHttp.get('https://api.bitget.com/api/v2/mix/market/candles', {
       params: { symbol: meta.bitgetFutures, productType: 'umcbl', granularity: '1m', limit: 1 }
     }),
     monitoringHttp
       .get('https://api.bitget.com/api/v2/mix/market/candles', {
         params: { symbol: meta.bitgetFutures, productType: 'umcbl', granularity: '1D', limit: 1 }
+      })
+      .catch((err) => ({ data: null, error: err })),
+    monitoringHttp
+      .get('https://api.bitget.com/api/v2/mix/market/orderbook', {
+        params: { symbol: meta.bitgetFutures, productType: 'umcbl', limit: 1 }
       })
       .catch((err) => ({ data: null, error: err }))
   ]);
@@ -4550,15 +4555,22 @@ async function fetchBitgetFuturesTicker(meta) {
     if (Number.isFinite(dailyVolume)) volume = dailyVolume;
   }
 
+  const bidEntry = Array.isArray(bookResp?.data?.data?.bids) ? bookResp.data.data.bids[0] : null;
+  const askEntry = Array.isArray(bookResp?.data?.data?.asks) ? bookResp.data.data.asks[0] : null;
+  const bid = toNumber(bidEntry?.[0]) ?? last;
+  const ask = toNumber(askEntry?.[0]) ?? last;
+  const bidSize = toNumber(bidEntry?.[1]);
+  const askSize = toNumber(askEntry?.[1]);
+
   return {
-    bid: last,
-    ask: last,
+    bid,
+    ask,
     last,
     volume,
-    bidSize: null,
-    askSize: null,
-    bidNotional: computeNotional(last, null),
-    askNotional: computeNotional(last, null),
+    bidSize,
+    askSize,
+    bidNotional: computeNotional(bid, bidSize),
+    askNotional: computeNotional(ask, askSize),
     fundingRate: null,
     changePct: null
   };

--- a/server.js
+++ b/server.js
@@ -4525,15 +4525,31 @@ async function fetchMexcFuturesTicker(meta) {
 }
 
 async function fetchBitgetFuturesTicker(meta) {
-  const { data } = await monitoringHttp.get('https://api.bitget.com/api/v2/mix/market/candles', {
-    params: { symbol: meta.bitgetFutures, productType: 'umcbl', granularity: '1m', limit: 1 }
-  });
-  if (!data || data.code !== '00000' || !data.data) {
-    throw new Error(data?.msg || 'Erro Bitget futures');
+  const [lastResp, dayResp] = await Promise.all([
+    monitoringHttp.get('https://api.bitget.com/api/v2/mix/market/candles', {
+      params: { symbol: meta.bitgetFutures, productType: 'umcbl', granularity: '1m', limit: 1 }
+    }),
+    monitoringHttp
+      .get('https://api.bitget.com/api/v2/mix/market/candles', {
+        params: { symbol: meta.bitgetFutures, productType: 'umcbl', granularity: '1D', limit: 1 }
+      })
+      .catch((err) => ({ data: null, error: err }))
+  ]);
+
+  if (!lastResp?.data || lastResp.data.code !== '00000' || !lastResp.data.data) {
+    throw new Error(lastResp?.data?.msg || 'Erro Bitget futures');
   }
-  const payload = Array.isArray(data.data) ? data.data[0] : null;
-  const last = toNumber(payload?.[4]);
-  const volume = toNumber(payload?.[5]);
+
+  const latest = Array.isArray(lastResp.data.data) ? lastResp.data.data[0] : null;
+  const last = toNumber(latest?.[4]);
+
+  let volume = toNumber(latest?.[6]) ?? toNumber(latest?.[5]);
+  if (dayResp?.data?.code === '00000' && Array.isArray(dayResp.data.data) && dayResp.data.data[0]) {
+    const dailyCandle = dayResp.data.data[0];
+    const dailyVolume = toNumber(dailyCandle?.[6]) ?? toNumber(dailyCandle?.[5]);
+    if (Number.isFinite(dailyVolume)) volume = dailyVolume;
+  }
+
   return {
     bid: last,
     ask: last,


### PR DESCRIPTION
## Summary
- fetch Bitget Futures tickers using both 1m and 1D candles to populate price and 24h volume
- fall back gracefully when daily candle is unavailable while keeping monitoring data responsive

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935d2b6d010832f96a59cc18874a68f)